### PR TITLE
CSCETSIN-686: Changed href of agent ling.

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/agent.jsx
+++ b/etsin_finder/frontend/js/components/dataset/agent.jsx
@@ -182,8 +182,7 @@ export default class Agent extends Component {
               noMargin
               noPadding
               color="primary"
-              /* eslint-disable-next-line no-script-url */
-              href="javascript:;"
+              href="#0"
               onMouseDown={e => {
                 // this prevents the popup not closing and opening
                 // when using this button to close


### PR DESCRIPTION
- The use of 'javascript:;' as href is discouraged by the React team and
  will be blocked in future versions of React.
- href='javascript:;' ==> href='#0'
- No side effects, only removes warning.