### PR TITLE
Addresses the cases where dataset contains maps but no data or events

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/content.jsx
+++ b/etsin_finder/frontend/js/components/dataset/content.jsx
@@ -81,7 +81,7 @@ class Content extends Component {
 
         {/* Initial route */}
         <Route
-          exact={this.showData() || this.showEvents()}
+          exact={this.showData() || this.showEvents() || this.showMaps()}
           path="/dataset/:identifier"
           render={props => (
             <Description

--- a/etsin_finder/frontend/js/components/dataset/tabs.jsx
+++ b/etsin_finder/frontend/js/components/dataset/tabs.jsx
@@ -20,78 +20,76 @@ export default class Tabs extends Component {
   render() {
     return (
       <Fragment>
-        {(this.props.showData || this.props.showEvents) && (
-          <EtsinTabs className="nav nav-tabs" role="tablist">
+        <EtsinTabs className="nav nav-tabs" role="tablist">
+          <li className="nav-item" role="presentation">
+            <NavLink
+              exact
+              replace
+              to={`/dataset/${this.props.identifier}`}
+              id="tab-for-description"
+              aria-controls="tab-description"
+              role="tab"
+              className="nav-link"
+              aria-selected={this.props.location.pathname === `/dataset/${this.props.identifier}`}
+            >
+              <Translate content="nav.dataset" fallback="Dataset" />
+            </NavLink>
+          </li>
+          {this.props.showData && (
             <li className="nav-item" role="presentation">
               <NavLink
                 exact
                 replace
-                to={`/dataset/${this.props.identifier}`}
-                id="tab-for-description"
-                aria-controls="tab-description"
+                to={`/dataset/${this.props.identifier}/data`}
+                id="tab-for-data"
+                aria-controls="tab-data"
                 role="tab"
                 className="nav-link"
-                aria-selected={this.props.location.pathname === `/dataset/${this.props.identifier}`}
+                aria-selected={
+                      this.props.location.pathname === `/dataset/${this.props.identifier}/data`
+                    }
               >
-                <Translate content="nav.dataset" fallback="Dataset" />
+                <Translate content="nav.data" fallback="Data" />
               </NavLink>
             </li>
-            {this.props.showData && (
-              <li className="nav-item" role="presentation">
-                <NavLink
-                  exact
-                  replace
-                  to={`/dataset/${this.props.identifier}/data`}
-                  id="tab-for-data"
-                  aria-controls="tab-data"
-                  role="tab"
-                  className="nav-link"
-                  aria-selected={
-                    this.props.location.pathname === `/dataset/${this.props.identifier}/data`
-                  }
-                >
-                  <Translate content="nav.data" fallback="Data" />
-                </NavLink>
-              </li>
-            )}
-            {this.props.showEvents && (
-              <li className="nav-item" role="presentation">
-                <NavLink
-                  exact
-                  replace
-                  to={`/dataset/${this.props.identifier}/events`}
-                  id="tab-for-events"
-                  aria-controls="tab-events"
-                  role="tab"
-                  className="nav-link"
-                  aria-selected={
-                    this.props.location.pathname === `/dataset/${this.props.identifier}/events`
-                  }
-                >
-                  <Translate content="nav.events" fallback="Identifiers and events" />
-                </NavLink>
-              </li>
-            )}
-            {this.props.showMaps && (
-              <li className="nav-item" role="presentation">
-                <NavLink
-                  exact
-                  replace
-                  to={`/dataset/${this.props.identifier}/maps`}
-                  id="tab-for-maps"
-                  aria-controls="tab-maps"
-                  role="tab"
-                  className="nav-link"
-                  aria-selected={
-                    this.props.location.pathname === `/dataset/${this.props.identifier}/maps  `
-                  }
-                >
-                  <Translate content="nav.maps" fallback="Maps" />
-                </NavLink>
-              </li>
-            )}
-          </EtsinTabs>
-        )}
+          )}
+          {this.props.showEvents && (
+            <li className="nav-item" role="presentation">
+              <NavLink
+                exact
+                replace
+                to={`/dataset/${this.props.identifier}/events`}
+                id="tab-for-events"
+                aria-controls="tab-events"
+                role="tab"
+                className="nav-link"
+                aria-selected={
+                  this.props.location.pathname === `/dataset/${this.props.identifier}/events`
+                }
+              >
+                <Translate content="nav.events" fallback="Identifiers and events" />
+              </NavLink>
+            </li>
+          )}
+          {this.props.showMaps && (
+            <li className="nav-item" role="presentation">
+              <NavLink
+                exact
+                replace
+                to={`/dataset/${this.props.identifier}/maps`}
+                id="tab-for-maps"
+                aria-controls="tab-maps"
+                role="tab"
+                className="nav-link"
+                aria-selected={
+                  this.props.location.pathname === `/dataset/${this.props.identifier}/maps`
+                }
+              >
+                <Translate content="nav.maps" fallback="Maps" />
+              </NavLink>
+            </li>
+          )}
+        </EtsinTabs>
       </Fragment>
     )
   }


### PR DESCRIPTION
- This commit will fix the bug where map and Maps -tab was not show if there was no other info than coordinates.

- It also fixes the bug where Dataset -tab was not shown at all if you have a Map but no Data or Events. Now the Dataset-tab will be displayed as default

- Also, this commit fixes the bug where info from Dataset-tab  was shown under Maps -tab if Maps didn't contain any other information than coordinates.

- Necessary because sometimes user feeds in only a WKT and no place name or other info

- Added this.showMaps() to line 84 in content.jsx and removed this.showData() || this.showEvents() -check from Dataset -tab display in tabs.jsx line 23