### PR TITLE
CSCETSIN-591: Change Metax request URL

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
@@ -16,19 +16,26 @@ export class ProjectSelectorBase extends Component {
 
   getOptions = () => {
     const { environment } = this.props.Stores.Env
-    if (environment === 'development') {
+
+    let projects
+
+    if (this.props.Stores.Auth.user.idaGroups) {
+      projects = this.props.Stores.Auth.user.idaGroups
+        .filter(group => group.includes('IDA'))
+        .map(group => group.substring(
+          group.indexOf(':') + 1,
+          group.length
+        ))
+        .map(projectId => ({ value: projectId, label: projectId }))
+    }
+
+    if ((environment === 'development') && (projects === undefined)) {
       return [
         { value: 'project_x', label: 'project_x' },
         { value: 'empty', label: 'test nonexistant IDA project' }
       ]
     }
-    const projects = this.props.Stores.Auth.user.idaGroups
-      .filter(group => group.includes('IDA'))
-      .map(group => group.substring(
-        group.indexOf(':') + 1,
-        group.length
-      ))
-      .map(projectId => ({ value: projectId, label: projectId }))
+
     return environment === 'test' ?
       [...projects, { value: 'project_x', label: 'project_x' }] :
       projects

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -32,9 +32,9 @@ class MetaxQvainLightAPIService(FlaskService):
         if metax_qvain_api_config:
 
             self.METAX_GET_DIRECTORY_FOR_PROJECT_URL = 'https://{0}/rest/directories'.format(metax_qvain_api_config['HOST']) + \
-                                                       '/root?project={0}'
+                                                       '/files?project={0}&path=%2F'
             self.METAX_GET_DIRECTORY = 'https://{0}/rest/directories'.format(metax_qvain_api_config['HOST']) + \
-                                       '/{0}/files'
+                                       '/{0}/files?project={0}&path=%2F'
             self.METAX_GET_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \
                                                '?metadata_provider_user={0}&file_details&ordering=-date_modified'
             self.METAX_GET_ALL_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \


### PR DESCRIPTION
- Change Metax request URL to be in line with how it is specified in Qvain
- Edited URL variable in qvain_light_service.py. Changed IDA retrieval logic.
- No side effects