### PR TITLE
CSCFAIRMETA-107: Fix index error issue when user with other than IDA groups publisher dataset.

### DIFF
--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -193,7 +193,7 @@ class QvainDataset(Resource):
             return {"Error": "The user doesn't belong to any IDA projects."}, 400
         if data["dataCatalog"] == "urn:nbn:fi:att:data-catalog-ida":
             if not check_if_data_in_user_IDA_project(data, user_projects):
-                return {"Error": "Permission to project data not granted."}, 403
+                return {"Error": "Error in IDA groups user Permission or user groups."}, 403
         metax_redy_data = data_to_metax(data, metadata_provider_org, metadata_provider_user)
         metax_response = create_dataset(metax_redy_data)
         return metax_response

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -1,9 +1,14 @@
 """Utilities for transforming the data from Qvain Light form to METAX compatible format"""
+
+from etsin_finder.cr_service import get_catalog_record
+from etsin_finder.finder import app
+from etsin_finder.authentication import get_user_ida_groups
+
 access_type = {}
 access_type["EMBARGO"] = "http://uri.suomi.fi/codelist/fairdata/access_type/code/embargo"
 access_type["OPEN"] = "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
 
-from etsin_finder.cr_service import get_catalog_record
+log = app.logger
 
 def clean_empty_keyvalues_from_dict(d):
     """
@@ -302,20 +307,29 @@ def check_if_data_in_user_IDA_project(data, projects):
         [bool] -- True if data belongs to user, and False is not.
 
     """
-    user_projects = [project.split(":")[1] for project in projects]
+    user_ida_projects = get_user_ida_groups()
+    try:
+        user_ida_projects_ids = [project.split(":")[1] for project in user_ida_projects]
+    except IndexError as e:
+        log.error('Index error while parsing user IDA projects:\n{0}'.fromat(e))
+        return False
+    if not user_ida_projects:
+        log.warning('Could not get user IDA groups.')
+        return False
+    log.debug('User IDA groups: {0}'.format(user_ida_projects_ids))
     # Add the test project 'project_x' for local development.
-    user_projects.append("project_x")
+    user_ida_projects_ids.append("project_x")
     if "files" or "directories" in data:
         files = data["files"] if "files" in data else []
         directories = data["directories"] if "directories" in data else []
         if files:
             for file in files:
                 identifier = file["projectIdentifier"]
-                if identifier not in user_projects:
+                if identifier not in user_ida_projects_ids:
                     return False
         if directories:
             for directory in directories:
                 identifier = directory["projectIdentifier"]
-                if identifier not in user_projects:
+                if identifier not in user_ida_projects_ids:
                     return False
     return True


### PR DESCRIPTION

- The issue was causing an unhandled error in the backend when an user
  with other groups than IDA groups tried to publish a dataset. This is
  due to the check only parsed groups of form 'ASD:123' and when a group
  of form 'ASD' came along it caused an Index error when the code tried
  to split with ':'.
- Used function from utils to get only IDA groups and added error
  handling and logging.
- Should not have side effects.