### PR TITLE
CSCETSIN_601: If applied, this commit will fix a bug where events-tab crashes or is…

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/events/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/events/index.jsx
@@ -122,10 +122,12 @@ class Events extends Component {
     )
   }
 
-  // If data does not have Identifier defined in 'Related material and history > Reference to a related source', an empty string is returned
-  checkRelation(rela) {
-    rela[0].entity.identifier = rela[0].entity.identifier || '';
-    return true
+  checkRelation(relation) {
+    if (relation[0]) {
+      relation[0].entity.identifier = relation[0].entity.identifier || '';
+      return true
+    }
+    return false
   }
 
   relationIdentifierIsUrl(identifier) {
@@ -133,7 +135,6 @@ class Events extends Component {
   }
 
   render() {
-    console.log(this.props.relation)
     return (
       <Margin>
         {this.checkProvenance(this.props.provenance) && (


### PR DESCRIPTION
… empty if there is no data in relations.

Necessary fix because events-tab crashed for example in datasets like: 3894fef7-631c-4a64-b918-b72c064bf7b4 that only had data in 'Other identifiers'

How does the change address the issue: A simple check of whether relations-data was present was added to events/index.jsx checkRelation(). If the return is false, the other tables (provenance and/or other identifier) are still drawn.

Should not have side-effects