### PR TITLE
CSCFAIRMETA-136: Fix long titles in dataset page

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
@@ -249,12 +249,12 @@ class DatasetTable extends Component {
             {!error &&
               onPage.map(dataset => (
                 <Row key={dataset.identifier} tabIndex="0">
-                  <BodyCell>
+                  <BodyCellWordWrap>
                     {dataset.research_dataset.title.en || dataset.research_dataset.title.fi}
                     {dataset.next_dataset_version !== undefined && (
                       <Translate color="yellow" content="qvain.datasets.oldVersion" component={OldVersionLabel} />
                     )}
-                  </BodyCell>
+                  </BodyCellWordWrap>
                   <BodyCell>{this.formatDatasetDateCreated(dataset.date_created)}</BodyCell>
                   <BodyCell>
                     <Translate
@@ -323,5 +323,9 @@ const SearchField = styled(FormField)`
 const SearchInput = styled(Input)`
   margin-bottom: inherit;
 `;
+
+const BodyCellWordWrap = styled(BodyCell)`
+  word-break: break-word;
+`
 
 export default withRouter(inject('Stores')(observer(DatasetTable)))


### PR DESCRIPTION
- Commit similar to CSCFAIRMETA-23, that fixed dataset titles in the Etsin view page
- Similar syntax, word-break: break-word
- No side effects