### PR TITLE
CSCETSIN-575: Fix button backgrounds in Safari and Firefox

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -13,6 +13,7 @@ import {
 export const CancelButton = styled.button`
   width: 84px;
   height: 42px;
+  background-color: #fff;
   border-radius: 4px;
   border: solid 1px #4f4f4f;
   font-size: 16px;
@@ -59,6 +60,7 @@ export const RemoveButton = styled.button`
   height: 42px;
   border-radius: 4px;
   border: solid 1px #cc0000;
+  background-color: #fff;
   font-size: 16px;
   font-weight: 600px;
   line-height: 1.31;


### PR DESCRIPTION
- Having the background-color undefined caused the buttons to default to a gray-ish color
- Added background-color to buttons
- No side effects.