### PR TITLE
CSCETSIN-499: Show info modal when IDA files/folders are edited in an existing dataset

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/description/descriptionField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/descriptionField.jsx
@@ -90,7 +90,7 @@ class DescriptionField extends Component {
         </LangButtonContainer>
         <DescriptionCard>
           <LabelLarge htmlFor="titleInput">
-            <Translate content="qvain.description.description.title.label" />
+            <Translate content="qvain.description.description.title.label" /> *
           </LabelLarge>
           {activeLang === 'FINNISH' && (
             <Translate
@@ -120,7 +120,7 @@ class DescriptionField extends Component {
           )}
           <ValidationError>{this.state.titleError}</ValidationError>
           <LabelLarge htmlFor="descriptionInput">
-            <Translate content="qvain.description.description.description.label" />
+            <Translate content="qvain.description.description.description.label" /> *
           </LabelLarge>
           {activeLang === 'FINNISH' && (
             <Translate

--- a/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
@@ -48,7 +48,7 @@ class DataCatalog extends Component {
     return (
       <Card>
         <LabelLarge htmlFor="dataCatalogSelect">
-          <Translate content="qvain.files.dataCatalog.label" />
+          <Translate content="qvain.files.dataCatalog.label" /> *
         </LabelLarge>
         <Translate component="p" content="qvain.files.dataCatalog.explanation" />
         <Translate

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -9,10 +9,16 @@ import { SelectedFilesTitle } from '../general/form'
 import FileForm from './fileForm'
 import DirectoryForm from './directoryForm'
 import { randomStr } from '../utils/fileHierarchy'
+import Modal from '../../general/modal'
+import { TableButton } from '../general/buttons'
 
 export class SelectedFilesBase extends Component {
   static propTypes = {
     Stores: PropTypes.object.isRequired
+  }
+
+  state = {
+    datasetDuplicationModalHasNotBeenShown: true,
   }
 
   handleEdit = (selected) => (event) => {
@@ -23,6 +29,13 @@ export class SelectedFilesBase extends Component {
     } else {
       this.props.Stores.Qvain.setInEdit(selected)
     }
+  }
+
+  closeDatasetDuplicationInformationModal = () => {
+    // Set to false permanently, since the warning only needs to be shown once, not every time a new file is added.
+    this.setState({
+      datasetDuplicationModalHasNotBeenShown: false,
+    })
   }
 
   renderFiles = (selected, inEdit, existing) => {
@@ -84,6 +97,16 @@ export class SelectedFilesBase extends Component {
         <Translate tabIndex="0" component={SelectedFilesTitle} content="qvain.files.existing.title" />
         <Translate tabIndex="0" component="p" content="qvain.files.existing.help" />
         {this.renderFiles(existing, inEdit, true)}
+        <Modal
+          // Inform the user that a new dataset will be created, if both existing and selected files are present.
+          isOpen={(selected.length) > 0 && (existing.length > 0) && (this.state.datasetDuplicationModalHasNotBeenShown === true)}
+          onRequestClose={this.closeDatasetDuplicationInformationModal}
+          contentLabel="notificationNewDatasetWillBeCreatedModal"
+        >
+          <Translate component="h3" content="qvain.files.notificationNewDatasetWillBeCreated.header" />
+          <Translate component="p" content="qvain.files.notificationNewDatasetWillBeCreated.content" />
+          <TableButton onClick={this.closeDatasetDuplicationInformationModal}>Ok.</TableButton>
+        </Modal>
       </Fragment>
     )
   }

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -625,6 +625,10 @@ const english = {
         title: 'Previously selected files',
         help: 'These are the files and directories that you have added before. If you do not touch these, upon saving the changes to the dataset METAX will go through all the selected directories and associate any files and directories within, even the new ones. In other words, if you don\'t touch these and save, you can associate new files within the directory structure with your dataset.'
       },
+      notificationNewDatasetWillBeCreated: {
+        header: 'Editing files and folders',
+        content: 'If you have already published the dataset, removing / adding files or folders will automatically create a new version of the dataset (excluding a published dataset without any files; you can add files/folder one time in the existing version). The old version will be tagged as "Old" and the files linked to it will remain untouched.',
+      },
       external: {
         title: 'External resources (ATT)',
         infoText: 'add text',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -594,7 +594,11 @@ const finnish = {
       },
       existing: {
         title: 'Aikaisemmin valitut tiedostot',
-        help: 'Nämä ovat sinun aiemmin valitsemia tiedostoja. Jos tallennat aineiston tekemättä muutoksia näihin, METAX katsoo läpi kaikki sisäkkäiset hakemistot ja tiedostot valitsemistasi hakemistoista ja lisää kaikki tiedostot mitä se ei ole aiemmin liittänyt aineistoon. Toisin sanoen, jos olet jälkikäteen lisännyt IDAan tiedostoja, voit liittää nämä uudet tiedostot aineistoon päivittämällä aineiston.'
+        help: 'Nämä ovat sinun aiemmin valitsemia tiedostoja. Jos tallennat aineiston tekemättä muutoksia näihin, METAX katsoo läpi kaikki sisäkkäiset hakemistot ja tiedostot valitsemistasi hakemistoista ja lisää kaikki tiedostot mitä se ei ole aiemmin liittänyt aineistoon. Toisin sanoen, jos olet jälkikäteen lisännyt IDAan tiedostoja, voit liittää nämä uudet tiedostot aineistoon päivittämällä aineiston.',
+      },
+      notificationNewDatasetWillBeCreated: {
+        header: 'Tiedostojen ja kansioiden muokkaaminen',
+        content: 'Jos julkaistuun aineistoon lisätään tiedostoja tai hakemistoja, tai siitä poistetaan tiedostoja tai hakemistoja, ko. aineistosta syntyy automaattisesti uusi versio. Vanha versio pysyy muuttumattomana ja siihen lisätään "vanha" -tagi. Jos julkaistu aineisto ei sisältänyt yhtään tiedostoa, voit lisätä tiedostoja ja/tai hakemistoja yhden kerran ilman, että uusi versio syntyy.',
       },
       external: {
         title: 'Ulkoiset aineistot (ATT)',


### PR DESCRIPTION
- The user needs to be informed that if they save a dataset with both new and existing IDA files, a new version of the dataset is created, in addition to the already existing one
- New translations, info modal shown the first time the user adds a new file or folder to the dataset

Bonus content:
- Fix missing asterisks that had gone missing at some point