### PR TITLE
CSCETSIN-576: Fix default values for IDA file/folders.

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/directoryForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/directoryForm.jsx
@@ -20,9 +20,11 @@ export class DirectoryFormBase extends Component {
     Stores: PropTypes.object.isRequired,
   }
 
+  inEdit = this.props.Stores.Qvain.inEdit
+
   state = {
-    title: this.props.Stores.Qvain.inEdit.title,
-    description: this.props.Stores.Qvain.inEdit.description || '',
+    title: this.inEdit.title || (this.inEdit.directoryName ? this.inEdit.directoryName : 'Directory'),
+    description: this.inEdit.description || 'Directory',
     useCategoriesEn: [],
     useCategoriesFi: [],
     useCategory: undefined,
@@ -138,7 +140,7 @@ export class DirectoryFormBase extends Component {
           />
           {titleError !== undefined && <ValidationError>{titleError}</ValidationError>}
           <Label>
-            <Translate content="qvain.files.selected.form.description.label" /> *
+            <Translate content="qvain.files.selected.form.description.label" />
           </Label>
           <Translate
             component={Textarea}

--- a/etsin_finder/frontend/js/components/qvain/files/fileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fileForm.jsx
@@ -22,13 +22,15 @@ class FileForm extends Component {
     Stores: PropTypes.object.isRequired
   }
 
+  inEdit = this.props.Stores.Qvain.inEdit
+
   state = {
     fileTypesEn: [],
     fileTypesFi: [],
     useCategoriesEn: [],
     useCategoriesFi: [],
-    title: this.props.Stores.Qvain.inEdit.title,
-    description: this.props.Stores.Qvain.inEdit.description || '',
+    title: this.inEdit.title || (this.inEdit.fileName ? this.fileName : 'File'),
+    description: this.inEdit.description || 'File',
     useCategory: undefined,
     fileType: undefined,
     fileError: undefined,


### PR DESCRIPTION
- If the file or folder does not have title set, it will put the fileName
  or directoryName as default. Also removed the asterisk from directory
  description which is not mandatory in Metax.
- In files the fileName is set in no title, and in directories the
  directoryName is set if no title. If no description then 'File' or
  'Description' is set.
- Effects creating datasets and adding IDA Files/Directories.