### PR TITLE
CSCFAIRMETA-198: Fix backend log time format.

### DIFF
--- a/etsin_finder/utils.py
+++ b/etsin_finder/utils.py
@@ -54,7 +54,7 @@ def get_log_config(log_file_path, log_lvl):
             'formatters': {
                 'standard': {
                     'format': '--------------\n[%(asctime)s] [%(process)d] %(levelname)s in %(filename)s:%(lineno)d: %(message)s',
-                    'datefmt': '%Y-%M-%d %H:%M:%S %z',
+                    'datefmt': '%Y-%m-%d %H:%M:%S %z',
                 }
             },
             'handlers': {


### PR DESCRIPTION
- The time format for month was set by accident to %M, which is for
  minutes. -> now %m for moth.
  source: https://docs.python.org/3/library/time.html#time.strftime
- '%Y-%M-%d %H:%M:%S %z' --> '%Y-%m-%d %H:%M:%S %z'
- Effects timestamp on loggs.