### PR TITLE
CSCETSIN-463 files not being rendered in file picker

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
@@ -16,7 +16,7 @@ export class ProjectSelectorBase extends Component {
 
   getOptions = () => {
     const { environment } = this.props.Stores.Env
-    if (environment === 'development' || environment === 'test') {
+    if (environment === 'development') {
       return [
         { value: 'project_x', label: 'project_x' },
         { value: 'empty', label: 'test nonexistant IDA project' }

--- a/etsin_finder/frontend/js/components/qvain/utils/object.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/object.js
@@ -1,0 +1,13 @@
+
+// gets deep nested values within objects.
+// Param: array that acts as an "address" for the value, ex: ['path', 'to', 'object']
+export const get = (p, o) => p.reduce((xs, x) => ((xs && xs[x]) ? xs[x] : undefined), o)
+
+// returns deep nested value by dotted address
+// ex. getPath('path.to.value', object)
+export const getPath = (path, object) => {
+  const pathArr = path.split('.')
+  return get(pathArr, object)
+}
+
+export default getPath

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -2,6 +2,7 @@ import { observable, action, computed } from 'mobx'
 import axios from 'axios'
 import { getDirectories, getFiles } from '../../components/qvain/utils/fileHierarchy'
 import { AccessTypeURLs, LicenseUrls, FileAPIURLs, UseCategoryURLs } from '../../components/qvain/utils/constants'
+import { getPath } from '../../components/qvain/utils/object'
 
 class Qvain {
   @observable original = undefined // used if editing, otherwise undefined
@@ -520,19 +521,19 @@ const File = (file, parent, selected) => ({
   ...Hierarchy(file, parent, selected),
   fileName: file.file_name,
   filePath: file.file_path,
-  useCategory: file.file_characteristics.use_category || UseCategoryURLs.OUTCOME_MATERIAL,
-  fileType: file.file_characteristics.file_type,
-  description: file.file_characteristics.description,
-  title: file.file_characteristics.title
+  useCategory: getPath('file_characteristics.use_category', file) || UseCategoryURLs.OUTCOME_MATERIAL,
+  fileType: getPath('file_characteristics.file_type', file),
+  description: getPath('file_characteristics.description', file),
+  title: getPath('file_characteristics.title', file)
 })
 
 const DatasetFile = (file) => ({
   identifier: file.identifier,
-  useCategory: file.use_category.identifier,
-  fileType: file.file_type ? file.file_type.identifier : undefined,
-  projectIdentifier: file.details.project_identifier,
+  useCategory: getPath('use_category.identifier'),
+  fileType: getPath('file_type.identifier', file),
+  projectIdentifier: getPath('details.project_identifier', file),
   title: file.title,
-  description: file.description || file.details.file_characteristics.description,
+  description: file.description || getPath('details.file_characteristics.description', file),
   fileCharacteristics: {
     ...file.details.file_characteristics,
     useCategory: file.use_category,


### PR DESCRIPTION
Undefined values were breaking the rendering of files in IDA file picker's file hierarchy view. Use a "get or undefined" function to get the values safely.