### PR TITLE
CSCETSIN-536: Provide instructions for date format in Create Dataset Embargo

### DIFF
--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -338,7 +338,7 @@ const english = {
         placeholder: 'Select option',
       },
       embargoDate: {
-        label: 'Embargo expiration date',
+        label: 'Embargo expiration date (yyyy-mm-dd)',
         placeholder: 'Date',
         help: 'By default, expiration date will be indefinite if not set.',
       },

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -342,7 +342,7 @@ const finnish = {
         placeholder: 'Valitse vaihtoehto',
       },
       embargoDate: {
-        label: 'Embargo loppumispäivämäärä',
+        label: 'Embargo loppumispäivämäärä (vvvv-kk-pp)',
         placeholder: 'Päivämäärä',
         help: 'Oletuksena embargo ei lopu jollei päivämäärää aseteta.',
       },


### PR DESCRIPTION
- Required date format is set to yyyy-mm-dd, in accordance with the ISO-8601 standard. However, since this is not the Finnish standard, date format instructions have now been added.
- Simple change text change, adding the required format example, both in Finnish and English
- The format example could potentially be added as the input placeholder instead, however, having it in the input label is probably better and easier to understand for the user, and it is always visible here.