### PR TITLE
CSCETSIN-566: Fix org name mapping from Qvain.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/participants/participantInfo.jsx
+++ b/etsin_finder/frontend/js/components/qvain/participants/participantInfo.jsx
@@ -139,6 +139,25 @@ export class ParticipantInfoBase extends Component {
     )
   }
 
+  getOrganizationName = (org, lang) => {
+    // Check if org is object. If object then it comes from edit and the
+    // values can be uncertain.
+    // If the org object contains the current language, return that.
+    // If not but contains 'und' language, return that.
+    // Else find any language it contains and return that.
+    if (typeof org === 'object' && org !== null) {
+      if (lang in org) {
+        return org[lang]
+      }
+      if ('und' in org) {
+        return org.und
+      }
+      const langX = Object.keys(org)[0]
+      return org[langX]
+    }
+    return org
+  }
+
   render() {
     const participant = this.props.Stores.Qvain.participantInEdit
     const { lang } = this.props.Stores.Locale
@@ -190,7 +209,7 @@ export class ParticipantInfoBase extends Component {
                   participant.identifier = ''
                 }
               }}
-              value={{ label: participant.name, value: participant.identifier }}
+              value={{ label: this.getOrganizationName(participant.name, lang), value: participant.identifier }}
               onBlur={this.handleOnNameBlur}
             />
             )}
@@ -240,7 +259,10 @@ export class ParticipantInfoBase extends Component {
           attributes={{ placeholder: 'qvain.participants.add.organization.placeholder' }}
           onChange={(selection) => { participant.organization = selection.label }}
           onBlur={this.handleOnOrganizationBlur}
-          value={{ label: participant.organization, value: participant.organization }}
+          value={{
+            label: this.getOrganizationName(participant.organization, lang),
+            value: this.getOrganizationName(participant.organization, lang)
+          }}
           filterOption={createFilter({ ignoreAccents: false })}
         />
         {organizationError && <ValidationError>{organizationError}</ValidationError>}

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -574,7 +574,7 @@ class Qvain {
   createParticipant = (participantJson, role, participants) => {
     let name
     if (participantJson['@type'].toLowerCase() === EntityType.ORGANIZATION) {
-      name = participantJson.name ? participantJson.name.und : undefined
+      name = participantJson.name ? participantJson.name : undefined
     } else {
       name = participantJson.name
     }
@@ -583,14 +583,15 @@ class Qvain {
     if (participantJson['@type'].toLowerCase() === EntityType.ORGANIZATION) {
       const isPartOf = participantJson.is_part_of
       if (isPartOf !== undefined) {
-        parentOrg = isPartOf.name.und
+        parentOrg = isPartOf.name
       } else {
         parentOrg = undefined
       }
     } else {
       const parentOrgName = participantJson.member_of.name
-      if (parentOrgName !== undefined && parentOrgName.und !== undefined) {
-        parentOrg = parentOrgName.und
+      if (parentOrgName !== undefined) {
+        parentOrg = parentOrgName
+        console.log(parentOrgName)
       } else {
         parentOrg = undefined
       }


### PR DESCRIPTION
- The participant organization field only showed org names in 'und'
  language because it is always set in reference data but causes
  problems with Qvain where it might not be set. This caused it to not
  show anything.
- Added function getOrganizationName that shows it in either the current
  language or then just some available language.
- Effects participant mapping in edit.