### PR TITLE
Removed preload from link element. Added media=none.

### DIFF
--- a/etsin_finder/frontend/static/index.html
+++ b/etsin_finder/frontend/static/index.html
@@ -10,7 +10,7 @@
   <link rel="manifest" href="/static/manifest.json">
   <!-- Path must be to static because other traffic is directed through Flask-->
   <link rel="icon" type="image/png" href="/static/favicon.png">
-  <link rel="preload" as="style" onload="this.rel='stylesheet'" href="/static/main.bundle.css">
+  <link rel="stylesheet" href="/static/main.bundle.css" media="none" onload="if(media!='all')media='all'">
   <noscript>
     <link href="/static/main.bundle.css" rel="stylesheet">
   </noscript>


### PR DESCRIPTION
## Problem
**rel="preload"** is a new feature what isn't currently supported by all browsers (https://caniuse.com/#search=preload). Preload allows asyncronously loading styles.
## Fix
Switched to use media="none" to allow loading styles asyncronously. Media is set to all after the styles have been loaded, to display them in the dom.