### PR TITLE
CSCFAIRMETA-199: User cannot publish dataset

### DIFF
--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -194,13 +194,8 @@ class QvainDataset(Resource):
         except KeyError as err:
             log.warning("The Metadata provider is not specified: \n{0}".format(err))
             return {"PermissionError": "The Metadata provider is not found in login information."}, 401
-        try:
-            user_projects = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.8057.2.80.26"]
-        except KeyError as err:
-            log.warning("User projects not found in saml metadata: \n{0}".format(err))
-            return {"Error": "The user doesn't belong to any IDA projects."}, 400
         if data["dataCatalog"] == "urn:nbn:fi:att:data-catalog-ida":
-            if not check_if_data_in_user_IDA_project(data, user_projects):
+            if not check_if_data_in_user_IDA_project(data):
                 return {"Error": "Error in IDA groups user Permission or user groups."}, 403
         metax_redy_data = data_to_metax(data, metadata_provider_org, metadata_provider_user)
         metax_response = create_dataset(metax_redy_data)

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -295,13 +295,12 @@ def edited_data_to_metax(data, original):
     }
     return clean_empty_keyvalues_from_dict(edited_data)
 
-def check_if_data_in_user_IDA_project(data, projects):
+def check_if_data_in_user_IDA_project(data):
     """
     Check if the user creating a dataset belongs to the project that the files/folders belongs to.
 
     Arguments:
         data {object} -- The dataset that the user is trying to create.
-        projects {list} -- List containing the users projects. Taken from the saml data.
 
     Returns:
         [bool] -- True if data belongs to user, and False is not.


### PR DESCRIPTION
- Remove general IDM project check for 'urn:oid:1.3.6.1.4.1.8057.2.80.26' when trying to publish a dataset. This situation caused problems for users without IDM projects. However, this value is still checked if the user has chosen IDA as catalog.
- Remove the 'urn:oid:1.3.6.1.4.1.8057.2.80.26' check.