### PR TITLE
CSCFAIRMETA-106: User cannot login

### DIFF
--- a/etsin_finder/authentication.py
+++ b/etsin_finder/authentication.py
@@ -48,10 +48,10 @@ def is_authenticated():
         return False
     return True if 'samlUserdata' in session and len(session['samlUserdata']) > 0 else False
 
-
 def is_authenticated_CSC_user():
     """
     Is the user authenticated with CSC username or not.
+
     :return:
     """
     key = 'urn:oid:1.3.6.1.4.1.16161.4.0.53'

--- a/etsin_finder/authentication.py
+++ b/etsin_finder/authentication.py
@@ -48,6 +48,18 @@ def is_authenticated():
         return False
     return True if 'samlUserdata' in session and len(session['samlUserdata']) > 0 else False
 
+
+def is_authenticated_CSC_user():
+    """
+    Is the user authenticated with CSC username or not.
+    :return:
+    """
+    key = 'urn:oid:1.3.6.1.4.1.16161.4.0.53'
+    if executing_travis():
+        return False
+    return True if 'samlUserdata' in session and len(session['samlUserdata']) > 0 and key in session['samlUserdata'] else False
+
+
 def prepare_flask_request_for_saml(request):
     """
     Used by saml library.
@@ -109,7 +121,7 @@ def get_user_csc_name():
 
     :return:
     """
-    if not is_authenticated() or 'samlUserdata' not in session:
+    if not is_authenticated() or not is_authenticated_CSC_user() or 'samlUserdata' not in session:
         return None
 
     csc_name = session['samlUserdata'].get('urn:oid:1.3.6.1.4.1.16161.4.0.53', False)

--- a/etsin_finder/authentication.py
+++ b/etsin_finder/authentication.py
@@ -48,18 +48,6 @@ def is_authenticated():
         return False
     return True if 'samlUserdata' in session and len(session['samlUserdata']) > 0 else False
 
-def is_authenticated_CSC_user():
-    """
-    Is the user authenticated with CSC username or not.
-
-    :return:
-    """
-    key = 'urn:oid:1.3.6.1.4.1.8057.2.80.26'
-    if executing_travis():
-        return False
-    return True if 'samlUserdata' in session and len(session['samlUserdata']) > 0 and key in session['samlUserdata'] else False
-
-
 def prepare_flask_request_for_saml(request):
     """
     Used by saml library.
@@ -121,7 +109,7 @@ def get_user_csc_name():
 
     :return:
     """
-    if not is_authenticated() or not is_authenticated_CSC_user() or 'samlUserdata' not in session:
+    if not is_authenticated() or 'samlUserdata' not in session:
         return None
 
     csc_name = session['samlUserdata'].get('urn:oid:1.3.6.1.4.1.16161.4.0.53', False)

--- a/etsin_finder/frontend/js/components/search/index.jsx
+++ b/etsin_finder/frontend/js/components/search/index.jsx
@@ -22,7 +22,7 @@ import HeroBanner from '../general/hero'
 import SearchBar from './searchBar'
 import Results from './results'
 import Tracking from '../../utils/tracking'
-import { Checkbox, Label } from '../qvain/general/form'
+// import { Checkbox, Label } from '../qvain/general/form'
 
 export default class Search extends Component {
   constructor() {

--- a/etsin_finder/frontend/js/components/search/index.jsx
+++ b/etsin_finder/frontend/js/components/search/index.jsx
@@ -22,6 +22,7 @@ import HeroBanner from '../general/hero'
 import SearchBar from './searchBar'
 import Results from './results'
 import Tracking from '../../utils/tracking'
+// The row below should be de-commented when continuing work on the PAS dataset functionality.
 // import { Checkbox, Label } from '../qvain/general/form'
 
 export default class Search extends Component {
@@ -77,6 +78,7 @@ export default class Search extends Component {
                 <IncludePasDatasetsInner>
                   <IncludePasDatasetsCheckboxContainer>
                     { /*
+                    // These rows should be de-commented when continuing work on the PAS dataset functionality.
                     <Checkbox
                       id="pasCheckbox"
                       checked={this.state.includePasDatasets}

--- a/etsin_finder/frontend/js/components/search/index.jsx
+++ b/etsin_finder/frontend/js/components/search/index.jsx
@@ -76,6 +76,7 @@ export default class Search extends Component {
               <IncludePasDatasetsContainer>
                 <IncludePasDatasetsInner>
                   <IncludePasDatasetsCheckboxContainer>
+                    { /*
                     <Checkbox
                       id="pasCheckbox"
                       checked={this.state.includePasDatasets}
@@ -86,6 +87,7 @@ export default class Search extends Component {
                     >
                       <Translate content="home.includePas" />
                     </Label>
+                    */ }
 
                   </IncludePasDatasetsCheckboxContainer>
                 </IncludePasDatasetsInner>

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -226,17 +226,14 @@ class User(Resource):
         """
         user_info = {
             'is_authenticated': authentication.is_authenticated(),
-            'is_authenticated_CSC_user': authentication.is_authenticated_CSC_user(),
+            'is_authenticated_CSC_user': authentication.get_user_csc_name(),
             'home_organization_id': authentication.get_user_home_organization_id(),
             'home_organization_name': authentication.get_user_home_organization_name()}
         dn = authentication.get_user_display_name()
-        csc_user = authentication.get_user_csc_name()
         groups = authentication.get_user_ida_groups()
         user_info['user_ida_groups'] = groups
         if dn is not None:
             user_info['user_display_name'] = dn
-        if csc_user is not None:
-            user_info['user_csc_name'] = csc_user
         return user_info, 200
 
 

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -226,14 +226,17 @@ class User(Resource):
         """
         user_info = {
             'is_authenticated': authentication.is_authenticated(),
-            'is_authenticated_CSC_user': authentication.get_user_csc_name(),
+            'is_authenticated_CSC_user': authentication.is_authenticated_CSC_user(),
             'home_organization_id': authentication.get_user_home_organization_id(),
             'home_organization_name': authentication.get_user_home_organization_name()}
         dn = authentication.get_user_display_name()
+        csc_user = authentication.get_user_csc_name()
         groups = authentication.get_user_ida_groups()
         user_info['user_ida_groups'] = groups
         if dn is not None:
             user_info['user_display_name'] = dn
+        if csc_user is not None:
+            user_info['user_csc_name'] = csc_user
         return user_info, 200
 
 


### PR DESCRIPTION
Use get_user_csc_name() instead of is_authenticated_CSC_user() to check whether the user is authenticated or not. 

The authentication check was implemented to prevent HAKA users from using Etsin, but was mistakenly implemented using this invalid function.

Bug fix description:
is_authenticated_CSC_user() retrieved samlData that pointed to urn:oid:1.3.6.1.4.1.8057.2.80.26, which, according refers to IDM groups, according to this page:

https://wiki.eduuni.fi/display/cscfairdata/Proxy+Attributes

get_user_csc_name() retrieves saml data that points to urn:oid:1.3.6.1.4.1.16161.4.0.53, which is the CSC username.

Additional content:

- Disabled the 'Include PAS datasets' checkbox