### PR TITLE
CSCFAIRMETA-160: Refreshing folder content

### DIFF
--- a/etsin_finder/finder.py
+++ b/etsin_finder/finder.py
@@ -61,7 +61,7 @@ def add_restful_resources(app):
     api = Api(app)
     from etsin_finder.resources import Contact, Dataset, User, Session, Files, Download
     from etsin_finder.qvain_light_resources import ProjectFiles, FileDirectory, UserDatasets, QvainDataset, QvainDatasetDelete
-    from etsin_finder.qvain_light_rpc import QvainDatasetChangeCumulativeState
+    from etsin_finder.qvain_light_rpc import QvainDatasetChangeCumulativeState, QvainDatasetRefreshDirectoryContent
 
     api.add_resource(Dataset, '/api/dataset/<string:cr_id>')
     api.add_resource(Files, '/api/files/<string:cr_id>')
@@ -77,6 +77,7 @@ def add_restful_resources(app):
     api.add_resource(QvainDataset, '/api/dataset')
     # Qvain light API RPC endpoints
     api.add_resource(QvainDatasetChangeCumulativeState, '/api/rpc/datasets/change_cumulative_state')
+    api.add_resource(QvainDatasetRefreshDirectoryContent, '/api/rpc/datasets/refresh_directory_content')
 
 app = create_app()
 add_restful_resources(app)

--- a/etsin_finder/frontend/__tests__/qvain.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.test.jsx
@@ -22,11 +22,10 @@ import { AddedActorsBase } from '../js/components/qvain/actors/addedActors'
 import Files from '../js/components/qvain/files'
 import IDAFilePicker, { IDAFilePickerBase } from '../js/components/qvain/files/idaFilePicker'
 import FileSelector, { FileSelectorBase } from '../js/components/qvain/files/fileSelector'
-import { SelectedFilesBase } from '../js/components/qvain/files/selectedFiles'
+import { SelectedFilesBase, FileLabel } from '../js/components/qvain/files/selectedFiles'
 import { ExternalFilesBase } from '../js/components/qvain/files/externalFiles'
 import {
   ButtonGroup,
-  ButtonLabel,
   DeleteButton
 } from '../js/components/qvain/general/buttons'
 import { SlidingContent } from '../js/components/qvain/general/card'
@@ -327,10 +326,10 @@ describe('Qvain.Files', () => {
     fileSelector.find('#test2Checkbox input').simulate('change')
     fileSelector.unmount()
     // mount the SelectedFiles component
-    const selectedFiles = mount(<SelectedFilesBase Stores={stores} />)
-    expect(selectedFiles.find(ButtonLabel).last().text()).toBe('project_y / directory2')
+    const selectedFiles = shallow(<SelectedFilesBase Stores={stores} />)
+    expect(selectedFiles.find(FileLabel).last().text()).toBe('<FontAwesomeIcon />project_y / directory2')
     selectedFiles.find(DeleteButton).last().simulate('click', { preventDefault: () => {} })
-    expect(selectedFiles.find(ButtonLabel).length).toBe(0)
+    expect(selectedFiles.find(FileLabel).length).toBe(0)
   })
 })
 

--- a/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
@@ -1,0 +1,124 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { inject, observer } from 'mobx-react'
+import Translate from 'react-translate-component'
+import axios from 'axios'
+
+import Modal from '../../general/modal'
+import Response from './response'
+import { CumulativeStates } from '../utils/constants'
+import { DangerButton, TableButton } from '../general/buttons'
+
+class RefreshDirectoryModal extends Component {
+  static propTypes = {
+    Stores: PropTypes.object.isRequired,
+    onClose: PropTypes.func.isRequired,
+    directory: PropTypes.string,
+  }
+
+  static defaultProps = {
+    directory: null,
+  }
+
+  state = {
+    response: null,
+    loading: false,
+  }
+
+  refreshDirectoryContent = () => {
+    const identifier = this.props.directory
+    if (!this.props.Stores.Qvain.original) { // only published datasets can be refreshed with the RPC
+      return
+    }
+    this.setState({
+      response: null,
+      loading: true
+    })
+
+    const currentState = this.props.Stores.Qvain.cumulativeState
+    const newState = currentState === CumulativeStates.YES ? CumulativeStates.CLOSED : CumulativeStates.YES
+    const obj = {
+      cr_identifier: this.props.Stores.Qvain.original.identifier,
+      dir_identifier: identifier
+    }
+    axios.post('/api/rpc/datasets/refresh_directory_content', obj)
+      .then(response => {
+        const data = response.data || {}
+        this.setState({
+          response: {
+            new_version_created: data.new_version_created
+          }
+        })
+        // when a new version is created, the cumulative_state of the current version remains unchanged
+        if (!data.new_version_created) {
+          this.props.Stores.Qvain.setCumulativeState(newState)
+        }
+      })
+      .catch(err => {
+        let error = ''
+        if (err.response && err.response.data && err.response.data.detail) {
+          error = err.response.data.detail
+        } else if (err.response && err.response.data) {
+          error = err.response.data
+        } else {
+          error = this.response.errorMessage
+        }
+
+        this.setState({
+          response: {
+            error
+          }
+        })
+      })
+      .finally(() => {
+        this.setState({
+          loading: false
+        })
+      })
+  }
+
+  handleRequestClose = () => {
+    if (!this.state.loading) {
+      this.props.onClose()
+    }
+  }
+
+  render() {
+    const { changed, cumulativeState } = this.props.Stores.Qvain
+    const isCumulative = cumulativeState === CumulativeStates.YES
+    const cumulativeKey = isCumulative ? 'cumulative' : 'noncumulative'
+    return (
+      <Modal
+        isOpen={!!this.props.directory}
+        onRequestClose={this.handleRequestClose}
+        contentLabel="refreshDirectoryModal"
+      >
+        <Translate component="h3" content="qvain.files.refreshModal.header" />
+        {this.state.loading || this.state.response ?
+          <Response response={this.state.response} />
+        : (
+          <>
+            <Translate component="p" content={`qvain.files.refreshModal.${cumulativeKey}`} />
+            { changed && <Translate component="p" content={'qvain.files.refreshModal.changes'} /> }
+          </>
+        )}
+        {this.state.response ? (
+          <TableButton onClick={() => this.setRefreshModalDirectory(null)}>
+            <Translate content={'qvain.files.refreshModal.buttons.close'} />
+          </TableButton>
+        ) : (
+          <>
+            <TableButton disabled={this.state.loading} onClick={() => this.setRefreshModalDirectory(null)}>
+              <Translate content={'qvain.files.refreshModal.buttons.cancel'} />
+            </TableButton>
+            <DangerButton disabled={changed || this.state.loading} onClick={() => this.refreshDirectoryContent()}>
+              <Translate content={'qvain.files.refreshModal.buttons.ok'} />
+            </DangerButton>
+          </>
+        )}
+      </Modal>
+    )
+  }
+}
+
+export default inject('Stores')(observer(RefreshDirectoryModal))

--- a/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
@@ -35,8 +35,6 @@ class RefreshDirectoryModal extends Component {
       loading: true
     })
 
-    const currentState = this.props.Stores.Qvain.cumulativeState
-    const newState = currentState === CumulativeStates.YES ? CumulativeStates.CLOSED : CumulativeStates.YES
     const obj = {
       cr_identifier: this.props.Stores.Qvain.original.identifier,
       dir_identifier: identifier
@@ -49,10 +47,6 @@ class RefreshDirectoryModal extends Component {
             new_version_created: data.new_version_created
           }
         })
-        // when a new version is created, the cumulative_state of the current version remains unchanged
-        if (!data.new_version_created) {
-          this.props.Stores.Qvain.setCumulativeState(newState)
-        }
       })
       .catch(err => {
         let error = ''

--- a/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
@@ -80,6 +80,9 @@ class RefreshDirectoryModal extends Component {
   handleRequestClose = () => {
     if (!this.state.loading) {
       this.props.onClose()
+      this.setState({
+        response: null,
+      })
     }
   }
 
@@ -103,12 +106,12 @@ class RefreshDirectoryModal extends Component {
           </>
         )}
         {this.state.response ? (
-          <TableButton onClick={() => this.setRefreshModalDirectory(null)}>
+          <TableButton onClick={this.handleRequestClose}>
             <Translate content={'qvain.files.refreshModal.buttons.close'} />
           </TableButton>
         ) : (
           <>
-            <TableButton disabled={this.state.loading} onClick={() => this.setRefreshModalDirectory(null)}>
+            <TableButton disabled={this.state.loading} onClick={this.handleRequestClose}>
               <Translate content={'qvain.files.refreshModal.buttons.cancel'} />
             </TableButton>
             <DangerButton disabled={changed || this.state.loading} onClick={() => this.refreshDirectoryContent()}>

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -4,10 +4,9 @@ import { inject, observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCopy, faFolder } from '@fortawesome/free-solid-svg-icons'
 import Translate from 'react-translate-component'
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { ButtonLabel, EditButton, DeleteButton, FileItem, ButtonContainer, TableButton,
-  RefreshDirectoryButton, RefreshDirectoryButtonText } from '../general/buttons'
+import { ButtonLabel, EditButton, DeleteButton, FileItem, ButtonContainer, TableButton } from '../general/buttons'
 import { SelectedFilesTitle } from '../general/form'
 import FileForm from './fileForm'
 import DirectoryForm from './directoryForm'
@@ -160,7 +159,42 @@ const FileLabel = styled(ButtonLabel)`{
   margin-bottom: 0;
   margin-left: 0;
   flex-shrink: 0;
-}
+}`
+
+const RefreshDirectoryButton = styled.button`
+  background-color: ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  color: #fff;
+  height: 56px;
+  border-radius: 4px;
+  border: solid 1px ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  text-transform: none;
+  font-weight: 600;
+  margin-right: 5px;
+  padding-left: 27px;
+  padding-right: 27px;
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-width: 64px;
+  outline: none;
+  -webkit-appearance: none;
+  overflow: hidden;
+  ${props => !props.disabled && css`
+    cursor: pointer;
+  `}
+`;
+
+const RefreshDirectoryButtonText = styled.span`
+  text-align: center;
+  color: inherit;
+  font-weight: 400;
+  text-transform: none;
 `
 
 const isDirectory = (inEdit) => inEdit.directoryName !== undefined

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -102,7 +102,7 @@ export class SelectedFilesBase extends Component {
       existingFiles,
       existingDirectories,
       inEdit,
-      cumulativeState,
+      cumulativeState
     } = this.props.Stores.Qvain
     const selected = [...selectedDirectories, ...selectedFiles]
     const existing = [...existingDirectories, ...existingFiles]
@@ -188,7 +188,7 @@ const RefreshDirectoryButton = styled.button`
   ${props => !props.disabled && css`
     cursor: pointer;
   `}
-`;
+`
 
 const RefreshDirectoryButtonText = styled.span`
   text-align: center;

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -154,7 +154,7 @@ const FileButtonsContainer = styled(ButtonContainer)`{
   margin-left: auto;
 }`
 
-const FileLabel = styled(ButtonLabel)`{
+export const FileLabel = styled(ButtonLabel)`{
   margin-top: 0;
   margin-bottom: 0;
   margin-left: 0;

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -210,42 +210,6 @@ export const CumulativeStateButtonText = styled.span`
   text-transform: none;
 `
 
-export const RefreshDirectoryButton = styled.button`
-  background-color: ${props => (
-    props.disabled ? '#7fbfd6' : '#007fad'
-  )};
-  color: #fff;
-  height: 56px;
-  border-radius: 4px;
-  border: solid 1px ${props => (
-    props.disabled ? '#7fbfd6' : '#007fad'
-  )};
-  text-transform: none;
-  font-weight: 600;
-  margin-right: 5px;
-  padding-left: 27px;
-  padding-right: 27px;
-  display: inline-flex;
-  position: relative;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 64px;
-  outline: none;
-  -webkit-appearance: none;
-  overflow: hidden;
-  ${props => !props.disabled && css`
-    cursor: pointer;
-  `}
-`;
-
-export const RefreshDirectoryButtonText = styled.span`
-  text-align: center;
-  color: inherit;
-  font-weight: 400;
-  text-transform: none;
-`
-
 export const FilePickerButton = styled.button`
   background-color: ${props => (
     props.disabled ? '#7fbfd6' : '#007fad'

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -53,8 +53,12 @@ export const SaveButton = styled.button`
 
 export const DangerButton = styled.button`
   border-radius: 4px;
-  border: solid 1px #ff0000;
-  background-color: #ff0000;
+  border: 1px solid ${props => (
+    props.disabled ? '#ddb6b6' : '#ff0000'
+  )};
+  background-color: ${props => (
+    props.disabled ? '#ddb6b6' : '#ff0000'
+  )};
   font-size: 16px;
   font-weight: 600;
   line-height: 1.31;
@@ -62,7 +66,9 @@ export const DangerButton = styled.button`
   margin-left: 20px;
   padding: 10px 25px;
   &:hover {
-    background-color: #ff4c4c;
+    background-color: ${props => (
+      props.disabled ? '#ddb6b6' : '#ff4c4c'
+    )};
   }
 `
 

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -204,6 +204,42 @@ export const CumulativeStateButtonText = styled.span`
   text-transform: none;
 `
 
+export const RefreshDirectoryButton = styled.button`
+  background-color: ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  color: #fff;
+  height: 56px;
+  border-radius: 4px;
+  border: solid 1px ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  text-transform: none;
+  font-weight: 600;
+  margin-right: 5px;
+  padding-left: 27px;
+  padding-right: 27px;
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-width: 64px;
+  outline: none;
+  -webkit-appearance: none;
+  overflow: hidden;
+  ${props => !props.disabled && css`
+    cursor: pointer;
+  `}
+`;
+
+export const RefreshDirectoryButtonText = styled.span`
+  text-align: center;
+  color: inherit;
+  font-weight: 400;
+  text-transform: none;
+`
+
 export const FilePickerButton = styled.button`
   background-color: ${props => (
     props.disabled ? '#7fbfd6' : '#007fad'

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -621,6 +621,18 @@ const english = {
         changeComplete: 'Action complete.',
         versionCreated: 'A new dataset version has been created with identifier %(identifier)s.',
       },
+      refreshModal: {
+        header: 'Refresh folder content',
+        noncumulative: 'If new files have been added to the folder, this will add them to the dataset and create a new version of it. The changes will take effect immediately.',
+        cumulative: 'If new files have been added to the folder, this will add them to the dataset. No new dataset version will be created. The changes will take effect immediately.',
+        changes: 'You need to save your changes to the dataset first.',
+        buttons: {
+          show: 'Refresh folder content',
+          ok: 'Ok',
+          cancel: 'Cancel',
+          close: 'Close',
+        }
+      },
       help:
         'Files associated with this dataset. A dataset can only have either IDA files or remote files. File metadata will not be associated with datasets, so remember to save edits to file metadata.',
       ida: {

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -627,7 +627,7 @@ const finnish = {
       },
       refreshModal: {
         header: 'Päivitä kansion tiedostot',
-        noncumulative: 'Toiminto lisää kansioon lisätyt tiedostot aineistoon. Aineistosta luodaan uusi versio.',
+        noncumulative: 'Mikäli kansioon on lisätty uusia tiedostoja, toiminto lisää ne aineistoon ja luo siitä uuden version.',
         cumulative: 'Toiminto lisää kansioon lisätyt tiedostot aineistoon. Muutos näkyy välittömästi aineiston julkaistussa versiossa.',
         changes: 'Aineistoon tehdyt muutokset on tallennettava ensin.',
         buttons: {

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -625,6 +625,18 @@ const finnish = {
         changeComplete: 'Toiminto suoritettu.',
         versionCreated: 'Aineistosta on luotu uusi versio tunnisteella %(identifier)s.',
       },
+      refreshModal: {
+        header: 'Päivitä kansion tiedostot',
+        noncumulative: 'Toiminto lisää kansioon lisätyt tiedostot aineistoon. Aineistosta luodaan uusi versio.',
+        cumulative: 'Toiminto lisää kansioon lisätyt tiedostot aineistoon. Muutos näkyy välittömästi aineiston julkaistussa versiossa.',
+        changes: 'Aineistoon tehdyt muutokset on tallennettava ensin.',
+        buttons: {
+          show: 'Päivitä kansion tiedostot',
+          ok: 'Päivitä',
+          cancel: 'Peruuta',
+          close: 'Sulje',
+        }
+      },
       help:
         'Aineistoon kuuluvat tiedostot. Aineistoon voi kuulua vain joko IDAssa olevia tiedostoja tai ulkopuolisia tiedostoja. Tiedostojen metadata ei ole osa aineistojen metadataa, joten muista tallentaa muutokset jotka teet tiedostojen metadataan.',
       ida: {

--- a/etsin_finder/qvain_light_rpc.py
+++ b/etsin_finder/qvain_light_rpc.py
@@ -97,7 +97,7 @@ class QvainDatasetRefreshDirectoryContent(Resource):
     @log_request
     def post(self):
         """
-        Change cumulative_state of a dataset in Metax.<
+        Refresh contents of a directory in a dataset. May create a new dataset version.
 
         Arguments:
             cr_identifier {string} -- The identifier of the dataset.
@@ -118,7 +118,7 @@ class QvainDatasetRefreshDirectoryContent(Resource):
         user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.16161.4.0.53"][0]
         creator = get_dataset_creator(cr_identifier)
         if user != creator:
-            log.warning('User: \"{0}\" is not the creator of the dataset. Changing cumulative state not allowed. Creator: \"{1}\"'.format(user, creator))
-            return {"PermissionError": "User not authorized to to change cumulative state of dataset."}, 403
+            log.warning('User: \"{0}\" is not the creator of the dataset. Refreshing directory is not allowed. Creator: \"{1}\"'.format(user, creator))
+            return {"PermissionError": "User not authorized to to refresh directory in dataset."}, 403
         metax_response = refresh_directory_content(cr_identifier, dir_identifier)
         return metax_response

--- a/etsin_finder/qvain_light_rpc.py
+++ b/etsin_finder/qvain_light_rpc.py
@@ -14,7 +14,7 @@ from flask_restful import abort, reqparse, Resource
 
 from etsin_finder.app_config import get_app_config
 from etsin_finder import authentication
-from etsin_finder.qvain_light_service import change_cumulative_state
+from etsin_finder.qvain_light_service import change_cumulative_state, refresh_directory_content
 from etsin_finder.finder import app
 from etsin_finder.qvain_light_utils import get_dataset_creator
 
@@ -83,4 +83,42 @@ class QvainDatasetChangeCumulativeState(Resource):
             log.warning('User: \"{0}\" is not the creator of the dataset. Changing cumulative state not allowed. Creator: \"{1}\"'.format(user, creator))
             return {"PermissionError": "User not authorized to to change cumulative state of dataset."}, 403
         metax_response = change_cumulative_state(cr_id, cumulative_state)
+        return metax_response
+
+class QvainDatasetRefreshDirectoryContent(Resource):
+    """Metax RPC for refreshing directory content in a dataset."""
+
+    def __init__(self):
+        """Setup endpoints"""
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument('cr_identifier', type=str, required=True)
+        self.parser.add_argument('dir_identifier', type=str, required=True)
+
+    @log_request
+    def post(self):
+        """
+        Change cumulative_state of a dataset in Metax.<
+
+        Arguments:
+            cr_identifier {string} -- The identifier of the dataset.
+            dir_identifier {string} -- The identifier of the directory.
+
+        Returns:
+            [type] -- Metax response.
+
+        """
+        args = self.parser.parse_args()
+        cr_identifier = args['cr_identifier']
+        dir_identifier = args['dir_identifier']
+        is_authd = authentication.is_authenticated()
+        if not is_authd:
+            return {"PermissionError": "User not logged in."}, 401
+
+        # only creator of the dataset is allowed to modify it
+        user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.16161.4.0.53"][0]
+        creator = get_dataset_creator(cr_identifier)
+        if user != creator:
+            log.warning('User: \"{0}\" is not the creator of the dataset. Changing cumulative state not allowed. Creator: \"{1}\"'.format(user, creator))
+            return {"PermissionError": "User not authorized to to change cumulative state of dataset."}, 403
+        metax_response = refresh_directory_content(cr_identifier, dir_identifier)
         return metax_response

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -293,7 +293,6 @@ class MetaxQvainLightAPIService(FlaskService):
         log.info('Changed cumulative state of dataset {} to {}'.format(cr_id, cumulative_state))
         return (json_or_empty(metax_api_response) or metax_api_response.text), metax_api_response.status_code
 
-
     def refresh_directory_content(self, cr_identifier, dir_identifier):
         """
         Call Metax refresh_directory_content RPC.


### PR DESCRIPTION
- Add a button to existing directories in dataset that allows refreshing the directory contents using a Metax RPC.
- The "Refresh folder content" button is pretty wide. Made some small styling changes in the selected files list to make the buttons behave more nicely in narrow windows.