### PR TITLE
Cscetsin 582 email for multiple recipients sent only to first address

### DIFF
--- a/etsin_finder/email_utils.py
+++ b/etsin_finder/email_utils.py
@@ -108,7 +108,6 @@ def get_email_recipient_addresses(catalog_record, agent_type_str):
     if agent_type == AgentType.CURATOR and rd.get('curator', False)[0].get('email'):
         return [curator['email'] for curator in rd['curator'] if 'email' in curator ]
         
-
     from etsin_finder.finder import app
     app.logger.error("No email addresses found with given agent type {0}".format(agent_type_str))
     return None

--- a/etsin_finder/email_utils.py
+++ b/etsin_finder/email_utils.py
@@ -107,7 +107,7 @@ def get_email_recipient_addresses(catalog_record, agent_type_str):
         return [rights_holder['email'] for rights_holder in rd['rights_holder'] if 'email' in rights_holder ]
     if agent_type == AgentType.CURATOR and rd.get('curator', False)[0].get('email'):
         return [curator['email'] for curator in rd['curator'] if 'email' in curator ]
-        
+
     from etsin_finder.finder import app
     app.logger.error("No email addresses found with given agent type {0}".format(agent_type_str))
     return None

--- a/etsin_finder/email_utils.py
+++ b/etsin_finder/email_utils.py
@@ -85,30 +85,32 @@ def validate_send_message_request(user_email, user_body, agent_type):
     return True
 
 
-def get_email_recipient_address(catalog_record, agent_type_str):
+def get_email_recipient_addresses(catalog_record, agent_type_str):
     """
-    Get email recipient address based on agent type.
+    Get email recipient addresses based on agent type.
 
     :param catalog_record:
     :param agent_type_str: agent_type enum name as string
     :return:
     """
     rd = catalog_record['research_dataset']
+
     agent_type = AgentType[agent_type_str]
 
     if agent_type == AgentType.CREATOR and rd.get('creator', False)[0].get('email'):
-        return rd['creator'][0]['email']
+        return [creator['email'] for creator in rd['creator'] if 'email' in creator ]
     if agent_type == AgentType.PUBLISHER and rd.get('publisher', False).get('email'):
-        return rd['publisher']['email']
+        return [publisher['email'] for publisher in rd['publisher'] if 'email' in publisher ]
     if agent_type == AgentType.CONTRIBUTOR and rd.get('contributor', False)[0].get('email'):
-        return rd['contributor'][0]['email']
+        return [contributor['email'] for contributor in rd['contributor'] if 'email' in contributor ]
     if agent_type == AgentType.RIGHTS_HOLDER and rd.get('rights_holder', False)[0].get('email'):
-        return rd['rights_holder'][0]['email']
+        return [rights_holder['email'] for rights_holder in rd['rights_holder'] if 'email' in rights_holder ]
     if agent_type == AgentType.CURATOR and rd.get('curator', False)[0].get('email'):
-        return rd['curator'][0]['email']
+        return [curator['email'] for curator in rd['curator'] if 'email' in curator ]
+        
 
     from etsin_finder.finder import app
-    app.logger.error("No email address found with given agent type {0}".format(agent_type_str))
+    app.logger.error("No email addresses found with given agent type {0}".format(agent_type_str))
     return None
 
 

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -22,7 +22,7 @@ from etsin_finder.email_utils import \
     create_email_message_body, \
     get_email_info, \
     get_email_message_subject, \
-    get_email_recipient_address, \
+    get_email_recipient_addresses, \
     get_harvest_info, \
     validate_send_message_request
 from etsin_finder.finder import app
@@ -182,10 +182,10 @@ class Contact(Resource):
         if harvested:
             abort(400, message="Contact form is not available for harvested datasets")
 
-        # Get the chose email recipient
-        recipient = get_email_recipient_address(cr, recipient_agent_role)
-        if not recipient:
-            abort(500, message="No recipient could be inferred from the dataset")
+        # Get the email recipients
+        recipients = get_email_recipient_addresses(cr, recipient_agent_role)
+        if not recipients:
+            abort(500, message="No recipients could be inferred from the dataset")
 
         app_config = get_app_config(app.testing)
         sender = app_config.get('MAIL_DEFAULT_SENDER', 'etsin-no-reply@fairdata.fi')
@@ -194,7 +194,7 @@ class Contact(Resource):
                                          user_email, user_subject, user_body)
 
         # Create the message
-        msg = Message(sender=sender, reply_to=user_email, recipients=[recipient], subject=subject, body=body)
+        msg = Message(sender=sender, reply_to=user_email, recipients=recipients, subject=subject, body=body)
 
         # Send the message
         with app.mail.record_messages() as outbox:


### PR DESCRIPTION
This commit should fix the issue of Etsin sending email only to the first recipient when you have many addresses. 

The changes were made to function get_email_recipient_addresses so that it returns a list of multiple items, as before it was returning only the first.

Related function & variable names were changed from recipient and address to recipients and addresses. 

Needs to be tested in test-environment later on