### PR TITLE
 CSCETSIN-585: Handle case where user has no datasets

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
@@ -158,6 +158,7 @@ const LinkToEtsin = styled.button`
   text-decoration: underline;
   margin-left: 10px;
   margin-bottom: 0px;
+  margin-top: 2.5px;
   cursor: pointer;
   border: none;
   background-color: transparent;

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -84,21 +84,25 @@ class Qvain extends Component {
             if (err.response.data.PermissionError) {
               this.setState({ response: [err.response.data.PermissionError] })
 
-            // If user is logged in, display the formatted Metax error
-            } else if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
+            // If user is logged in...
+            } else if (err.response.data) {
+            // ...try to format the Metax error
+            if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
               this.setState({
                 response:
-                  [err.response.data.slice(
+                  [
+                    err.response.data.slice(
                     err.response.data.indexOf(':["') + 3,
                     err.response.data.indexOf('"],'))
                   ]
               })
 
-            // If formatting cannot be done, just display the entire error
-            } else if (err.response.data) {
+            // If the Metax error message formatting cannot be done, just display the entire error
+            } else {
               this.setState({
                 response: [err.response.data]
               })
+            }
 
             // If error response is empty, just display 'Error...'
             } else {
@@ -140,21 +144,25 @@ class Qvain extends Component {
             if (err.response.data.PermissionError) {
               this.setState({ response: [err.response.data.PermissionError] })
 
-            // If user is logged in, display the formatted Metax error
-            } else if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
+            // If user is logged in...
+            } else if (err.response.data) {
+            // ...try to format the Metax error
+            if ((err.response.data.includes(':["')) && (err.response.data.includes('"],'))) {
               this.setState({
                 response:
-                  [err.response.data.slice(
+                  [
+                    err.response.data.slice(
                     err.response.data.indexOf(':["') + 3,
                     err.response.data.indexOf('"],'))
                   ]
               })
 
-            // If formatting cannot be done, just display the entire error
-            } else if (err.response.data) {
+            // If the Metax error message formatting cannot be done, just display the entire error
+            } else {
               this.setState({
                 response: [err.response.data]
               })
+            }
 
             // If error response is empty, just display 'Error...'
             } else {

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -150,6 +150,9 @@ class UserDatasets(Resource):
                 # Remove the datasets that have the metax property 'removed': True
                 result = remove_deleted_datasets_from_results(result)
                 result['results'] = slice_array_on_limit(result['results'], TOTAL_ITEM_LIMIT)
+            # If no datasets are created, an empty response should be returned, without error
+            if (result == 'no datasets'):
+                return '', 200
             return result, 200
         return '', 404
 

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -141,6 +141,9 @@ class MetaxQvainLightAPIService(FlaskService):
                 log.error(e)
             return None
 
+        if (len(metax_api_response.json()) == 0):
+            return 'no datasets'
+
         return metax_api_response.json()
 
     def create_dataset(self, data):


### PR DESCRIPTION
- Handle cases where user is logged in and has no datasets.
- Backend response handling added. If user's dataset list is empty, but no errors present, an empty response is returned to the frontend. 
- The frontend then handles the empty response correctly: displays 'You have no datasets', instead of an error.
- Important commit is: e1fff76
- Other two commits (ab8653a & efc0fa9) are unrelated marginal improvements.