### PR TITLE
CSCETSIN-185: Link license text

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
@@ -146,11 +146,12 @@ class Sidebar extends Component {
             <SidebarItem component="div" trans="dataset.license" hideEmpty="true">
               {this.state.license &&
                 this.state.license.map(rights => {
+                  // If license URL is available, link license title
                   if (rights.license &&
                     (rights.license.startsWith('http://') || rights.license.startsWith('https://'))) {
                     return (
                       <p key={rights.identifier}>
-                        <a href={rights.license}>{checkDataLang(rights.title)}</a>
+                        <a href={rights.license} target="_blank">{checkDataLang(rights.title)}</a>
                       </p>
                     )
                   }

--- a/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
@@ -142,12 +142,23 @@ class Sidebar extends Component {
                   this.dateSeparator(dates.start_date, dates.end_date)
                 )}
             </SidebarItem>
-            {/* LICENCE */}
+            {/* LICENSE */}
             <SidebarItem component="div" trans="dataset.license" hideEmpty="true">
               {this.state.license &&
-                this.state.license.map(rights => (
-                  <p key={rights.identifier}>{checkDataLang(rights.title)}</p>
-                ))}
+                this.state.license.map(rights => {
+                  if (rights.license &&
+                    (rights.license.startsWith('http://') || rights.license.startsWith('https://'))) {
+                    return (
+                      <p key={rights.identifier}>
+                        <a href={rights.license}>{checkDataLang(rights.title)}</a>
+                      </p>
+                    )
+                  }
+                  return (
+                    <p key={rights.identifier}>{checkDataLang(rights.title)}</p>
+                  )
+                })
+              }
             </SidebarItem>
 
             <SidebarItem


### PR DESCRIPTION
In dataset view, if license has a somewhat reasonable URL (= starting with http(s)://), link license text to the URL.