### PR TITLE
CSCETSIN-562: Show filename instead of title

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -37,7 +37,7 @@ export class SelectedFilesBase extends Component {
             <FileItem active={isInEdit(inEdit, s.identifier)}>
               <ButtonLabel>
                 <FontAwesomeIcon icon={(s.directoryName ? faFolder : faCopy)} style={{ marginRight: '8px' }} />
-                {s.projectIdentifier} / {s.directoryName || s.title}
+                {s.projectIdentifier} / {s.directoryName || s.fileName}
               </ButtonLabel>
               <ButtonContainer>
                 <EditButton onClick={this.handleEdit(s)} />


### PR DESCRIPTION
Files are more easily identified by their filenames. Thus filename should be used as display value in the IDA selected files list, instead of file title. Simple variable name change.