### PR TITLE
CSCETSIN-568: Restriction grounds fix

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
@@ -73,7 +73,7 @@ const handleSubmitToBackend = (values) => {
     keywords: values.keywords,
     participants: participantsToMetax(values.participants),
     accessType: values.accessType ? values.accessType : undefined,
-    restrictionGrounds: values.restrictionGrounds ? values.restrictionGrounds.value : undefined,
+    restrictionGrounds: values.restrictionGrounds ? values.restrictionGrounds.identifier : undefined,
     embargoDate: values.embargoExpDate,
     license: values.license ? values.license : undefined,
     otherLicenseUrl: values.otherLicenseUrl,


### PR DESCRIPTION
- Setting restriction grounds caused an error
- Fixed variable that caused the error (value --> identifier)
- Strangely, the default display values for restriction grounds seem to be working correctly, but are slightly different than the display values retrieved for a restriction grounds object saved in the backend. Investigate?