### PR TITLE
CSCFAIRMETA-249: Creator name can be too long

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/description.jsx
+++ b/etsin_finder/frontend/js/components/dataset/description.jsx
@@ -262,6 +262,7 @@ const Title = styled.h1`
 const MainInfo = styled.div`
   color: ${p => p.theme.color.gray};
   font-size: 0.9em;
+  word-break: break-word;
 `
 
 const PasInfo = styled.div`


### PR DESCRIPTION
- Creator name can be too long and extend across the sidebar. This probably wouldn't happen, but you never know.
- Added word-break: break-word as a .CSS property to MainInfo, which is inherited by child elements (including the text display elements).