### PR TITLE
Delete dataset

### DIFF
--- a/etsin_finder/finder.py
+++ b/etsin_finder/finder.py
@@ -71,7 +71,7 @@ def add_restful_resources(app):
     """
     api = Api(app)
     from etsin_finder.resources import Contact, Dataset, User, Session, Files, Download
-    from etsin_finder.qvain_light_resources import ProjectFiles, FileDirectory, UserDatasets, QvainDataset
+    from etsin_finder.qvain_light_resources import ProjectFiles, FileDirectory, UserDatasets, QvainDataset, QvainDatasetDelete
     api.add_resource(Dataset, '/api/dataset/<string:cr_id>')
     api.add_resource(Files, '/api/files/<string:cr_id>')
     api.add_resource(Contact, '/api/email/<string:cr_id>')
@@ -82,6 +82,7 @@ def add_restful_resources(app):
     api.add_resource(ProjectFiles, '/api/files/project/<string:pid>')
     api.add_resource(FileDirectory, '/api/files/directory/<string:dir_id>')
     api.add_resource(UserDatasets, '/api/datasets/<string:user_id>')
+    api.add_resource(QvainDatasetDelete, '/api/dataset/<string:cr_id>')
     api.add_resource(QvainDataset, '/api/dataset')
 
 

--- a/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
@@ -73,9 +73,12 @@ class DatasetTable extends Component {
 
   handleRemove = identifier => event => {
     event.preventDefault()
-    this.setState(state => ({
-      datasets: [...state.datasets.filter(d => d.identifier !== identifier)],
-    }))
+    axios
+      .delete('/api/dataset/' + identifier)
+      .then(this.setState(state => ({
+          datasets: [...state.datasets.filter(d => d.identifier !== identifier)],
+        })))
+      .catch(err => { this.setState({ error: true, errorMessage: err.message })})
   }
 
   noDatasets = () => {

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -24,7 +24,7 @@ from etsin_finder.utils import \
     slice_array_on_limit
 from etsin_finder.qvain_light_dataset_schema import DatasetValidationSchema
 from etsin_finder.qvain_light_utils import data_to_metax
-from etsin_finder.qvain_light_service import create_dataset, update_dataset
+from etsin_finder.qvain_light_service import create_dataset, update_dataset, delete_dataset
 
 log = app.logger
 
@@ -149,7 +149,7 @@ class UserDatasets(Resource):
         return '', 404
 
 class QvainDataset(Resource):
-    """POST and PATCH request handling coming in from Qvain Light. Used for adding datasets to METAX."""
+    """POST and PATCH request handling coming in from Qvain Light. Used for adding/editing datasets in METAX."""
 
     def __init__(self):
         """Setup required utils for dataset metadata handling"""
@@ -225,4 +225,32 @@ class QvainDataset(Resource):
             data_catalog = "urn:nbn:fi:att:data-catalog-att"
         metax_redy_data = data_to_metax(data, metadata_provider_org, metadata_provider_user, data_catalog)
         metax_response = update_dataset(metax_redy_data)
+        return metax_response, 200
+
+class QvainDatasetDelete(Resource):
+    """DELETE request handling coming in from Qvain Light. Used for deleting datasets in METAX."""
+
+    @log_request
+    def delete(self, cr_id):
+        """
+        Delete dataset from Metax.
+
+        Arguments:
+            config {object} -- Includes 'data' key that has the identifier of the dataset.
+
+        Returns:
+            [type] -- Metax response.
+        """
+
+        is_authd = authentication.is_authenticated()
+        if not is_authd:
+            return 'Not logged in', 400
+        # todo ensure user has rights to do this
+        # try:
+        #     metadata_provider_org = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.25178.1.2.9"]
+        #     metadata_provider_user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.8057.2.80.26"]
+        # except KeyError as err:
+        #     log.warning("The Metadata provider is not specified: \n{0}".format(err))
+        #     return "The Metadata provider is not specified", 400
+        metax_response = delete_dataset(cr_id)
         return metax_response, 200

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -23,7 +23,7 @@ from etsin_finder.utils import \
     sort_array_of_obj_by_key, \
     slice_array_on_limit
 from etsin_finder.qvain_light_dataset_schema import DatasetValidationSchema
-from etsin_finder.qvain_light_utils import data_to_metax
+from etsin_finder.qvain_light_utils import data_to_metax, get_dataset_creator
 from etsin_finder.qvain_light_service import create_dataset, update_dataset, delete_dataset
 
 log = app.logger
@@ -245,12 +245,12 @@ class QvainDatasetDelete(Resource):
         is_authd = authentication.is_authenticated()
         if not is_authd:
             return 'Not logged in', 400
-        # todo ensure user has rights to do this
-        # try:
-        #     metadata_provider_org = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.25178.1.2.9"]
-        #     metadata_provider_user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.8057.2.80.26"]
-        # except KeyError as err:
-        #     log.warning("The Metadata provider is not specified: \n{0}".format(err))
-        #     return "The Metadata provider is not specified", 400
+
+        # only creator of the dataset is allowed to delete it
+        user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.16161.4.0.53"][0]
+        creator = get_dataset_creator(cr_id)
+        if user != creator:
+            return 'No permission', 403
+
         metax_response = delete_dataset(cr_id)
         return metax_response, 200

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -203,6 +203,33 @@ class MetaxQvainLightAPIService(FlaskService):
 
         return metax_api_response.json()
 
+    def delete_dataset(self, cr_id):
+        """
+        Delete dataset from Metax.
+
+        Arguments:
+            cr_id {string} -- The identifier of the dataset.
+
+        Returns:
+            [type] -- Metax response.
+        """
+        req_url = self.METAX_CREATE_DATASET + "/" + cr_id
+        headers = {'Accept': 'application/json'}
+        try:
+            metax_api_response = requests.delete(req_url,
+                                                headers=headers,
+                                                auth=(self.user, self.pw),
+                                                verify=self.verify_ssl,
+                                                timeout=10)
+        except Exception as e:
+            if isinstance(e, requests.HTTPError):
+                log.debug("Failed to deletedataset.")
+                log.debug('Response status code: {0}'.format(metax_api_response.status_code))
+                log.debug('Response text: {0}'.format(json_or_empty(metax_api_response) or metax_api_response.text))
+            return {'Error_message': 'Error trying to send data to metax.'}
+
+        return metax_api_response.status_code
+
 
 _metax_api = MetaxQvainLightAPIService(app)
 
@@ -259,3 +286,15 @@ def update_dataset(form_data, cr_id):
 
     """
     return _metax_api.update_dataset(form_data, cr_id)
+
+def delete_dataset(cr_id):
+    """
+    Delete dataset from Metax.
+
+    Arguments:
+        cr_id {string} -- The identifier of the dataset.
+
+    Returns:
+        [type] -- Metax response.
+    """
+    return _metax_api.delete_dataset(cr_id)

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -3,6 +3,7 @@ access_type = {}
 access_type["EMBARGO"] = "http://uri.suomi.fi/codelist/fairdata/access_type/code/embargo"
 access_type["OPEN"] = "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
 
+from etsin_finder.cr_service import get_catalog_record
 
 def clean_empty_keyvalues_from_dict(d):
     """
@@ -218,3 +219,8 @@ def data_to_metax(data, metadata_provider_org, metadata_provider_user, data_cata
         }
     }
     return clean_empty_keyvalues_from_dict(dataset_data)
+
+def get_dataset_creator(cr_id):
+    # get dataset
+    dataset = get_catalog_record(cr_id, False)
+    return dataset['metadata_provider_user']


### PR DESCRIPTION
Add functionality to delete dataset button.

When button is clicked, frontend fires a new API call. Backend checks that logged in user is also the creator of the dataset in question. If users match, delete request is sent to Metax API. If users don't match, returns 403.