### PR TITLE
Cscetsin 343 data tab bug

### DIFF
--- a/etsin_finder/frontend/__tests__/createDirTree.test.jsx
+++ b/etsin_finder/frontend/__tests__/createDirTree.test.jsx
@@ -108,36 +108,6 @@ describe('Create file tree', () => {
     expect(result[1].name).toEqual('Experiment_X')
     expect(result[2].name).toEqual('file_name_1')
   })
-  it('should have correct child amount', () => {
-    const files = [
-      {
-        path: 'project_x_FROZEN/Experiment_X/file_name_1',
-        details: { id: 1 },
-      },
-      {
-        path: 'amazing/Experiment_X/newFolder/file_name_3',
-        details: { id: 6 },
-      },
-      {
-        path: 'amazing/Experiment_X/file_name_2',
-        details: { id: 2 },
-      },
-      {
-        path: 'myRootFile/Folder2/file_name_1',
-        details: { id: 3 },
-      },
-      {
-        path: 'amazing/Experiment_X/newFolder',
-        details: { id: 5 },
-      },
-      {
-        path: 'amazing/Experiment_X',
-        details: { id: 4 },
-      },
-    ]
-    const result = createTree(files)
-    expect(result[1].childAmount).toEqual(3)
-  })
   it('should have file details', () => {
     const files = [
       {

--- a/etsin_finder/frontend/js/utils/createTree.jsx
+++ b/etsin_finder/frontend/js/utils/createTree.jsx
@@ -64,18 +64,17 @@ export default function createTree(files) {
     let x = hier
     const split = file.path.split('/')
     split.map((item, index) => {
+      // check if has already been added to hierarchy
       let current = x.find(single => single.name === item)
+      // if not added add either as folder or as file
       if (!current) {
-        if (index === split.length - 1) {
+        if (index === split.length - 1 && file.type !== 'dir') {
           current = { name: item }
           x.push(current)
         } else {
-          current = { name: item, children: [], childAmount: 0 }
+          current = { name: item, children: [] }
           x.push(current)
         }
-      } else {
-        const amountindex = x.indexOf(current)
-        x[amountindex].childAmount += 1
       }
       const i = x.map(single => single.name).indexOf(item)
       if (index === split.length - 1) {


### PR DESCRIPTION
# Problem
While creating a tree structure from the files and folders one folder did not have the empty children array. `children: []`. This was due to a bug in the code where it thought the folder specified was the last item in the tree and didn't add the children object. But then the next folder specified was inside that folder and it couldnt add itself inside the children folder.

## Fix
Added a file.type check while initially creating the items in the tree structure.
`file.type !== 'dir'` then don't add children array. But if yes add the children array.

# Additionally
Removed unused code childAmount. It was not used and unnecessary due to `children.length`being also available.