### PR TITLE
CSCETSIN-525: Login without home organization

### DIFF
--- a/etsin_finder/authentication.py
+++ b/etsin_finder/authentication.py
@@ -170,3 +170,35 @@ def get_user_ida_groups():
                  "Saml userdata:\n{0}".format(session['samlUserdata']))
 
     return None
+
+def get_user_home_organization_id():
+    """
+    Get the organization id from the saml userdata
+
+    :return:
+    """
+    if not is_authenticated() or 'samlUserdata' not in session:
+        return None
+
+    home_organization = session['samlUserdata'].get('urn:oid:1.3.6.1.4.1.25178.1.2.9', False)
+    if home_organization:
+        return home_organization[0]
+    else:
+        log.warn("User seems to be authenticated but CSC organization id not in session object."
+                            "Saml userdata:\n{0}".format(session['samlUserdata']))
+
+def get_user_home_organization_name():
+    """
+    Get the organization id from the saml userdata
+
+    :return:
+    """
+    if not is_authenticated() or 'samlUserdata' not in session:
+        return None
+
+    home_organization_id = session['samlUserdata'].get('urn:oid:1.3.6.1.4.1.16161.4.0.88', False)
+    if home_organization_id:
+        return home_organization_id[0]
+    else:
+        log.warn("User seems to be authenticated but CSC organization name not in session object."
+                            "Saml userdata:\n{0}".format(session['samlUserdata']))

--- a/etsin_finder/frontend/js/components/frontpage/index.jsx
+++ b/etsin_finder/frontend/js/components/frontpage/index.jsx
@@ -40,9 +40,11 @@ export default class FrontPage extends Component {
 
     this.state = {
       userPermissionErrorModalIsOpen: false,
+      userHomeOrganizationErrorModalIsOpen: false,
     }
 
-    this.closeModal = this.closeModal.bind(this)
+    this.closeUserPermissionErrorModal = this.closeUserPermissionErrorModal.bind(this)
+    this.closeUserHomeOrganizationErrorModal = this.closeUserHomeOrganizationErrorModal.bind(this)
   }
 
   componentDidMount() {
@@ -56,12 +58,24 @@ export default class FrontPage extends Component {
   }
 
   checkUserLoginStatus() {
-    // If the user has a user.commonName, but not a user.name, it means they were verified through HAKA, but do not have a CSC account.
     Stores.Auth.checkLogin()
       .then(() => {
-        if (Stores.Auth.user.commonName !== undefined && Stores.Auth.user.name === undefined) {
+        console.log(Stores.Auth.user)
+        // If the user has a user.commonName, but not a user.name,
+        // it means they were verified through HAKA, but do not have a CSC account.
+        if (
+          Stores.Auth.user.commonName !== undefined &&
+          Stores.Auth.user.name === undefined) {
           this.setState({
             userPermissionErrorModalIsOpen: true,
+          })
+        // If the user has a user.name, but not a user.homeOrganizationName,
+        // it means they have a CSC account, but no home organization set.
+        } else if (
+          Stores.Auth.user.name !== undefined &&
+          Stores.Auth.user.homeOrganizationName === undefined) {
+          this.setState({
+            userHomeOrganizationErrorModalIsOpen: true,
           })
         }
       })
@@ -71,7 +85,7 @@ export default class FrontPage extends Component {
       })
   }
 
-  closeModal() {
+  closeUserPermissionErrorModal() {
     this.setState({
       userPermissionErrorModalIsOpen: false,
     })
@@ -80,17 +94,35 @@ export default class FrontPage extends Component {
     Auth.logout()
   }
 
+  closeUserHomeOrganizationErrorModal() {
+    this.setState({
+      userHomeOrganizationErrorModalIsOpen: false,
+    })
+    // At this point, the user is "logged in" and has a CSC account, but does not have a home organization set in sui.csc.fi.
+    // Performing Auth.logout(), ensuring the user is not still logged in onRefreshPage
+    Auth.logout()
+  }
+
   render() {
     return (
       <div className="search-page">
         <Modal
           isOpen={this.state.userPermissionErrorModalIsOpen}
-          onRequestClose={this.closeModal}
+          onRequestClose={this.closeUserPermissionErrorModal}
           customStyles={customStyles}
-          contentLabel="LoginUnsuccessful"
+          contentLabel="LoginUnsuccessfulPermissionError"
         >
           <Translate content="userAuthenticationError.header" component="h2" />
           <Translate content="userAuthenticationError.content" component="p" />
+        </Modal>
+        <Modal
+          isOpen={this.state.userHomeOrganizationErrorModalIsOpen}
+          onRequestClose={this.closeUserHomeOrganizationErrorModal}
+          customStyles={customStyles}
+          contentLabel="LoginUnsuccessfulHomeOrganizationError"
+        >
+          <Translate content="userHomeOrganizationErrror.header" component="h2" />
+          <Translate content="userHomeOrganizationErrror.content" component="p" />
         </Modal>
         <HeroBanner className="hero-primary">
           <div className="container">

--- a/etsin_finder/frontend/js/components/frontpage/index.jsx
+++ b/etsin_finder/frontend/js/components/frontpage/index.jsx
@@ -60,7 +60,6 @@ export default class FrontPage extends Component {
   checkUserLoginStatus() {
     Stores.Auth.checkLogin()
       .then(() => {
-        console.log(Stores.Auth.user)
         // If the user has a user.commonName, but not a user.name,
         // it means they were verified through HAKA, but do not have a CSC account.
         if (

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -29,9 +29,11 @@ class Auth {
           headers: { 'content-type': 'application/json', charset: 'utf-8' },
         })
         .then(res => {
+          console.log(res)
           this.user = {
             name: res.data.user_csc_name,
             commonName: res.data.user_display_name,
+            homeOrganizationName: res.data.home_organization_name,
             idaGroups: res.data.user_ida_groups,
           }
           if (res.data.is_authenticated && !res.data.is_authenticated_CSC_user) {
@@ -39,7 +41,12 @@ class Auth {
             // but do not have a valid CSC account and should not be granted permission.
             this.userLogged = false
             this.cscUserLogged = false
-          } else if (res.data.is_authenticated && res.data.is_authenticated_CSC_user) {
+          } else if (!res.data.home_organization_name) {
+            // The user was able to verify themself using their CSC account,
+            // but do not have a home organization set (sui.csc.fi) and should not be granted permission.
+            this.userLogged = false
+            this.cscUserLogged = false
+          } else if (res.data.is_authenticated && res.data.is_authenticated_CSC_user && res.data.home_organization_name) {
             // The user has a valid CSC account and was logged in.
             this.userLogged = res.data.is_authenticated
             this.cscUserLogged = res.data.is_authenticated_CSC_user

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -29,7 +29,6 @@ class Auth {
           headers: { 'content-type': 'application/json', charset: 'utf-8' },
         })
         .then(res => {
-          console.log(res)
           this.user = {
             name: res.data.user_csc_name,
             commonName: res.data.user_display_name,

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -646,6 +646,10 @@ const english = {
     header: 'Login unsuccessful.',
     content: 'Please make sure that you have a valid CSC account. If you tried to log in with an external account (for example Haka) you might get this error if your account is not associated with a CSC account. Please register a CSC account at https://sui.csc.fi. You can register with or without a Haka account.',
   },
+  userHomeOrganizationErrror: {
+    header: 'Login unsuccesful.',
+    content: 'You have a verified CSC account, but your account does not seem to have a home organization. Please contact the CSC Helpdesk to set a home organization for your CSC account.',
+  }
 }
 
 export default english

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -617,6 +617,10 @@ const finnish = {
     header: 'Kirjautuminen epäonnistui.',
     content: 'Tarkistathan, että sinulla on voimassaoleva CSC-tunnus (Qvaimen ja Qvain Lightin käyttö vaatii sen). Jos yritit kirjaututua jollain toisella tunnuksella (esim. Haka), sitä ei todennäköisesti ole liitetty CSC-tunnukseen. Voit rekisteröidä itsellesi CSC-tunnuksen osoitteessa https://sui.csc.fi.',
   },
+  userHomeOrganizationErrror: {
+    header: 'Kirjautuminen epäonnistui.',
+    content: 'Tunnusta ei ole liitetty mihinkään kotiorganisaatioon. Olethan yhteydessä CSC:n asiakaspalveluun.',
+  }
 }
 
 export default finnish

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -226,7 +226,9 @@ class User(Resource):
         """
         user_info = {
             'is_authenticated': authentication.is_authenticated(),
-            'is_authenticated_CSC_user': authentication.is_authenticated_CSC_user()}
+            'is_authenticated_CSC_user': authentication.is_authenticated_CSC_user(),
+            'home_organization_id': authentication.get_user_home_organization_id(),
+            'home_organization_name': authentication.get_user_home_organization_name()}
         dn = authentication.get_user_display_name()
         csc_user = authentication.get_user_csc_name()
         groups = authentication.get_user_ida_groups()


### PR DESCRIPTION
- If the user tries to login with their CSC account and succeeds, but do not have a home organization set through sui.csc.fi, an error should be displayed.
- New backend requests, new error message modal, verificiation variables/logic and translation
- Both home organization name and id are retrieved from the backend. Verification through the home organization name, since HAKA accounts seem to have a home organization id (funet.fi).