### PR TITLE
CSCETSIN-571: Fix participant org mapping issues.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/participants/addedParticipants.jsx
+++ b/etsin_finder/frontend/js/components/qvain/participants/addedParticipants.jsx
@@ -33,7 +33,22 @@ export class AddedParticipantsBase extends Component {
     this.props.Stores.Qvain.editParticipant(EmptyParticipant)
   }
 
+  getAddedParticipantName = (name, lang) => {
+    if (typeof name === 'object' && name !== null) {
+      if (lang in name) {
+        return name[lang]
+      }
+      if ('und' in name) {
+        return name.und
+      }
+      const langX = Object.keys(name)[0]
+      return name[langX]
+    }
+    return name
+  }
+
   render() {
+    const { lang } = this.props.Stores.Locale
     return (
       <ContainerSubsectionBottom>
         <Translate
@@ -47,7 +62,7 @@ export class AddedParticipantsBase extends Component {
           <ButtonGroup key={addedParticipant.uiId}>
             <ButtonLabel>
               <FontAwesomeIcon icon={addedParticipant.type === EntityType.PERSON ? faUser : faBuilding} style={{ marginRight: '8px' }} />
-              {addedParticipant.name}{addedParticipant.role.map(role => (` / ${ role }`))}
+              {this.getAddedParticipantName(addedParticipant.name, lang)}{addedParticipant.role.map(role => (` / ${ role }`))}
             </ButtonLabel>
             <ButtonContainer>
               <EditButton onClick={this.handleEditParticipant(addedParticipant)} />

--- a/etsin_finder/frontend/js/components/qvain/participants/participantInfo.jsx
+++ b/etsin_finder/frontend/js/components/qvain/participants/participantInfo.jsx
@@ -32,10 +32,8 @@ export class ParticipantInfoBase extends Component {
   }
 
   state = {
-    orgs: {
-      en: [],
-      fi: []
-    },
+    orgs: [],
+    orgsLang: [],
     nameError: undefined,
     emailError: undefined,
     participantError: undefined,
@@ -46,25 +44,16 @@ export class ParticipantInfoBase extends Component {
   componentDidMount = () => {
     axios.get('https://metax.fairdata.fi/es/organization_data/organization/_search?size=1000')
       .then(res => {
+        const { lang } = this.props.Stores.Locale
         const list = res.data.hits.hits;
-        const refsEn = list.map(ref => (
+        const refs = list.map(ref => (
           {
             value: ref._source.code,
-            label: ref._source.label.und,
+            label: ref._source.label,
           }
           ))
-        const refsFi = list.map(ref => (
-          {
-            value: ref._source.code,
-            label: ref._source.label.fi,
-          }
-          ))
-        this.setState({
-          orgs: {
-            en: refsEn,
-            fi: refsFi
-          }
-        })
+        this.setState({ orgs: refs })
+        this.setState({ orgsLang: this.getOrgOptionsWithLang(refs, lang) })
       })
       .catch(error => {
         if (error.response) {
@@ -139,6 +128,19 @@ export class ParticipantInfoBase extends Component {
     )
   }
 
+  getOrgOptionsWithLang = (orgs, lang) => {
+    // From the reference data parse the values with the current lang
+    // or und.
+    const organizations = orgs.map(org => {
+      const orgWithLang = {
+        label: org.label[lang] ? org.label[lang] : org.label.und,
+        value: org.value
+      }
+      return orgWithLang
+    })
+    return organizations
+  }
+
   getOrganizationName = (org, lang) => {
     // Check if org is object. If object then it comes from edit and the
     // values can be uncertain.
@@ -163,6 +165,7 @@ export class ParticipantInfoBase extends Component {
     const { lang } = this.props.Stores.Locale
     const {
       orgs,
+      orgsLang,
       nameError,
       emailError,
       participantError,
@@ -191,7 +194,7 @@ export class ParticipantInfoBase extends Component {
               component={SelectOrg}
               name="nameField"
               id="nameField"
-              options={orgs[lang]}
+              options={orgsLang}
               formatCreateLabel={inputValue => (
                 <Fragment>
                   <Translate content="qvain.participants.add.newOrganization.label" />
@@ -200,16 +203,19 @@ export class ParticipantInfoBase extends Component {
               )}
               attributes={{ placeholder: 'qvain.participants.add.organization.placeholder' }}
               onChange={(selection) => {
-                participant.name = selection.label
+                participant.name = orgs.find(org => org.value === selection.value).label
                 // if selection value ie the org identifier is not in the reference data, then we are adding a new org, so do not define
                 // identifier
-                if (orgs[lang].filter(opt => opt.value === selection.value).length > 0) {
+                if (orgs.filter(opt => opt.value === selection.value).length > 0) {
                   participant.identifier = selection.value
                 } else {
                   participant.identifier = ''
                 }
               }}
-              value={{ label: this.getOrganizationName(participant.name, lang), value: participant.identifier }}
+              value={{
+                label: this.getOrganizationName(participant.name, lang),
+                value: participant.identifier
+              }}
               onBlur={this.handleOnNameBlur}
             />
             )}
@@ -234,7 +240,7 @@ export class ParticipantInfoBase extends Component {
           id="identifierField"
           component={Input}
           type="text"
-          disabled={orgs[lang].find(opt => opt.value === participant.identifier)}
+          disabled={orgsLang.find(opt => opt.value === participant.identifier)}
           attributes={{ placeholder: 'qvain.participants.add.identifier.placeholder' }}
           onChange={(event) => { participant.identifier = event.target.value }}
           value={participant.identifier}
@@ -249,7 +255,7 @@ export class ParticipantInfoBase extends Component {
           component={SelectOrg}
           name="orgField"
           id="orgField"
-          options={orgs[lang]}
+          options={orgsLang}
           formatCreateLabel={inputValue => (
             <Fragment>
               <Translate content="qvain.participants.add.newOrganization.label" />
@@ -257,7 +263,9 @@ export class ParticipantInfoBase extends Component {
             </Fragment>
           )}
           attributes={{ placeholder: 'qvain.participants.add.organization.placeholder' }}
-          onChange={(selection) => { participant.organization = selection.label }}
+          onChange={(selection) => {
+            participant.organization = orgs.find(org => org.value === selection.value).label
+          }}
           onBlur={this.handleOnOrganizationBlur}
           value={{
             label: this.getOrganizationName(participant.organization, lang),

--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -139,7 +139,7 @@ const participantOrganizationSchema = yup.object().shape({
   organization: yup.mixed().when('type', {
     is: 'person',
     then: yup
-      .string(translate('qvain.validationMessages.participants.organization.string'))
+      .object()
       .required(translate('qvain.validationMessages.participants.organization.required')),
     otherwise: yup
       .object(translate('qvain.validationMessages.participants.organization.object'))
@@ -231,10 +231,10 @@ const participantSchema = yup.object().shape({
   organization: yup.mixed().when('type', {
     is: 'person',
     then: yup
-      .string(translate('qvain.validationMessages.participants.organization.string'))
+      .object()
       .required(translate('qvain.validationMessages.participants.organization.required')),
     otherwise: yup
-      .string(translate('qvain.validationMessages.participants.organization.string'))
+      .object()
       .nullable(),
   }),
 })
@@ -251,10 +251,10 @@ const participantsSchema = yup
       organization: yup.mixed().when('type', {
         is: 'person',
         then: yup
-          .string(translate('qvain.validationMessages.participants.organization.string'))
+          .object()
           .required(translate('qvain.validationMessages.participants.organization.required')),
         otherwise: yup
-          .string(translate('qvain.validationMessages.participants.organization.string'))
+          .object()
           .nullable(),
       }),
     })

--- a/etsin_finder/qvain_light_dataset_schema.py
+++ b/etsin_finder/qvain_light_dataset_schema.py
@@ -30,13 +30,12 @@ class ParticipantsValidationSchema(Schema):
         fields.Str(validate=Length(min=1)),
         required=True
     )
-    name = fields.Str(
+    name = fields.Raw(
         required=True,
-        validate=Length(min=1)
     )
     email = fields.Email()
     identifier = fields.Str()
-    organization = fields.Str()
+    organization = fields.Dict()
 
 class DatasetValidationSchema(Schema):
     """

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -45,17 +45,14 @@ def alter_role_data(participant_list, role):
             participant["@type"] = "Person"
             participant["name"] = participant_object["name"]
             participant["member_of"] = {}
-            participant["member_of"]["name"] = {}
-            participant["member_of"]["name"]["und"] = participant_object["organization"]
+            participant["member_of"]["name"] = participant_object["organization"]
             participant["member_of"]["@type"] = "Organization"
         else:
             participant["@type"] = "Organization"
-            participant["name"] = {}
-            participant["name"]["und"] = participant_object["name"]
-            if "organization" in participant_object and participant_object["organization"] != "":
+            participant["name"] = participant_object["name"]
+            if "organization" in participant_object and participant_object["organization"] != {}:
                 participant["is_part_of"] = {}
-                participant["is_part_of"]["name"] = {}
-                participant["is_part_of"]["name"]["und"] = participant_object["organization"]
+                participant["is_part_of"]["name"] = participant_object["organization"]
                 participant["is_part_of"]["@type"] = "Organization"
 
         if "email" in participant_object:


### PR DESCRIPTION
- Show in the dropdown the values of the current lang, or if not available
  show in und, and if not available show in some language that is specified.
  Also when selecting an org for a participant it sends to metax all
  languages set in reference data.
- Changed the org field to be an object with lang as keys instead of just
  a string with the value in und. Also changed validation to support
  changes.
- Effects adding participant org in create and edit. Also effects selecting
  the org in edit.