### PR TITLE
CSCETSIN-564: Validate dataset publisher and creator

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -258,6 +258,28 @@ const participantsSchema = yup
       }),
     })
   )
+  // Test: loop through the participant list and the roles of each participant
+  // A Creator and a Publisher must be found in the participant list in order to allow the dataset to be posted to the database
+  .test(
+    'contains-creator-and-publisher',
+    translate('qvain.validationMessages.participants.requiredParticipants.required'),
+    (value) => {
+      let foundCreator = false;
+      let foundPublisher = false;
+        for (let i = 0; i < value.length; i += 1) {
+          for (let j = 0; j < value[i].role.length; j += 1) {
+          if (value[i].role[j] === 'creator') {
+            foundCreator = true;
+          } else if (value[i].role[j] === 'publisher') {
+            foundPublisher = true;
+          }
+        }
+      }
+      if (foundCreator && foundPublisher) {
+        return true;
+      }
+      return false;
+    })
   .required()
 
 // ENTIRE FORM VALIDATION

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -479,6 +479,9 @@ const english = {
           string: 'The Organization value must be string.',
           required: 'Organization is required if the participant is a person.',
         },
+        requiredParticipants: {
+          required: 'Participants: Creator and publisher roles are mandatory. You must specify at least one creator, as well as a publisher, for your dataset. Note: one person can have both these roles.',
+        },
       },
       accessType: {
         string: 'Access Type must be string value.',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -483,6 +483,9 @@ const finnish = {
           string: 'Organisaation arvo tulisi olla merkkijono.',
           required: 'Organisaatio on pakollinen kenttä jos Toimija on Luonnollinen henkilö.',
         },
+        requiredParticipants: {
+          required: 'Toimijat: Tekijä ja julkaisija-roolit ovat pakollisia. Määrittele vähintään yksi tekijä ja likäksi julkaisija. Huomioi: yksittäisellä toimijalla voi olla useampi rooli.',
+        },
       },
       accessType: {
         string: 'Pääsyoikeus tulisi olla arvoltaan merkkijono.',


### PR DESCRIPTION
- In order to post a dataset to the backend, a publisher and a creator must be defined for the dataset
- Yup validation test that loops through the participant list and each participant's role. If creator and publisher roles are found, the test checks out. Otherwise, error message is displayed.
- Noticed that some translations for error messages could be added/improved