### PR TITLE
CSCETSIN-531: Rename 'name' column in Dataset list to 'title'

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
@@ -114,7 +114,7 @@ class DatasetTable extends Component {
           <TableHeader>
             <Row>
               <Translate component={HeaderCell} content="qvain.datasets.tableRows.id" />
-              <Translate component={HeaderCell} content="qvain.datasets.tableRows.name" />
+              <Translate component={HeaderCell} content="qvain.datasets.tableRows.title" />
               <Translate component={HeaderCell} content="qvain.datasets.tableRows.modified" />
               <Translate component={HeaderCell} content="qvain.datasets.tableRows.actions" />
             </Row>

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -282,7 +282,7 @@ const english = {
       createButton: 'Create dataset',
       tableRows: {
         id: 'ID',
-        name: 'Name',
+        title: 'Title',
         modified: 'Modified',
         actions: 'Actions',
       },

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -282,7 +282,7 @@ const finnish = {
       createButton: 'Luo aineisto',
       tableRows: {
         id: 'ID',
-        name: 'Nimi',
+        title: 'Otsikko',
         modified: 'Muokattu',
         actions: 'Toiminnot',
       },


### PR DESCRIPTION
- Consistency improvement, simple renaming of:
1. Variable: name --> title
2. English variable value: 'Name' --> 'Title'
3. Finnish variable value: 'Nimi' --> 'Otsikko'