### PR TITLE
CSCETSIN-590: Fix (hopefully) of Matomo tracking

### DIFF
--- a/etsin_finder/frontend/static/index.template.ejs
+++ b/etsin_finder/frontend/static/index.template.ejs
@@ -33,21 +33,19 @@
         }
       }
     </style>
-    <!-- Matomo, activated if in production -->
-    <% if (process.env.NODE_ENV === 'production') { %>
+    <!-- Load Matomo script, add a PageView -->
+    <% if (process.env['8']) { %>
     <script>
-      var _paq = _paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      window._paq = [];
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
         var u="//matomo.rahtiapp.fi/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);
-        _paq.push(['setSiteId', '8']);
+        _paq.push(['setSiteId', process.env['8']]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-      // }
     </script>
     <% } %>
     <!-- End Matomo Code -->


### PR DESCRIPTION
- Process.env == production has been changed to process.env['VUE_APP_MATOMO_SITE_ID'], according to instructions.

- Also changed: var _paq = _paq || []; to window._paq = [];

 so that all code should be exactly as specified by Shreyas. Previously it was specified according to Matomo's own instructions.
