### PR TITLE
CSCETSIN-524: Login without CSC account

### DIFF
--- a/etsin_finder/frontend/js/components/frontpage/index.jsx
+++ b/etsin_finder/frontend/js/components/frontpage/index.jsx
@@ -28,9 +28,9 @@ import Stores from '../../stores'
 
 const customStyles = {
   content: {
-      minWidth: '20vw',
-      maxWidth: '800px',
-      padding: '3em',
+    minWidth: '20vw',
+    maxWidth: '800px',
+    padding: '3em',
   },
 }
 
@@ -39,7 +39,7 @@ export default class FrontPage extends Component {
     super(props)
 
     this.state = {
-      userPermissionErrorModalIsOpen: false
+      userPermissionErrorModalIsOpen: false,
     }
 
     this.closeModal = this.closeModal.bind(this)
@@ -51,24 +51,29 @@ export default class FrontPage extends Component {
     // preload search page
     Search.preload()
 
-    // TimeOut to check the user status, and display modal message if user is not authenticated
-    setTimeout(() => {
-      this.checkUserLoginStatus()
-    }, 1000)
+    // Check the user status, and display modal message if user is not authenticated
+    this.checkUserLoginStatus()
   }
 
   checkUserLoginStatus() {
     // If the user has a user.commonName, but not a user.name, it means they were verified through HAKA, but do not have a CSC account.
-    if (Stores.Auth.user.commonName !== undefined && Stores.Auth.user.name === undefined) {
-      this.setState({
-        userPermissionErrorModalIsOpen: true
+    Stores.Auth.checkLogin()
+      .then(() => {
+        if (Stores.Auth.user.commonName !== undefined && Stores.Auth.user.name === undefined) {
+          this.setState({
+            userPermissionErrorModalIsOpen: true,
+          })
+        }
       })
-    }
+      .catch(err => {
+        console.log('ERROR in checkLogin')
+        console.log(err)
+      })
   }
 
   closeModal() {
     this.setState({
-      userPermissionErrorModalIsOpen: false
+      userPermissionErrorModalIsOpen: false,
     })
     // At this point, the user is "logged in", but not verified.
     // Performing Auth.logout(), ensuring the user is not still logged in with their unverified HAKA-account onRefreshPage
@@ -82,6 +87,7 @@ export default class FrontPage extends Component {
           isOpen={this.state.userPermissionErrorModalIsOpen}
           onRequestClose={this.closeModal}
           customStyles={customStyles}
+          contentLabel="LoginUnsuccessful"
         >
           <Translate content="userAuthenticationError.header" component="h2" />
           <Translate content="userAuthenticationError.content" component="p" />

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -9,7 +9,6 @@
  */
 
 import { observable, action } from 'mobx'
-// import { observable, action, toJS } from 'mobx'
 import axios from 'axios'
 
 class Auth {
@@ -30,15 +29,21 @@ class Auth {
           headers: { 'content-type': 'application/json', charset: 'utf-8' },
         })
         .then(res => {
-          // console.log(res.data)
-          this.userLogged = res.data.is_authenticated
-          this.cscUserLogged = res.data.is_authenticated_CSC_user
           this.user = {
             name: res.data.user_csc_name,
             commonName: res.data.user_display_name,
             idaGroups: res.data.user_ida_groups,
           }
-          // console.log(toJS(this.user))
+          if (res.data.is_authenticated && !res.data.is_authenticated_CSC_user) {
+            // The user was able to verify themself using HAKA or some other external verification,
+            // but do not have a valid CSC account and should not be granted permission.
+            this.userLogged = false
+            this.cscUserLogged = false
+          } else if (res.data.is_authenticated && res.data.is_authenticated_CSC_user) {
+            // The user has a valid CSC account and was logged in.
+            this.userLogged = res.data.is_authenticated
+            this.cscUserLogged = res.data.is_authenticated_CSC_user
+          }
           this.loading = false
           resolve(res)
         })

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -642,6 +642,10 @@ const english = {
   tombstone: {
     info: 'The dataset has been either deprecated or removed',
   },
+  userAuthenticationError: {
+    header: 'Login unsuccessful.',
+    content: 'Please make sure that you have a valid CSC account. If you tried to log in with an external account (for example Haka) you might get this error if your account is not associated with a CSC account. Please register a CSC account at https://sui.csc.fi. You can register with or without a Haka account.',
+  },
 }
 
 export default english

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -613,6 +613,10 @@ const finnish = {
   tombstone: {
     info: 'Aineisto on joko vanhentunut tai poistettu',
   },
+  userAuthenticationError: {
+    header: 'Kirjautuminen epäonnistui.',
+    content: 'Tarkistathan, että sinulla on voimassaoleva CSC-tunnus (Qvaimen ja Qvain Lightin käyttö vaatii sen). Jos yritit kirjaututua jollain toisella tunnuksella (esim. Haka), sitä ei todennäköisesti ole liitetty CSC-tunnukseen. Voit rekisteröidä itsellesi CSC-tunnuksen osoitteessa https://sui.csc.fi.',
+  },
 }
 
 export default finnish


### PR DESCRIPTION
- To account for cases where a user has logged in through HAKA, but does not have a CSC account
- Display an error message, directing the user to create a CSC account for access.
- When the error message is closed by the user, their account is logged out.