### PR TITLE
Cscfairmeta 23 wordwrap into header in etsin dataset page

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/description.jsx
+++ b/etsin_finder/frontend/js/components/dataset/description.jsx
@@ -166,10 +166,10 @@ class Description extends Component {
               )
             }
           </div>
-          <div className="d-inline-flex align-items-center dataset-title justify-content-between">
+          <div className="d-md-flex align-items-center dataset-title justify-content-between">
             <Title lang={getDataLang(this.state.title)}>{checkDataLang(this.state.title)}</Title>
           </div>
-          <div className="d-inline-flex justify-content-between basic-info">
+          <div className="d-flex justify-content-between basic-info">
             <MainInfo>
               <ErrorBoundary>
                 <TogglableAgentList agents={this.state.creator} agentType="creator" />

--- a/etsin_finder/frontend/js/components/dataset/description.jsx
+++ b/etsin_finder/frontend/js/components/dataset/description.jsx
@@ -166,10 +166,10 @@ class Description extends Component {
               )
             }
           </div>
-          <div className="d-md-flex align-items-center dataset-title justify-content-between">
+          <div className="d-inline-flex align-items-center dataset-title justify-content-between">
             <Title lang={getDataLang(this.state.title)}>{checkDataLang(this.state.title)}</Title>
           </div>
-          <div className="d-flex justify-content-between basic-info">
+          <div className="d-inline-flex justify-content-between basic-info">
             <MainInfo>
               <ErrorBoundary>
                 <TogglableAgentList agents={this.state.creator} agentType="creator" />
@@ -254,6 +254,9 @@ Description.propTypes = {
 
 const Title = styled.h1`
   margin-bottom: 0.1rem;
+  color: ${p => p.theme.color.superdarkgray};
+  word-wrap: break-word;
+  
 `
 
 const MainInfo = styled.div`


### PR DESCRIPTION
Wordwrap to break long continuous titles such as https://etsin.fairdata.fi/dataset/083921cf-100c-4c0b-8239-4dd9d903cf4b 