### PR TITLE
CSCETSIN-581: Fix error messages in the submit response

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -25,7 +25,6 @@ import {
 import handleSubmitToBackend from './utils/handleSubmit'
 import Title from './general/title'
 import SubmitResponse from './general/submitResponse'
-import isJsonString from './utils/isJsonSring'
 import { InvertedButton } from '../general/button';
 
 class Qvain extends Component {
@@ -84,19 +83,28 @@ class Qvain extends Component {
             // If user is not logged in, display logged in error
             if (err.response.data.PermissionError) {
               this.setState({ response: [err.response.data.PermissionError] })
-            // Otherwise, display the formatted Metax error
+
+            // If user is logged in, display the formatted Metax error
+            } else if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
+              this.setState({
+                response:
+                  [err.response.data.slice(
+                    err.response.data.indexOf(':["') + 3,
+                    err.response.data.indexOf('"],'))
+                  ]
+              })
+
+            // If formatting cannot be done, just display the entire error
+            } else if (err.response.data) {
+              this.setState({
+                response: [err.response.data]
+              })
+
+            // If error response is empty, just display 'Error...'
             } else {
-              this.setState(
-                err ?
-                { response:
-                    [err.response.data.slice(
-                      err.response.data.indexOf(':["') + 3,
-                      err.response.data.indexOf('"],'))
-                    ]
-                }
-                :
-                { response: 'Error...' }
-              )
+              this.setState({
+                response: ['Error...']
+              })
             }
           })
       })
@@ -127,21 +135,42 @@ class Qvain extends Component {
             this.setState({ response: JSON.parse(res.data) })
           })
           .catch(err => {
-            console.log(err.response)
-            const res = {
-              Error: isJsonString(err.response.data)
-                ? JSON.parse(err.response.data)
-                : err.response.data,
-              Status: err.response.status,
-              Data: isJsonString(err.response.config.data)
-                ? JSON.parse(err.response.config.data)
-                : err.response.config.data,
+            // Refreshing error header
+            this.setState({ response: null })
+
+            // If user is not logged in, display logged in error
+            if (err.response.data.PermissionError) {
+              this.setState({ response: [err.response.data.PermissionError] })
+
+            // If user is logged in, display the formatted Metax error
+            } else if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
+              this.setState({
+                response:
+                  [err.response.data.slice(
+                    err.response.data.indexOf(':["') + 3,
+                    err.response.data.indexOf('"],'))
+                  ]
+              })
+
+            // If formatting cannot be done, just display the entire error
+            } else if (err.response.data) {
+              this.setState({
+                response: [err.response.data]
+              })
+
+            // If error response is empty, just display 'Error...'
+            } else {
+              this.setState({
+                response: ['Error...']
+              })
             }
-            this.setState(err ? { response: res } : { response: 'Error...' })
           })
       })
       .catch(err => {
         console.log(err.errors)
+
+        // Refreshing error header
+        this.setState({ response: null })
         this.setState({ response: err.errors })
       })
   }

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -78,21 +78,32 @@ class Qvain extends Component {
             }
           })
           .catch(err => {
-            console.log(err.response)
-            const res = {
-              Error: isJsonString(err.response.data)
-                ? JSON.parse(err.response.data)
-                : err.response.data,
-              Status: err.response.status,
-              Data: isJsonString(err.response.config.data)
-                ? JSON.parse(err.response.config.data)
-                : err.response.config.data,
+            // Refreshing error header
+            this.setState({ response: null })
+
+            // If user is not logged in, display logged in error
+            if (err.response.data.PermissionError) {
+              this.setState({ response: [err.response.data.PermissionError] })
+            // Otherwise, display the formatted Metax error
+            } else {
+              this.setState(
+                err ?
+                { response:
+                    [err.response.data.slice(
+                      err.response.data.indexOf(':["') + 3,
+                      err.response.data.indexOf('"],'))
+                    ]
+                }
+                :
+                { response: 'Error...' }
+              )
             }
-            this.setState(err ? { response: res } : { response: 'Error...' })
           })
       })
       .catch(err => {
         console.log(err.errors)
+
+        // Refreshing error header
         this.setState({ response: null })
         this.setState({ response: err.errors })
       })


### PR DESCRIPTION
- Messages from Metax were displayed as [Object object], providing no information
- Login errors are now handled, as well as general Metax errors. Both are displayed in the error header.