### PR TITLE
Cscetsin 472 fix invalid url

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -54,16 +54,21 @@ export class ExternalEditFormBase extends Component {
     })
   }
 
-  handleOnUrlBlur = () => {
+  verifyURL = () => {
     const resource = this.props.Stores.Qvain.resourceInEdit
     externalResourceUrlSchema
       .validate(resource ? resource.url : this.state.url)
       .then(() => {
         this.setState({ urlError: undefined, resourceError: undefined })
+        this.props.Stores.Qvain.resetInEditResource()  
       })
       .catch(err => {
         this.setState({ urlError: err.errors })
-      })
+      }) 
+  }
+
+  handleOnUrlBlur = () => {
+    this.verifyURL();
   }
 
   handleAddResource = event => {
@@ -98,7 +103,7 @@ export class ExternalEditFormBase extends Component {
 
   handleCloseEdit = event => {
     event.preventDefault()
-    this.props.Stores.Qvain.resetInEditResource()
+    this.verifyURL();
   }
 
   render() {

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -18,11 +18,17 @@ import {
 import { Input, SelectedFilesTitle } from '../general/form'
 import { FileContainer, SlidingContent } from '../general/card'
 import ExternalEditForm from './externalFileForm'
+import { externalResourceUrlSchema } from '../utils/formValidation'
 
 export class ExternalFilesBase extends Component {
   static propTypes = {
     Stores: PropTypes.object.isRequired
   }
+
+  /*state = {
+    resourceError: undefined,
+    urlError: undefined,
+  }*/
 
   handleToggleForm = (event) => {
     event.preventDefault()
@@ -33,6 +39,18 @@ export class ExternalFilesBase extends Component {
       this.props.Stores.Qvain.extResFormOpen = true
       this.props.Stores.Qvain.idaPickerOpen = false
     }
+  }
+
+  verifyURL = () => {
+    const resource = this.props.Stores.Qvain.resourceInEdit
+    externalResourceUrlSchema
+      .validate(resource.url)
+      .then(() => {
+        this.props.Stores.Qvain.resetInEditResource()  
+      })
+      .catch(err => {
+        console.log(err)
+      }) 
   }
 
   handleRemoveResource = (resourceId) => (event) => {
@@ -47,7 +65,7 @@ export class ExternalFilesBase extends Component {
 
   handleCloseEdit = (event) => {
     event.preventDefault()
-    this.props.Stores.Qvain.resetInEditResource()
+    this.verifyURL();
   }
 
   render() {

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -25,11 +25,6 @@ export class ExternalFilesBase extends Component {
     Stores: PropTypes.object.isRequired
   }
 
-  /*state = {
-    resourceError: undefined,
-    urlError: undefined,
-  }*/
-
   handleToggleForm = (event) => {
     event.preventDefault()
     const { extResFormOpen } = this.props.Stores.Qvain


### PR DESCRIPTION
Fix save bug in externalFileForm.jsx, where it was possible to save an invalid URL by clicking the Save button twice.

Implement invalid URL check also for the Edit button, found in externalFiles.jsx. URL check runs when trying to exit edit mode without first clicking "Save".