### PR TITLE
CSCFAIRMETA-245: Update metax display error

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/projectSelector.jsx
@@ -68,7 +68,12 @@ export class ProjectSelectorBase extends Component {
           onChange={this.handleOnChange}
           attributes={{ placeholder: 'qvain.files.projectSelect.placeholder' }}
         />
-        {error !== undefined && (
+        {error === 'Request failed with status code 404' && (
+          <ErrorMessage>
+            <Translate content="qvain.files.projectSelect.loadErrorNoFiles" />
+          </ErrorMessage>
+        )}
+        {(error !== undefined) && (error !== 'Request failed with status code 404') && (
           <ErrorMessage>
             <Translate content="qvain.files.projectSelect.loadError" />
             {error}

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -594,6 +594,7 @@ const english = {
       projectSelect: {
         placeholder: 'Select project',
         loadError: 'Failed to load project folders, error: ',
+        loadErrorNoFiles: 'No files found. If you wish to make files available here, make sure that you have frozen the project files in IDA.',
       },
       selected: {
         title: 'Selected files',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -598,6 +598,7 @@ const finnish = {
       projectSelect: {
         placeholder: 'Valitse projekti',
         loadError: 'Projektin hakemistojen lataus epäonnistui, virhe: ',
+        loadErrorNoFiles: 'Tiedostoja ei löytynyt. Jos haluat saada tiedostot näkyviin, tarkistaa että olet jäädyttänyt kyseessä olevat tiedostot IDA:ssa.',
       },
       selected: {
         title: 'Valitut tiedostot',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -598,7 +598,7 @@ const finnish = {
       projectSelect: {
         placeholder: 'Valitse projekti',
         loadError: 'Projektin hakemistojen lataus epäonnistui, virhe: ',
-        loadErrorNoFiles: 'Tiedostoja ei löytynyt. Jos haluat saada tiedostot näkyviin, tarkistaa että olet jäädyttänyt kyseessä olevat tiedostot IDA:ssa.',
+        loadErrorNoFiles: 'Tiedostoja ei löytynyt. Jos haluat saada tiedostot näkyviin, tarkista että olet jäädyttänyt kyseessä olevat tiedostot IDA:ssa.',
       },
       selected: {
         title: 'Valitut tiedostot',


### PR DESCRIPTION
- This update has already been done in demo. Display a clearer error message if Metax returns 404
- This error means that there are no files in Metax, so the user must first go to IDA and freeze files
- If error message is 404, display text guiding the user to IDA