### PR TITLE
CSCETSIN-569: Fix Qvain Light title/description overwrite bug.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
@@ -60,14 +60,8 @@ const filesToMetax = (selectedFiles, existingFiles) => {
 
 const handleSubmitToBackend = (values) => {
   const obj = {
-    title: {
-      fi: values.title.fi,
-      en: values.title.en,
-    },
-    description: {
-      fi: values.description.fi,
-      en: values.description.en,
-    },
+    title: values.title,
+    description: values.description,
     identifiers: values.otherIdentifiers,
     fieldOfScience: values.fieldOfScience ? values.fieldOfScience.url : undefined,
     keywords: values.keywords,

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -445,6 +445,8 @@ class Qvain {
     const researchDataset = dataset.research_dataset
 
     // Load description
+    this.title = { ...researchDataset.title }
+    this.description = { ...researchDataset.description }
     this.title.en = researchDataset.title.en ? researchDataset.title.en : ''
     this.title.fi = researchDataset.title.fi ? researchDataset.title.fi : ''
     this.description.en = researchDataset.description.en ? researchDataset.description.en : ''
@@ -591,7 +593,6 @@ class Qvain {
       const parentOrgName = participantJson.member_of.name
       if (parentOrgName !== undefined) {
         parentOrg = parentOrgName
-        console.log(parentOrgName)
       } else {
         parentOrg = undefined
       }

--- a/etsin_finder/qvain_light_dataset_schema.py
+++ b/etsin_finder/qvain_light_dataset_schema.py
@@ -3,17 +3,6 @@ from marshmallow import Schema, fields
 from marshmallow.validate import Length
 import json
 
-class LangValidationSchema(Schema):
-    """
-    Validation schema for language.
-
-    Arguments:
-        Schema {library} -- Marshmallows Schema library.
-    """
-
-    en = fields.Str()
-    fi = fields.Str()
-
 class ParticipantsValidationSchema(Schema):
     """
     Validation schema for participants.
@@ -46,13 +35,11 @@ class DatasetValidationSchema(Schema):
     """
 
     original = fields.Dict()
-    title = fields.Nested(
-        LangValidationSchema,
+    title = fields.Dict(
         required=True,
         validate=lambda x: len(x['en']) + len(x['fi']) > 0
     )
-    description = fields.Nested(
-        LangValidationSchema,
+    description = fields.Dict(
         required=True,
         validate=lambda x: len(x['en']) + len(x['fi']) > 0
     )


### PR DESCRIPTION
- If a dataset had title or description in other languages then Qvain
  Light overwrote them with only finnish and english. Now all previous
  data is stored and only english and finnish ca  be edited.
- Spread the title and description data to a object and edit only fi
  and en. In backend validate other than fi and en.
- Effects editing datasets.