### PR TITLE
CSCETSIN-237: Update organization and project name indexing

### DIFF
--- a/etsin_finder/frontend/js/components/frontpage/keyValues.jsx
+++ b/etsin_finder/frontend/js/components/frontpage/keyValues.jsx
@@ -38,7 +38,7 @@ export default class KeyValues extends Component {
         distinct_fieldsofscience: {
           cardinality: { field: 'field_of_science.pref_label.en.keyword' },
         },
-        distinct_projects: { cardinality: { field: 'project_name.keyword' } },
+        distinct_projects: { cardinality: { field: 'project_name_en.keyword' } },
       },
     })
 

--- a/etsin_finder/frontend/js/components/search/filterResults/filterSection.jsx
+++ b/etsin_finder/frontend/js/components/search/filterResults/filterSection.jsx
@@ -18,8 +18,8 @@ class FilterSection extends Component {
     this.aggregations = {
       organization: {
         title: { en: 'Organization', fi: 'Organisaatio' },
-        aggregation: { und: 'organization' },
-        term: { und: 'organization_name.keyword' },
+        aggregation: { en: 'organization_name_en', fi: 'organization_name_fi' },
+        term: { en: 'organization_name_en.keyword', fi: 'organization_name_fi.keyword' },
       },
       creator: {
         title: { en: 'Creator', fi: 'Tekijä' },
@@ -49,8 +49,8 @@ class FilterSection extends Component {
       },
       project: {
         title: { en: 'Project', fi: 'Projekti' },
-        aggregation: { und: 'project' },
-        term: { und: 'project_name.keyword' },
+        aggregation: { en: 'project_name_en', fi: 'project_name_fi' },
+        term: { en: 'project_name_en.keyword', fi: 'project_name_fi.keyword' },
       },
       file_type: {
         title: { en: 'File Type', fi: 'Tiedostotyyppi' },

--- a/etsin_finder/frontend/js/stores/view/elasticquery.js
+++ b/etsin_finder/frontend/js/stores/view/elasticquery.js
@@ -20,7 +20,7 @@ const fields = [
   'theme.pref_label.*',
   'field_of_science.pref_label.*',
   'infrastructure.pref_label.*',
-  'project.pref_label.*',
+  'project.*',
   'identifier',
   'preferred_identifier',
   'other_identifier.notation',
@@ -250,9 +250,14 @@ class ElasticQuery {
       const filters = createFilters()
       const sorting = createSorting()
       const aggregations = {
-        organization: {
+        organization_name_fi: {
           terms: {
-            field: 'organization_name.keyword',
+            field: 'organization_name_fi.keyword',
+          },
+        },
+        organization_name_en: {
+          terms: {
+            field: 'organization_name_en.keyword',
           },
         },
         creator: {
@@ -263,25 +268,21 @@ class ElasticQuery {
         field_of_science_en: {
           terms: {
             field: 'field_of_science.pref_label.en.keyword',
-            size: '123',
           },
         },
         field_of_science_fi: {
           terms: {
             field: 'field_of_science.pref_label.fi.keyword',
-            size: '123',
           },
         },
         keyword_en: {
           terms: {
             field: 'theme.label.en.keyword',
-            size: '123',
           },
         },
         keyword_fi: {
           terms: {
             field: 'theme.label.fi.keyword',
-            size: '123',
           },
         },
         infrastructure_en: {
@@ -294,9 +295,14 @@ class ElasticQuery {
             field: 'infrastructure.pref_label.fi.keyword',
           },
         },
-        project: {
+        project_name_fi: {
           terms: {
-            field: 'project_name.keyword',
+            field: 'project_name_fi.keyword',
+          },
+        },
+        project_name_en: {
+          terms: {
+            field: 'project_name_en.keyword',
           },
         },
         file_type_en: {


### PR DESCRIPTION
**This feature changes both etsin-finder and etsin-finder-search**

Makes "number of projects" on front page more accurate and reduces number of duplicate items in "organization" and "project" facets on search results page. Doesn't make things perfect, but the improvement should be visible.

Under the hood, organization and project names are split into language-specific fields that always have the same amount of items. Items in *_fi prefer Finnish names whenever they're available, English works likewise. If preferred language is not available, another name is picked.

Search result page facets use these fields to ensure facet values are displayed in user interface language as much as possible.

Number of distinct English project names is displayed on front page.