### PR TITLE
CSCETSIN-563: Validate external resource use category

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -209,6 +209,11 @@ const externalResourceTitleSchema = yup
   .string()
   .required(translate('qvain.validationMessages.externalResources.title.required'))
 
+// Use category is one of preset 7 options (all strings)
+const externalResourceUseCategorySchema = yup
+  .string()
+  .required(translate('qvain.validationMessages.externalResources.useCategory.required'))
+
 const externalResourceUrlSchema = yup
   .string()
   .url(translate('qvain.validationMessages.externalResources.url.url'))
@@ -216,6 +221,7 @@ const externalResourceUrlSchema = yup
 
 const externalResourceSchema = yup.object().shape({
   title: externalResourceTitleSchema,
+  useCategory: externalResourceUseCategorySchema,
   url: externalResourceUrlSchema,
 })
 

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -525,6 +525,9 @@ const english = {
         title: {
           required: 'External resource title is required',
         },
+        useCategory: {
+          required: 'External resource use category is required',
+        },
         url: {
           required: 'External resource URL is required',
           url: 'External Resource URL needs to be of valid URL format',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -529,6 +529,9 @@ const finnish = {
         title: {
           required: 'Ulkoisen aineiston otsikko on pakollinen',
         },
+        useCategory: {
+          required: 'Ulkoisen aineiston käyttökategoria on pakollinen',
+        },
         url: {
           required: 'Ulkoisen aineiston URL osoite on pakollinen',
           url: 'Ulkoisen aineiston URL osoitteen pitää olla oikeassa URL formaatissa',


### PR DESCRIPTION
- Use category is a required field, and so must be validated
- Validation using string check, since the use category options are 7 preset strings
- Noticed possible general issue: Need to check field input error message displays for Finnish language