### PR TITLE
Fix for Travis failing to run tests.

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     exit 0
 fi
 
-pip install ansible
+pip install ansible==2.8.6
 git clone https://github.com/CSCfi/etsin-ops
 cd etsin-ops/ansible/
 


### PR DESCRIPTION
- Travis fails in .travis-deploy.sh while running
  `ansible-galaxy -r requirements.yml install --roles-path=roles` and this
  gives the error:
  `ansible-galaxy role: error: argument ROLE_ACTION: invalid choice:
  'requirements.yml' (choose from 'init', 'remove', 'delete', 'list',
  'search', 'import', 'setup', 'login', 'info', 'install')`. This might
  be happening because no ansible version is specified and a new release
  came 31.10.2019 ansible==2.9.0
- Specified ansible==2.8.6 to see if it fixes the issue.
- Can effect all ansible code.