### PR TITLE
CSCETSIN-420: Enable Matomo when in production

### DIFF
--- a/etsin_finder/frontend/static/index.template.ejs
+++ b/etsin_finder/frontend/static/index.template.ejs
@@ -33,29 +33,30 @@
         }
       }
     </style>
-    <% if(process.env.MATOMO === 'true') { %>
-    <!-- Matomo -->
+    <!-- Matomo, activated if in production -->
+    <% if (process.env.NODE_ENV === 'production') { %>
     <script>
-      var _paq = _paq || []
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      // _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking'])
-      ;(function() {
-        var u = '//matomo.rahtiapp.fi/'
-        _paq.push(['setTrackerUrl', u + 'piwik.php'])
-        _paq.push(['setSiteId', '3'])
-        var d = document,
-          g = d.createElement('script'),
-          s = d.getElementsByTagName('script')[0]
-        g.type = 'text/javascript'
-        g.async = true
-        g.defer = true
-        g.src = u + 'piwik.js'
-        s.parentNode.insertBefore(g, s)
-      })()
+        window._paq = []
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+          var u = '//matomo.rahtiapp.fi/'
+          _paq.push(['setTrackerUrl', u + 'piwik.php'])
+          // Site ID set in rahtiapp
+          _paq.push(['setSiteId', '8'])
+          var d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0]
+          g.type = 'text/javascript'
+          g.async = true
+          g.defer = true
+          g.src = u + 'piwik.js'
+          s.parentNode.insertBefore(g, s)
+        })()
+      // }
     </script>
-    <!-- End Matomo Code -->
     <% } %>
+    <!-- End Matomo Code -->
   </head>
 
   <body>


### PR DESCRIPTION
- Matomo is set up to track user visits and better understand what parts of the app are most used.
- Some older Matomo code was already present in index.template.ejs, though apparently unused. Rewrote some functionality.
- The Matomo functionality needs to be tested once these changes pushed to test.