### PR TITLE
CSCFAIRMETA-143: Switching actor type bug

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/actors/actorTypeSelect.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/actorTypeSelect.jsx
@@ -23,6 +23,7 @@ export class ActorTypeSelectBase extends Component {
   handleChangeEntity = (actor, type) => () => {
     actor.type = type
     actor.role = []
+    this.props.Stores.Qvain.emptyActorInEdit(type)
   }
 
   checkIfActorRoleExists = role => {

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -181,6 +181,12 @@ class Qvain {
     this.actorInEdit = { ...actor }
   }
 
+  // Used to reset all actor values if the user switches actor type
+  @action
+  emptyActorInEdit = actorType => {
+    this.actorInEdit = Actor(actorType, [], '', '', '', undefined, undefined)
+  }
+
   @computed
   get addedActors() {
     return this.actors


### PR DESCRIPTION
- Previously, if the actor name was defined, and the user then switched actor type, the dataset became unpublishable. This was because person and organization are different data types, and the conversion cased errors.
- If the user changes actor type (person <-> organization), the actor details are reset.
- No side effects