### PR TITLE
[FIX] matomo not being active in production

### DIFF
--- a/etsin_finder/frontend/js/utils/tracking/index.js
+++ b/etsin_finder/frontend/js/utils/tracking/index.js
@@ -1,14 +1,15 @@
 /* eslint-disable no-undef */
 class Tracking {
   isActive() {
-    return process.env.MATOMO === true
+    // check if Matomo is active, will return false in development
+    return typeof _paq === 'object'
   }
 
   newPageView(title, location) {
     if (this.isActive()) {
-      _paq.push(['setCustomUrl', location]);
-      _paq.push(['setDocumentTitle', title]);
-      _paq.push(['trackPageView']);
+      _paq.push(['setCustomUrl', location])
+      _paq.push(['setDocumentTitle', title])
+      _paq.push(['trackPageView'])
     }
   }
 


### PR DESCRIPTION
# Changes
`process.env` is only available in backend while building but not in frontend.
function `isActive()` checks if _paq function has been defined.