### PR TITLE
CSCETSIN-577: Disallow file origin change

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
@@ -24,7 +24,6 @@ class DataCatalog extends Component {
     errorMessage: undefined,
   }
 
-
   handleOnBlur = () => {
     const dataCatalog = this.props.Stores.Qvain.dataCatalog
     dataCatalogSchema
@@ -43,7 +42,7 @@ class DataCatalog extends Component {
 
   render() {
     const { errorMessage } = this.state
-    const { dataCatalog, setDataCatalog, selectedFiles, selectedDirectories, externalResources } = this.props.Stores.Qvain
+    const { dataCatalog, setDataCatalog, selectedFiles, selectedDirectories, externalResources, original } = this.props.Stores.Qvain
     const selected = [...selectedFiles, ...selectedDirectories, ...externalResources]
     return (
       <Card>
@@ -63,7 +62,7 @@ class DataCatalog extends Component {
           }}
           onBlur={this.handleOnBlur}
           attributes={{ placeholder: 'qvain.files.dataCatalog.placeholder' }}
-          isDisabled={selected.length > 0}
+          isDisabled={(selected.length > 0) || (original !== undefined)}
         />
         {errorMessage && <ValidationError>{errorMessage}</ValidationError>}
       </Card>

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -546,7 +546,7 @@ const english = {
       dataCatalog: {
         label: 'File origin',
         infoText: 'Add text',
-        explanation: 'Choose IDA if the data is stored in Fairdata Ida service. Choose ATT if the data is stored elsewhere.',
+        explanation: 'Choose IDA if the data is stored in the Fairdata IDA service. Choose ATT if the data is stored elsewhere.',
         placeholder: 'Select option'
       },
       help:


### PR DESCRIPTION
- File origin change now disallowed either when 1: A file (IDA or external) has been added or 2: The dataset has been saved
- Checking this.props.Stores.Qvain.original to see if dataset has been saved or not
- Small English translation improvement