### PR TITLE
CSCETSIN-261

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/agent.jsx
+++ b/etsin_finder/frontend/js/components/dataset/agent.jsx
@@ -19,9 +19,9 @@ import faUser from '@fortawesome/fontawesome-free-solid/faUser'
 import faUniversity from '@fortawesome/fontawesome-free-solid/faUniversity'
 import faGlobe from '@fortawesome/fontawesome-free-solid/faGlobe'
 
-import { TransparentLink } from '../../general/button'
-import PopUp from '../../general/popup'
-import checkDataLang, { getDataLang } from '../../../utils/checkDataLang'
+import { TransparentLink } from '../general/button'
+import PopUp from '../general/popup'
+import checkDataLang, { getDataLang } from '../../utils/checkDataLang'
 
 export default class Agent extends Component {
   constructor(props) {

--- a/etsin_finder/frontend/js/components/dataset/description.jsx
+++ b/etsin_finder/frontend/js/components/dataset/description.jsx
@@ -23,7 +23,7 @@ import Contact from './contact'
 import ErrorBoundary from '../general/errorBoundary'
 import GoToOriginal from './goToOriginal'
 import Label from '../general/label'
-import Agents from './agents'
+import TogglableAgentList from './togglableAgentList'
 import VersionChanger from './versionChanger'
 import checkDataLang, { getDataLang } from '../../utils/checkDataLang'
 import checkNested from '../../utils/checkNested'
@@ -119,10 +119,10 @@ class Description extends Component {
           <div className="d-flex justify-content-between basic-info">
             <MainInfo>
               <ErrorBoundary>
-                <Agents creator={this.state.creator} />
+                <TogglableAgentList agents={this.state.creator} agentType="creator" />
               </ErrorBoundary>
               <ErrorBoundary>
-                <Agents contributor={this.state.contributor} />
+                <TogglableAgentList agents={this.state.contributor} agentType="contributor" />
               </ErrorBoundary>
               {this.state.issued && (
                 <p lang={getDataLang(this.state.issued)}>

--- a/etsin_finder/frontend/js/components/dataset/events/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/events/index.jsx
@@ -20,6 +20,7 @@ import Accessibility from '../../../stores/view/accessibility'
 import checkDataLang, { getDataLang } from '../../../utils/checkDataLang'
 import dateFormat from '../../../utils/dateFormat'
 import Tracking from '../../../utils/tracking'
+import Agent from '../agent'
 
 const Table = styled.table`
   overflow-x: scroll;
@@ -165,15 +166,21 @@ class Events extends Component {
                     <td>
                       {/* eslint-disable react/jsx-indent */}
                       {single.was_associated_with &&
-                        single.was_associated_with.map((associate, i) => (
-                          <span
-                            key={checkDataLang(associate.name)}
-                            lang={getDataLang(associate.name)}
-                          >
-                            {i === 0 ? '' : ', '}
-                            {checkDataLang(associate.name)}
-                          </span>
-                        ))}
+                        single.was_associated_with.map((associate, i) => {
+                          if (associate.name) {
+                            return (
+                              <InlineUl key={`ul-${checkDataLang(associate.name)}`}>
+                                <Agent
+                                  lang={getDataLang(associate)}
+                                  key={checkDataLang(associate) || associate.name}
+                                  first={i === 0}
+                                  agent={associate}
+                                />
+                              </InlineUl>
+                            )
+                          }
+                          return ''
+                        })}
                       {/* eslint-enable react/jsx-indent */}
                     </td>
                     <td>
@@ -273,5 +280,11 @@ Events.propTypes = {
   provenance: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
   other_identifier: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
 }
+
+const InlineUl = styled.ul`
+  display: inline;
+  margin: 0;
+  padding: 0;
+`
 
 export default inject('Stores')(observer(Events))

--- a/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
@@ -12,6 +12,7 @@ import Citation from './special/citation'
 import Logo from './special/logo'
 import License from './special/license'
 import ErrorBoundary from '../../general/errorBoundary'
+import Agent from '../agent'
 
 class Sidebar extends Component {
   constructor(props) {
@@ -25,9 +26,7 @@ class Sidebar extends Component {
       catalog_publisher: checkNested(dataCatalog, 'catalog_json', 'publisher', 'name')
         ? dataCatalog.catalog_json.publisher.name
         : false,
-      publisher: checkNested(researchDataset, 'publisher', 'name')
-        ? researchDataset.publisher.name
-        : false,
+      publisher: researchDataset.publisher,
       catalogTitle: dataCatalog.catalog_json.title,
       catalogPublisherHomepage: checkNested(dataCatalog, 'catalog_json', 'publisher', 'homepage')
         ? dataCatalog.catalog_json.publisher.homepage[0].identifier
@@ -244,7 +243,12 @@ class Sidebar extends Component {
                     checkNested(output, 'has_funding_agency') &&
                     output.has_funding_agency.map(agency => (
                       <ListItem key={checkDataLang(agency.name)} lang={getDataLang(agency.name)}>
-                        {checkDataLang(agency.name)}
+                        <Agent
+                          lang={getDataLang(agency)}
+                          key={checkDataLang(agency) || agency.name}
+                          first
+                          agent={agency}
+                        />
                       </ListItem>
                     ))
                 )}
@@ -253,48 +257,62 @@ class Sidebar extends Component {
             {/* PUBLISHER */}
 
             <SidebarItem
-              component="dd"
+              componen="dd"
               trans="dataset.publisher"
               hideEmpty="true"
               lang={this.state.publisher && getDataLang(this.state.publisher)}
             >
-              {this.state.publisher && checkDataLang(this.state.publisher)}
+              {this.state.publisher && (
+                <Agent
+                  lang={getDataLang(this.state.publisher)}
+                  key={checkDataLang(this.state.publisher) || this.state.publisher.name}
+                  first
+                  agent={this.state.publisher}
+                />
+              )}
             </SidebarItem>
 
             {/* CURATOR */}
 
             <SidebarItem trans="dataset.curator" hideEmpty="true">
               {this.state.curator &&
-                this.state.curator.map((curators, i) => {
-                  let curator = checkDataLang(curators.name)
-                  if (curator === '') {
-                    curator = curators.name
+                this.state.curator.map((curator) => {
+                  let curatorName = checkDataLang(curator.name)
+                  if (curatorName === '') {
+                    curatorName = curator.name
                   }
                   return (
-                    /* eslint-disable react/no-array-index-key */
-                    <ListItem key={`${curator}-${i}`} lang={getDataLang(curators.name)}>
-                      {curator}
+                    <ListItem key={`li-${curatorName}`} lang={getDataLang(curator)}>
+                      <Agent
+                        lang={getDataLang(curator)}
+                        key={curatorName}
+                        first
+                        agent={curator}
+                      />
                     </ListItem>
-                    /* eslint-enable react/no-array-index-key */
                   )
-                })}
+                })
+              }
             </SidebarItem>
 
             {/* RIGHTS HOLDER */}
 
             <SidebarItem trans="dataset.rights_holder" hideEmpty="true">
               {this.state.rightsHolder &&
-                this.state.rightsHolder.map((rightsHolders, i) => {
-                  let rightsHolder = checkDataLang(rightsHolders.name)
-                  if (rightsHolder === '') {
-                    rightsHolder = rightsHolders.name
+                this.state.rightsHolder.map((rightsHolder) => {
+                  let rightsHolderName = checkDataLang(rightsHolder.name)
+                  if (rightsHolderName === '') {
+                    rightsHolderName = rightsHolder.name
                   }
                   return (
-                    /* eslint-disable react/no-array-index-key */
-                    <ListItem key={`${rightsHolder}-${i}`} lang={getDataLang(rightsHolder.name)}>
-                      {rightsHolder}
+                    <ListItem key={`li-${rightsHolderName}`} lang={getDataLang(rightsHolder)}>
+                      <Agent
+                        lang={getDataLang(rightsHolder)}
+                        key={rightsHolderName}
+                        first
+                        agent={rightsHolder}
+                      />
                     </ListItem>
-                    /* eslint-enable react/no-array-index-key */
                   )
                 })}
             </SidebarItem>

--- a/etsin_finder/frontend/js/components/dataset/togglableAgentList.jsx
+++ b/etsin_finder/frontend/js/components/dataset/togglableAgentList.jsx
@@ -16,19 +16,20 @@ import Translate from 'react-translate-component'
 import styled from 'styled-components'
 
 import Agent from './agent'
-import checkDataLang, { getDataLang } from '../../../utils/checkDataLang'
-import { LinkButton } from '../../general/button'
+import checkDataLang, { getDataLang } from '../../utils/checkDataLang'
+import { LinkButton } from '../general/button'
 
-export default class Agents extends Component {
+export default class TogglableAgentList extends Component {
   constructor(props) {
     super(props)
 
-    const mode = typeof props.creator === 'object' ? 'creator' : 'contributor'
-    if (this.props[mode]) {
+    const agents = props.agents
+    const agentType = props.agentType
+    if (agents) {
       this.state = {
-        mode,
-        firstThree: this.props[mode].slice(0, 3),
-        rest: this.props[mode].slice(3),
+        agentType,
+        firstThree: agents.slice(0, 3),
+        rest: agents.slice(3),
         open: false,
       }
     } else {
@@ -47,12 +48,12 @@ export default class Agents extends Component {
   }
 
   render() {
-    return this.props[this.state.mode] ? (
+    return this.props.agents ? (
       <AgentsCont>
-        {this.props[this.state.mode].length > 1 ? (
-          <Translate content={`dataset.${this.state.mode}.plrl`} />
+        {this.props.agents.length > 1 ? (
+          <Translate content={`dataset.${this.state.agentType}.plrl`} />
         ) : (
-          <Translate content={`dataset.${this.state.mode}.snglr`} />
+          <Translate content={`dataset.${this.state.agentType}.snglr`} />
         )}
         {': '}
         <InlineUl>
@@ -71,7 +72,7 @@ export default class Agents extends Component {
             return ''
           })}
           {/* Show the rest */}
-          {this.props[this.state.mode].length > 3 &&
+          {this.props.agents.length > 3 &&
             this.state.open &&
             this.state.rest.map(agent => {
               if (agent.name) {
@@ -86,7 +87,7 @@ export default class Agents extends Component {
               return ''
             })}
           {/* Show Button to open rest */}{' '}
-          {this.props[this.state.mode].length > 3 && (
+          {this.props.agents.length > 3 && (
             <LinkButton onClick={this.toggleOpen}>
               [{' '}
               {this.state.open ? (
@@ -103,12 +104,14 @@ export default class Agents extends Component {
   }
 }
 
-Agents.defaultProps = {
-  creator: undefined,
+TogglableAgentList.defaultProps = {
+  agents: undefined,
+  agentType: undefined,
 }
 
-Agents.propTypes = {
-  creator: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+TogglableAgentList.propTypes = {
+  agents: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  agentType: PropTypes.string
 }
 
 const AgentsCont = styled.div`

--- a/etsin_finder/frontend/stories/index.js
+++ b/etsin_finder/frontend/stories/index.js
@@ -53,8 +53,8 @@ import Info from '../js/components/dataset/data/info'
 import Dropdown from '../js/components/general/dropdown'
 import PopUp from '../js/components/general/popup'
 // import Select from '../js/components/general/select'
-import Agents from '../js/components/dataset/agents'
-import Agent from '../js/components/dataset/agents/agent'
+import TogglableAgentList from '../js/components/dataset/togglableAgentList'
+import Agent from '../js/components/dataset/agent'
 import Sidebar from '../js/components/dataset/sidebar'
 import License from '../js/components/dataset/sidebar/license'
 
@@ -533,7 +533,7 @@ storiesOf('Dataset/Timestamp', module).add('Available', () => (
   </Container>
 ))
 
-storiesOf('Dataset/Agents', module)
+storiesOf('Dataset/TogglableAgentList', module)
   .add('Creator', () => (
     <Container
       center
@@ -545,7 +545,7 @@ storiesOf('Dataset/Agents', module)
       }}
     >
       <ComponentCode>
-        <Agents creator={MetaxRes.research_dataset.creator} />
+        <TogglableAgentList agents={MetaxRes.research_dataset.creator} agentType="creator" />
       </ComponentCode>
     </Container>
   ))
@@ -554,7 +554,7 @@ storiesOf('Dataset/Agents', module)
     return (
       <Container center maxWidth="800px" style={{ marginTop: '10em' }}>
         <ComponentCode>
-          <Agents contributor={twoContributors} />
+          <TogglableAgentList agents={twoContributors} agentType="contributor" />
         </ComponentCode>
       </Container>
     )
@@ -569,7 +569,7 @@ storiesOf('Dataset/Agents', module)
   .add('More than 3 agents', () => (
     <Container center maxWidth="800px" style={{ marginTop: '10em' }}>
       <ComponentCode>
-        <Agents contributor={MetaxRes.research_dataset.contributor} />
+        <TogglableAgentList agents={MetaxRes.research_dataset.contributor} agemntType="contributor" />
       </ComponentCode>
     </Container>
   ))

--- a/etsin_finder/frontend/stories/metaxRes.js
+++ b/etsin_finder/frontend/stories/metaxRes.js
@@ -754,7 +754,7 @@ export default {
         pref_label: {
           fi: 'Saatavuutta rajoitettu muulla perusteella',
           en: 'Restricted access due to other reasons',
-          sv: 'Begränsad åtkomst av övriga skäl'
+          sv: 'Begränsad åtkomst av övriga skäl',
           und: 'Saatavuutta rajoitettu muulla perusteella',
         },
       }]


### PR DESCRIPTION
- Rename and relocate dataset/agents/index.jsx -> dataset/togglableAgentList.jsx and change its contents so that it now gets the agent(s) object as props and separately agent type.
- Relocate dataset/agents/agent.jsx -> dataset/agent.jsx
- Add agent popup for curator, rights_holder and publisher
- Add agent popup for provenance item's was_associated_with agent
- Add agent popup for is_output_of item's has_funding_agency agent