### PR TITLE
CSCETSIN-543 get use category for directory

### DIFF
--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -728,6 +728,7 @@ const DatasetDirectory = directory => ({
   identifier: directory.identifier,
   description: directory.description,
   title: directory.title,
+  useCategory: directory.use_category.identifier,
   existing: true
 })
 


### PR DESCRIPTION
Fix use category always being Outcome Material even though specified to be different.