### PR TITLE
CSCETSIN-541: Refactor form validation to accept longer titles, descriptions, keywords and participant fields.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -9,15 +9,15 @@ const titleSchema = yup.object().shape({
     is: val => val.length > 0,
     then: yup
       .string(translate('qvain.validationMessages.title.string'))
-      .max(100, translate('qvain.validationMessages.title.max')),
+      .max(500, translate('qvain.validationMessages.title.max')),
     otherwise: yup
       .string(translate('qvain.validationMessages.title.string'))
-      .max(100, translate('qvain.validationMessages.title.max'))
+      .max(500, translate('qvain.validationMessages.title.max'))
       .required(translate('qvain.validationMessages.title.required')),
   }),
   en: yup
     .string(translate('qvain.validationMessages.title.string'))
-    .max(100, translate('qvain.validationMessages.title.max')),
+    .max(500, translate('qvain.validationMessages.title.max')),
 })
 
 const descriptionSchema = yup.object().shape({
@@ -25,15 +25,15 @@ const descriptionSchema = yup.object().shape({
     is: val => val.length > 0,
     then: yup
       .string(translate('qvain.validationMessages.description.string'))
-      .max(100, translate('qvain.validationMessages.description.max')),
+      .max(50000, translate('qvain.validationMessages.description.max')),
     otherwise: yup
       .string(translate('qvain.validationMessages.description.string'))
-      .max(100, translate('qvain.validationMessages.description.max'))
+      .max(50000, translate('qvain.validationMessages.description.max'))
       .required(translate('qvain.validationMessages.description.required')),
   }),
   en: yup
     .string(translate('qvain.validationMessages.description.string'))
-    .max(100, translate('qvain.validationMessages.description.max')),
+    .max(50000, translate('qvain.validationMessages.description.max')),
 })
 
 const keywordsSchema = yup
@@ -41,7 +41,7 @@ const keywordsSchema = yup
   .of(
     yup
       .string(translate('qvain.validationMessages.keywords.string'))
-      .max(100, translate('qvain.validationMessages.keywords.max'))
+      .max(1000, translate('qvain.validationMessages.keywords.max'))
   )
   .required(translate('qvain.validationMessages.keywords.required'))
 
@@ -49,7 +49,7 @@ const otherIdentifierSchema = yup
   .string(translate('qvain.validationMessages.otherIdentifiers.string'))
   .min(10, translate('qvain.validationMessages.otherIdentifiers.min'))
   .url(translate('qvain.validationMessages.otherIdentifiers.url'))
-  .max(100, translate('qvain.validationMessages.otherIdentifiers.max'))
+  .max(1000, translate('qvain.validationMessages.otherIdentifiers.max'))
 
 const otherIdentifiersSchema = yup
   .array()
@@ -119,18 +119,18 @@ const participantRolesSchema = yup
 
 const participantNameSchema = yup
   .string(translate('qvain.validationMessages.participants.name.string'))
-  .max(100, translate('qvain.validationMessages.participants.name.max'))
+  .max(1000, translate('qvain.validationMessages.participants.name.max'))
   .required(translate('qvain.validationMessages.participants.name.required'))
 
 const participantEmailSchema = yup
   .string(translate('qvain.validationMessages.participants.email.string'))
-  .max(100, translate('qvain.validationMessages.participants.email.max'))
+  .max(1000, translate('qvain.validationMessages.participants.email.max'))
   .email(translate('qvain.validationMessages.participants.email.email'))
   .nullable()
 
 const participantIdentifierSchema = yup
   .string()
-  .max(100, translate('qvain.validationMessages.participants.identifier.max'))
+  .max(1000, translate('qvain.validationMessages.participants.identifier.max'))
   .nullable()
 
 const participantOrganizationSchema = yup.object().shape({


### PR DESCRIPTION
 - Allow longer text in these fields to avoid errors where someone has
  added longer text than Qvain Light allows and then is unable to edit
  dataset.
- Altered the formValidation to accept longer `max` values.
- Changes have the side effect of possibly getting larger datasets to
  handel.