### PR TITLE
Cscetsin 520 Check if user belongs to projects that data come from.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
@@ -21,7 +21,8 @@ const directoriesToMetax = (selectedDirectories, existingDirectories) => {
     description: dir.description ? dir.description : undefined,
     useCategory: {
       identifier: dir.useCategory
-    }
+    },
+    projectIdentifier: dir.projectIdentifier ? dir.projectIdentifier : undefined
   }))
   return parsedDirectoryData
 }
@@ -39,7 +40,8 @@ const filesToMetax = (selectedFiles, existingFiles) => {
     } : undefined,
     useCategory: {
       identifier: file.useCategory
-    }
+    },
+    projectIdentifier: file.projectIdentifier ? file.projectIdentifier : undefined
   }))
   return parsedFileData
 }

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -26,7 +26,8 @@ from etsin_finder.qvain_light_dataset_schema import DatasetValidationSchema
 from etsin_finder.qvain_light_utils import data_to_metax, \
     get_dataset_creator, \
     remove_deleted_datasets_from_results, \
-    edited_data_to_metax
+    edited_data_to_metax, \
+    check_if_data_in_user_IDA_project
 from etsin_finder.qvain_light_service import create_dataset, update_dataset, delete_dataset
 
 log = app.logger
@@ -180,7 +181,9 @@ class QvainDataset(Resource):
         except KeyError as err:
             log.warning("The Metadata provider is not specified: \n{0}".format(err))
             return {"Error": "The Metadata provider is not specified"}
-
+        user_projects = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.8057.2.80.26"]
+        if not check_if_data_in_user_IDA_project(data, user_projects):
+            return {"Error": "Permission to project data not granted."}, 403
         metax_redy_data = data_to_metax(data, metadata_provider_org, metadata_provider_user)
         metax_response = create_dataset(metax_redy_data)
         return metax_response

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -277,3 +277,34 @@ def edited_data_to_metax(data, original):
         "research_dataset": original["research_dataset"]
     }
     return clean_empty_keyvalues_from_dict(edited_data)
+
+def check_if_data_in_user_IDA_project(data, projects):
+    """
+    Check if the user creating a dataset belongs to the project that the files/folders
+    belogs to.
+
+    Arguments:
+        data {object} -- The dataset that the user is trying to create.
+        projects {list} -- List containing the users projects. Taken from the saml data.
+
+    Returns:
+        [bool] -- True if data belongs to user, and False is not.
+
+    """
+    user_projects = [project.split(":")[0] for project in projects]
+    # Add the test project 'project_x' for local development.
+    user_projects.append("project_x")
+    if "files" or "directories" in data:
+        files = data["files"]
+        directories = data["directories"]
+        if files:
+            for file in files:
+                identifier = file["projectIdentifier"]
+                if identifier in user_projects:
+                    return True
+        if directories:
+            for directory in directories:
+                identifier = directory["projectIdentifier"]
+                if identifier in user_projects:
+                    return True
+    return False


### PR DESCRIPTION
- Added function to the backend that checks if the user belongs to the same projects that the IDA files or folders come from.
- Added the projectIdentifier to the data submitted to the backend.