### PR TITLE
CSCFAIRMETA-200: Update AccessRights component description.

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/accessRights.jsx
+++ b/etsin_finder/frontend/js/components/dataset/accessRights.jsx
@@ -13,6 +13,7 @@
 import React, { Component } from 'react'
 import { inject, observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import translate from 'counterpart'
 import {
   faLock,
   faLockOpen,
@@ -27,6 +28,7 @@ import checkNested from '../../utils/checkNested'
 import checkDataLang, { getDataLang } from '../../utils/checkDataLang'
 import Button from '../general/button'
 import Modal from '../general/modal'
+import { accessTypes } from '../../stores/view/access'
 
 export const accessRightsBool = accessRights => {
   const openValue = 'http://uri.suomi.fi/codelist/fairdata/access_type/code/open'
@@ -47,12 +49,16 @@ class AccessRights extends Component {
     super(props)
     let title = { en: 'Restricted Access', fi: 'Rajoitettu käyttöoikeus' }
     let description = ''
+    let identifier = ''
     let url = ''
+    let id = ''
     if (props.access_rights !== undefined && props.access_rights !== null) {
       if (checkNested(props.access_rights, 'access_type', 'pref_label')) {
         title = props.access_rights.access_type.pref_label
       }
-      description = props.access_rights.description
+      identifier = props.access_rights.access_type.identifier
+      id = Object.keys(accessTypes).find(key => accessTypes[key] === identifier)
+      description = translate(`dataset.access_rights_description.${id !== undefined ? id : ''}`)
       url = props.access_rights.access_url
     }
     this.state = {

--- a/etsin_finder/frontend/js/stores/view/access.js
+++ b/etsin_finder/frontend/js/stores/view/access.js
@@ -12,7 +12,7 @@ import { observable, action } from 'mobx'
 
 import auth from '../domain/auth'
 
-const accessTypes = {
+export const accessTypes = {
   open: 'http://uri.suomi.fi/codelist/fairdata/access_type/code/open',
   login: 'http://uri.suomi.fi/codelist/fairdata/access_type/code/login',
   embargo: 'http://uri.suomi.fi/codelist/fairdata/access_type/code/embargo',

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -11,6 +11,14 @@
 const english = {
   changepage: 'Navigated to page: %(page)s',
   dataset: {
+    access_rights_description: {
+      none: '',
+      open: 'Anyone can access the data.',
+      login: 'Users have to log in to access the data.',
+      embargo: 'Data can be accessed only after the embargo has expired.',
+      permit: 'Data can be accessed only by applying for permission. You need to be logged in to be able to fill-in the application.',
+      restricted: 'Data cannot be accessed.'
+    },
     access_permission: 'Ask for access',
     access_locked: 'Restricted Access',
     access_open: 'Open Access',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -11,6 +11,14 @@
 const finnish = {
   changepage: 'Siirryit sivulle: %(page)s',
   dataset: {
+    access_rights_description: {
+      none: '',
+      open: 'Kuka tahansa voi ladata datan.',
+      login: 'Käyttän pitää olla sisään kirjautunut ladatakseen datan.',
+      embargo: 'Datan voi ladata vasta, kun embargo-pvm on ohitettu.',
+      permit: 'Datan voi ladata ainoastaan hakemalla erillisen luvan lataamista varten. Luvan hakeminen vaatii kirjautumisen.',
+      restricted: 'Data ei ladattavissa.'
+    },
     access_permission: 'Hae käyttölupaa',
     access_locked: 'Rajattu käyttöoikeus',
     access_open: 'Avoin',


### PR DESCRIPTION
- Before the description was taken from the dataset access_rights.description
  and it could be whatever the users decides it should be. Now updated to
  be fixed strings with a short description of the access right.
- Choose the translation according to the accessRights identifier, If
  for some reason the identifier is wrong and not in the constants, then
  the value is empty.
- No side effects.