### PR TITLE
CSCETSIN-537: Remove ? icon

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/licenses/embargoExpires.jsx
+++ b/etsin_finder/frontend/js/components/qvain/licenses/embargoExpires.jsx
@@ -46,6 +46,7 @@ class EmbargoExpires extends Component {
         <DatePickerWrapper>
           <Translate
             component={SingleDatePicker}
+            hideKeyboardShortcutsPanel
             date={embargoExpDate ? moment.utc(embargoExpDate) : null}
             onDateChange={date => {
               if (date === null) {


### PR DESCRIPTION
- Removed the question mark icon (?), since it was deemed unnecessary to show it. Clicking it opens a navigation help window. 
- DatePicker is part of the imported library react-dates, developed by react-dates
- The question mark/help window is also a native library function. Found in the react-dates/SingleDatePicker library
- Turned off by using the hideKeyboardShortcutsPanel prop, inherent to the library

See demo of the library
http://airbnb.io/react-dates/?path=/story/daterangepicker-drp--default