### PR TITLE
 CSCETSIN-550: Added sticky subheader for publishing and updating datasets

### DIFF
--- a/etsin_finder/frontend/js/components/general/button.jsx
+++ b/etsin_finder/frontend/js/components/general/button.jsx
@@ -104,6 +104,15 @@ export const LinkButton = styled(TransparentButton)`
   }
 `
 
+export const LinkButtonDarkGray = styled(TransparentButton)`
+  margin: 0;
+  padding: 0;
+  color: rgb(110, 110, 110)
+  &:hover {
+    color: ${p => darken(0.1, p.color ? checkColor(p.color) : p.theme.color.primary)};
+  }
+`
+
 // prettier-ignore
 export const Link = styled.a.attrs(props => ({
   padding: props.padding ? props.padding : '0.3em 0.6em 0.4em',

--- a/etsin_finder/frontend/js/components/general/navigation/dropdownMenu.jsx
+++ b/etsin_finder/frontend/js/components/general/navigation/dropdownMenu.jsx
@@ -104,6 +104,7 @@ const MenuContainer = styled.div`
   display: flex;
   align-items: center;
   height: 100%;
+  z-index: 3;
 `
 
 const ButtonContainer = styled.div`

--- a/etsin_finder/frontend/js/components/qvain/description/descriptionField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/descriptionField.jsx
@@ -80,7 +80,7 @@ class DescriptionField extends Component {
           <EmptyBlock width="48%" />
         </LangButtonContainer>
         <DescriptionCard>
-          <h3><Translate content="qvain.description.description.title.label" /></h3>
+          <h3><Translate content="qvain.description.description.title.label" /> *</h3>
           {activeLang === 'FINNISH' && (
             <Translate
               component={Input}
@@ -102,7 +102,7 @@ class DescriptionField extends Component {
             />
           )}
           <ValidationError>{this.state.titleError}</ValidationError>
-          <h3><Translate content="qvain.description.description.description.label" /></h3>
+          <h3><Translate content="qvain.description.description.description.label" /> *</h3>
           {activeLang === 'FINNISH' && (
             <Translate
               component={Textarea}

--- a/etsin_finder/frontend/js/components/qvain/general/card.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/card.jsx
@@ -55,7 +55,6 @@ export const SubHeader = styled.div`
 export const StickySubHeaderWrapper = styled.div`
   top: 0;
   position: sticky;
-  scroll-margin-top: 50px;
   z-index: 2;
 `
 

--- a/etsin_finder/frontend/js/components/qvain/general/card.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/card.jsx
@@ -52,6 +52,30 @@ export const SubHeader = styled.div`
   align-items: center;
 `
 
+export const StickySubHeaderWrapper = styled.div`
+  top: 0;
+  position: sticky;
+  scroll-margin-top: 50px;
+  z-index: 2;
+`
+
+export const StickySubHeader = styled.div`
+  height: 50px;
+  background-color: rgb(231,233,237);
+  font-color: #4F4F4F;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  border-bottom: 1px solid rgba(0,0,0,0.3);
+`
+
+export const StickySubHeaderResponse = styled.div`
+  font-color: #4F4F4F;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+`
+
 export const SubHeaderText = styled.div`
   font-family: 'Lato', sans-serif;
   font-size: 32px;

--- a/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
@@ -149,7 +149,6 @@ const ResponseContainer = styled.div`
   background-color: #E8FFEB;
   color: green;
   z-index: 2;
-  scroll-margin-top: 100px;
   width: 100%;
   border-bottom: 1px solid rgba(0,0,0,0.3);
 `
@@ -157,7 +156,6 @@ const ResponseContainer = styled.div`
 const ResponseContainerLoading = styled.div`
   background-color: #fff;
   z-index: 2;
-  scroll-margin-top: 100px;
   width: 100%;
   height: 105px;
   padding-top: 30px;
@@ -168,7 +166,6 @@ const ResponseContainerError = styled.div`
   background-color: #FFEBE8;
   color: red;
   z-index: 2;
-  scroll-margin-top: 100px;
   width: 100%;
   border-bottom: 1px solid rgba(0,0,0,0.3);
 `

--- a/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { inject, observer } from 'mobx-react'
 import Translate from 'react-translate-component'
-import { Container, SlidingContent } from './card'
 import Loader from '../../general/loader'
-import { InvertedButton } from '../../general/button'
+import { LinkButtonDarkGray } from '../../general/button';
 
 class SubmitResponse extends Component {
   static propTypes = {
@@ -13,15 +12,32 @@ class SubmitResponse extends Component {
     response: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array]),
   }
 
-  state = {
-    openResponse: false,
+  constructor() {
+    super()
+    this.state = {
+      clearSubmitResponse: false,
+    }
+
+    this.closeSubmitResponse = this.closeSubmitResponse.bind(this)
+  }
+
+  closeSubmitResponse() {
+    this.setState({
+      clearSubmitResponse: true,
+    })
   }
 
   render() {
     const { response } = this.props
-    const { openResponse } = this.state
     const { original } = this.props.Stores.Qvain
-    // If a NEW dataset has been created successfully.
+
+    // If the user wants to clear the submitResponse
+    if (this.state.clearSubmitResponse) {
+      this.state.clearSubmitResponse = false;
+      return null;
+    }
+
+    // If a new dataset has been created successfully.
     if (response &&
         'identifier' in response &&
         !('new_version_created' in response) &&
@@ -30,10 +46,17 @@ class SubmitResponse extends Component {
       const identifier = response.identifier
       return (
         <ResponseContainer>
-          <ResponseLabel success>
-            <Translate content="qvain.submitStatus.success" />
-          </ResponseLabel>
-          <p>Identifier: {identifier}</p>
+          <ResponseContainerLeftColumn>
+            <ResponseLabel success>
+              <Translate content="qvain.submitStatus.success" />
+            </ResponseLabel>
+            <p>Identifier: {identifier}</p>
+          </ResponseContainerLeftColumn>
+          <ResponseContainerRightColumn>
+            <LinkButtonDarkGray type="button" onClick={this.closeSubmitResponse}>
+              x
+            </LinkButtonDarkGray>
+          </ResponseContainerRightColumn>
         </ResponseContainer>
       )
     }
@@ -51,10 +74,17 @@ class SubmitResponse extends Component {
       const identifier = response.identifier
       return (
         <ResponseContainer>
-          <ResponseLabel success>
-            <Translate content="qvain.submitStatus.editMetadataSuccess" />
-          </ResponseLabel>
-          <p>Identifier: {identifier}</p>
+          <ResponseContainerLeftColumn>
+            <ResponseLabel success>
+              <Translate content="qvain.submitStatus.editMetadataSuccess" />
+            </ResponseLabel>
+            <p>Identifier: {identifier}</p>
+          </ResponseContainerLeftColumn>
+          <ResponseContainerRightColumn>
+            <LinkButtonDarkGray type="button" onClick={this.closeSubmitResponse}>
+              x
+            </LinkButtonDarkGray>
+          </ResponseContainerRightColumn>
         </ResponseContainer>
       )
     }
@@ -66,41 +96,43 @@ class SubmitResponse extends Component {
         : response.identifier
       return (
         <ResponseContainer>
-          <ResponseLabel success>
-            <Translate content="qvain.submitStatus.editFilesSuccess" />
-          </ResponseLabel>
-          <p>Identifier: {identifier}</p>
+          <ResponseContainerLeftColumn>
+            <ResponseLabel success>
+              <Translate content="qvain.submitStatus.editFilesSuccess" />
+            </ResponseLabel>
+            <p>Identifier: {identifier}</p>
+          </ResponseContainerLeftColumn>
+          <ResponseContainerRightColumn>
+            <LinkButtonDarkGray type="button" onClick={this.closeSubmitResponse}>
+              x
+            </LinkButtonDarkGray>
+          </ResponseContainerRightColumn>
         </ResponseContainer>
       )
     }
     // If something went wrong.
     if (response) {
       return (
-        <ResponseContainer>
-          <ResponseLabel>
-            <Translate content="qvain.submitStatus.fail" />
-          </ResponseLabel>
-          <InvertedButton
-            color="red"
-            onClick={() => this.setState(prevState => ({ openResponse: !prevState.openResponse }))}
-            type="button"
-          >
-            {openResponse ? (
-              <Translate content="qvain.closeErrorMessages" />
-            ) : (
-              <Translate content="qvain.openErrorMessages" />
-            )}
-          </InvertedButton>
-          <SlidingContent open={openResponse}>
-            <Pre>{JSON.stringify(response, null, 8)}</Pre>
-          </SlidingContent>
-        </ResponseContainer>
+        <ResponseContainerError>
+          <ResponseContainerLeftColumn>
+            <ResponseLabel>
+              <Translate content="qvain.submitStatus.fail" />
+            </ResponseLabel>
+            <p>{(response.toString().replace(/,/g, '\n'))}</p>
+          </ResponseContainerLeftColumn>
+          <ResponseContainerRightColumn>
+            <LinkButtonDarkGray type="button" onClick={this.closeSubmitResponse}>
+              x
+            </LinkButtonDarkGray>
+          </ResponseContainerRightColumn>
+        </ResponseContainerError>
       )
     }
+
     return (
-      <ResponseContainer>
+      <ResponseContainerLoading>
         <Loader active />
-      </ResponseContainer>
+      </ResponseContainerLoading>
     )
   }
 }
@@ -110,22 +142,49 @@ SubmitResponse.defaultProps = {
 }
 
 const ResponseLabel = styled.p`
+  font-weight: bold;
   color: ${props => (props.success ? 'green' : 'red')};
-  font-size: 2em;
 `
-const ResponseContainer = styled(Container)`
-  padding: 25px 45px 45px 45px;
-  margin: 15px;
+const ResponseContainer = styled.div`
+  background-color: #E8FFEB;
+  color: green;
+  z-index: 2;
+  scroll-margin-top: 100px;
+  width: 100%;
+  border-bottom: 1px solid rgba(0,0,0,0.3);
 `
-const Pre = styled.pre`
-  color: white;
-  margin-top: inherit;
-  padding: 15px;
-  background-color: black;
-  white-space: pre-wrap; /* Since CSS 2.1 */
-  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
-  white-space: -pre-wrap; /* Opera 4-6 */
-  white-space: -o-pre-wrap; /* Opera 7 */
-  word-wrap: break-word;
+
+const ResponseContainerLoading = styled.div`
+  background-color: #fff;
+  z-index: 2;
+  scroll-margin-top: 100px;
+  width: 100%;
+  height: 105px;
+  padding-top: 30px;
+  border-bottom: 1px solid rgba(0,0,0,0.3);
+`
+
+const ResponseContainerError = styled.div`
+  background-color: #FFEBE8;
+  color: red;
+  z-index: 2;
+  scroll-margin-top: 100px;
+  width: 100%;
+  border-bottom: 1px solid rgba(0,0,0,0.3);
+`
+const ResponseContainerLeftColumn = styled.div`
+  padding-left: 20px;
+  padding-top: 20px;
+  display:inline-block;
+  width: 90%;
+  white-space: pre-line;
+`
+const ResponseContainerRightColumn = styled.div`
+  display:inline-block;
+  width: 10%;
+  text-align: right;
+  padding-top: 10px;
+  padding-right: 10px;
+  vertical-align: top;
 `
 export default inject('Stores')(observer(SubmitResponse))

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -33,6 +33,13 @@ class Qvain extends Component {
     Stores: PropTypes.object.isRequired,
   }
 
+  constructor(props) {
+    super(props)
+    this.setFocusOnSubmitOrUpdateButton = this.setFocusOnSubmitOrUpdateButton.bind(this);
+    this.submitDatasetButton = React.createRef();
+    this.updateDatasetButton = React.createRef();
+  }
+
   state = {
     response: null,
     submitted: false,
@@ -41,6 +48,16 @@ class Qvain extends Component {
   componentWillUnmount() {
     this.props.Stores.Qvain.resetQvainStore()
     this.props.Stores.Qvain.original = undefined
+  }
+
+  setFocusOnSubmitOrUpdateButton(event) {
+    if (this.props.Stores.Qvain.original) {
+      this.updateDatasetButton.current.focus()
+    } else {
+      this.submitDatasetButton.current.focus()
+    }
+    // preventDefault, since the page wants to refresh at this point
+    event.preventDefault();
   }
 
   handleCreate = e => {
@@ -137,12 +154,12 @@ class Qvain extends Component {
             <ButtonContainer>
               {this.props.Stores.Qvain.original
                 ? (
-                  <SubmitButton type="button" onClick={this.handleUpdate}>
+                  <SubmitButton ref={this.updateDatasetButton} type="button" onClick={this.handleUpdate}>
                     <Translate content="qvain.edit" />
                   </SubmitButton>
                 )
                 : (
-                  <SubmitButton type="button" onClick={this.handleCreate}>
+                  <SubmitButton ref={this.submitDatasetButton} type="button" onClick={this.handleCreate}>
                     <Translate content="qvain.submit" />
                   </SubmitButton>
                 )
@@ -163,12 +180,31 @@ class Qvain extends Component {
           <SubmitContainer>
             <Translate component="p" content="qvain.consent" unsafe />
           </SubmitContainer>
+          <STSD onClick={this.setFocusOnSubmitOrUpdateButton}>
+            <Translate content="stsd" />
+          </STSD>
         </Form>
       </QvainContainer>
     )
   }
 }
 
+const STSD = styled.button`
+    background: ${p => p.theme.color.primary};
+    color: #fafafa;
+    max-height: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    letter-spacing: 2px;
+    transition: 0.2s ease;
+    &:focus {
+    text-decoration: underline;
+    padding: 0.5em;
+    max-height: 3em;
+    }
+`
 const SubHeaderTextContainer = styled.div`
   white-space: nowrap;
 `

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -13,12 +13,20 @@ import Description from './description'
 import Participants from './participants'
 import { qvainFormSchema } from './utils/formValidation'
 import Files from './files'
-import { QvainContainer, SubHeader, SubHeaderText, Container } from './general/card'
+import {
+  QvainContainer,
+  SubHeader,
+  StickySubHeaderWrapper,
+  StickySubHeader,
+  StickySubHeaderResponse,
+  SubHeaderText,
+  Container
+} from './general/card'
 import handleSubmitToBackend from './utils/handleSubmit'
 import Title from './general/title'
 import SubmitResponse from './general/submitResponse'
-import { InvertedButton } from '../general/button'
 import isJsonString from './utils/isJsonSring'
+import { InvertedButton } from '../general/button';
 
 class Qvain extends Component {
   static propTypes = {
@@ -112,21 +120,20 @@ class Qvain extends Component {
     return (
       <QvainContainer>
         <SubHeader>
-          <SubHeaderText>
-            <Translate component={Title} content="qvain.title" />
-          </SubHeaderText>
+          <SubHeaderTextContainer>
+            <SubHeaderText>
+              <Translate component={Title} content="qvain.title" />
+            </SubHeaderText>
+          </SubHeaderTextContainer>
+          <LinkBackContainer>
+            <LinkBack to="/qvain">
+              <FontAwesomeIcon size="lg" icon={faChevronLeft} />
+              <Translate component="span" display="block" content="qvain.backLink" />
+            </LinkBack>
+          </LinkBackContainer>
         </SubHeader>
-        <Form className="container">
-          <LinkBack to="/qvain">
-            <FontAwesomeIcon size="lg" icon={faChevronLeft} />
-            <Translate component="span" content="qvain.backLink" />
-          </LinkBack>
-          <Description />
-          <Participants />
-          <RightsAndLicenses />
-          <Files />
-          <SubmitContainer>
-            <Translate component="p" content="qvain.consent" unsafe />
+        <StickySubHeaderWrapper>
+          <StickySubHeader>
             <ButtonContainer>
               {this.props.Stores.Qvain.original
                 ? (
@@ -141,25 +148,49 @@ class Qvain extends Component {
                 )
               }
             </ButtonContainer>
+          </StickySubHeader>
+          {this.state.submitted ? (
+            <StickySubHeaderResponse>
+              <SubmitResponse response={this.state.response} />
+            </StickySubHeaderResponse>
+          ) : null}
+        </StickySubHeaderWrapper>
+        <Form className="container">
+          <Description />
+          <Participants />
+          <RightsAndLicenses />
+          <Files />
+          <SubmitContainer>
+            <Translate component="p" content="qvain.consent" unsafe />
           </SubmitContainer>
-          {this.state.submitted ? <SubmitResponse response={this.state.response} /> : null}
         </Form>
       </QvainContainer>
     )
   }
 }
 
+const SubHeaderTextContainer = styled.div`
+  white-space: nowrap;
+`
+const LinkBackContainer = styled.div`
+  text-align: right;
+  width: 100%;
+  white-space: nowrap;
+`
 const LinkBack = styled(Link)`
-  display: inline-block;
-  margin: 10px 15px 0;
+  color: #fff;
+  margin-right: 40px;
 `
 const ButtonContainer = styled.div`
   text-align: center;
 `
 const SubmitButton = styled(InvertedButton)`
+  background: #fff;
   font-size: 1.2em;
   border-radius: 25px;
   padding: 5px 30px;
+  border-color: #007fad;
+  border: 1px solid;
 `
 const Form = styled.form`
   margin-bottom: 20px;

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -183,6 +183,7 @@ const LinkBack = styled(Link)`
 `
 const ButtonContainer = styled.div`
   text-align: center;
+  padding-top: 2px;
 `
 const SubmitButton = styled(InvertedButton)`
   background: #fff;

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -662,6 +662,7 @@ const english = {
   },
   slogan: 'Research data finder',
   stc: 'Skip to content',
+  stsd: 'Skip to submit dataset',
   tombstone: {
     info: 'The dataset has been either deprecated or removed',
   },

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -262,8 +262,6 @@ const english = {
       editFilesSuccess: 'New dataset version has been created!',
       editMetadataSuccess: 'Dataset successfully updated!',
     },
-    openErrorMessages: 'Open error messages',
-    closeErrorMessages: 'Close error messages',
     unsuccessfullLogin: 'Login unsuccessful.',
     notCSCUser1:
       'Please make sure that you have a valid CSC account. If you tried to log in with an external account (for example Haka) you might get this error if your account is not associated with CSC account. Please do the registration in',
@@ -481,7 +479,7 @@ const english = {
         },
         requiredParticipants: {
           atLeastOneParticipant: 'You must add at least one participant to your dataset.',
-          mandatoryParticipants: 'Participants: Creator and publisher roles are mandatory. You must specify at least one creator, as well as a publisher, for your dataset. Note: one person can have both these roles.',
+          mandatoryParticipants: 'Participants: Creator and publisher roles are mandatory. Note: one person can have both these roles.',
         },
       },
       accessType: {

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -262,8 +262,6 @@ const finnish = {
       editSuccess: 'Uusi aineisto versio luotu!',
       editMetadataSuccess: 'Aineisto päivitys onnistui!',
     },
-    openErrorMessages: 'Avaa virheviestit',
-    closeErrorMessages: 'Sulje virheviestit',
     unsuccessfullLogin: 'Kirjautuminen epäonnistui.',
     notCSCUser1:
       'Varmistakaa että teillä on voimassaoleva CSC tunnus. Jos yritit kirjautua sisään ulkoisella tunnuksella (kuten Haka) Niin saatat saada tämän virhe ilmoituksen jos titlit eivät ole linkitetty. Linkityksen voi tehdä',
@@ -485,7 +483,7 @@ const finnish = {
         },
         requiredParticipants: {
           atLeastOneParticipant: 'Aineistoon on lisättävä vähintään yksi toimija.',
-          mandatoryParticipants: 'Toimijat: Tekijä ja julkaisija-roolit ovat pakollisia. Määrittele vähintään yksi tekijä ja likäksi julkaisija. Huomioi: yksittäisellä toimijalla voi olla useampi rooli.',
+          mandatoryParticipants: 'Toimijat: Tekijä ja julkaisija-roolit ovat pakollisia. Huomioi: yksittäisellä toimijalla voi olla useampi rooli.',
         },
       },
       accessType: {

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -633,6 +633,7 @@ const finnish = {
   },
   slogan: 'Tutkimustenhaku palvelu',
   stc: 'Siirry sivun pääsisältöön',
+  stsd: 'Siirry "Julkaise Aineisto"-nappiin',
   tombstone: {
     info: 'Aineisto on joko vanhentunut tai poistettu',
   },


### PR DESCRIPTION
- Redesign: Moved publish/update dataset from the bottom of the page to a subheader
- The publish/update button is now always visible on top, using a sticky subheader that follows the user as they scroll the page. Success/loading/error messages are also implemented as part of the sticky subheader. Messages can be closed using a (x) button in the top right corner.
- New containers, close message functionality, lots of .css updates.