### PR TITLE
CSCETSIN-503: Fix use category dropdown

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -20,8 +20,10 @@ export class ExternalEditFormBase extends Component {
   }
 
   state = {
-    useCategoriesEn: [],
-    useCategoriesFi: [],
+    useCategories: {
+      en: [],
+      fi: [],
+    },
     title: '',
     url: '',
     useCategory: '',
@@ -32,9 +34,11 @@ export class ExternalEditFormBase extends Component {
   componentDidMount = () => {
     getLocalizedOptions('use_category').then(translations => {
       this.setState({
-        useCategoriesEn: translations.en,
-        useCategoriesFi: translations.fi,
-      })
+          useCategories: {
+            en: translations.en,
+            fi: translations.fi
+          }
+        })
     })
   }
 
@@ -104,6 +108,8 @@ export class ExternalEditFormBase extends Component {
   render() {
     const resource = this.props.Stores.Qvain.resourceInEdit
     const { isEditForm } = this.props
+    const { lang } = this.props.Stores.Locale
+    const { useCategories } = this.state
     return (
       <Fragment>
         <Translate component={Label} content="qvain.files.external.form.title.label" />
@@ -124,13 +130,12 @@ export class ExternalEditFormBase extends Component {
         <Translate component={Label} content="qvain.files.external.form.useCategory.label" />
         <Translate
           component={CustomSelect}
-          value={this.state.useCategory}
-          options={
-            this.props.Stores.Locale.lang === 'en'
-              ? this.state.useCategoriesEn
-              : this.state.useCategoriesFi
+          value={isEditForm ? resource.useCategory : this.state.useCategory
           }
-          onChange={this.handleChangeUse}
+          options={useCategories[lang]}
+          onChange={(selection) => {
+            isEditForm ? resource.useCategory = selection : this.setState({useCategory: selection})
+          }}
           attributes={{ placeholder: 'qvain.files.external.form.useCategory.placeholder' }}
         />
         <Translate component={Label} content="qvain.files.external.form.url.label" />

--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -52,12 +52,6 @@ export class ExternalEditFormBase extends Component {
     return uc
   }
 
-  handleChangeUse = selectedOption => {
-    this.setState({
-      useCategory: selectedOption,
-    })
-  }
-
   handleOnUrlBlur = () => {
     const resource = this.props.Stores.Qvain.resourceInEdit
     externalResourceUrlSchema

--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -52,7 +52,7 @@ export class ExternalEditFormBase extends Component {
     return uc
   }
 
-  handleOnUrlBlur = () => {
+  verifyURL = () => {
     const resource = this.props.Stores.Qvain.resourceInEdit
     externalResourceUrlSchema
       .validate(resource ? resource.url : this.state.url)


### PR DESCRIPTION
CSCETSIN-503: Fix use category dropdown
- In the use category dropdown, the selected use category was previously not visible. Furthermore, it was only possible to save the use category selection once.
- The use category dropdown is now updated correctly, using binary logic (boolean: isEditForm).
- Some syntax improvements (state: useCategories and const: lang) in externalFileForm.jsx

- The function handleChangeUse is now redundant, since its functionality is now handled directly in the useCategory dropdown's onChange event
- Functionality moved from handleChangeUse to onChange
- The boolean isEditForm is used to select the correct functionality in onChange