### PR TITLE
CSCFAIRMETA-133: Fix version select dropdown visual issue

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/versionselect.jsx
+++ b/etsin_finder/frontend/js/components/dataset/versionselect.jsx
@@ -20,6 +20,7 @@ import Button from '../general/button'
 const SelectContainer = styled.div`
   width: ${props => props.width};
   margin-right: 1em;
+  z-index: 1;
 `
 
 const List = styled.div`


### PR DESCRIPTION
- On the etsin dataset page, the creator's name was visible through the version select dropdown
- Added z-index = 1 to the dropdown, forcing it to stay above the other content
- No side effects. Z-index seems to be functional in combination with tab navigation too.