### PR TITLE
CSCFAIRMETA-273: Configure matomo-test.fairdata.fi

### DIFF
--- a/etsin_finder/frontend/static/index.template.ejs
+++ b/etsin_finder/frontend/static/index.template.ejs
@@ -33,22 +33,66 @@
         }
       }
     </style>
-    <!-- Load Matomo script, add a PageView -->
-    <% if (process.env['8']) { %>
+    <% if(process.env.NODE_ENV === 'development') { %>
+      <script>
+      console.log('Matomo, in development')
+        var _paq = _paq || []
+        _paq.push(['enableLinkTracking'])
+        ;(function() {
+          let u = '//matomo-test.fairdata.fi/'
+          _paq.push(['setTrackerUrl', u + 'matomo.php'])
+          _paq.push(['setSiteId', '8'])
+          let d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0]
+          g.type = 'text/javascript'
+          g.async = true
+          g.defer = true
+          g.src = u + 'matomo.js'
+          s.parentNode.insertBefore(g, s)
+        })()
+      </script>
+    <% } %>
+    <% if(process.env.NODE_ENV === 'test') { %>
     <script>
-      window._paq = [];
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u="//matomo.rahtiapp.fi/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
-        _paq.push(['setSiteId', process.env['8']]);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-      })();
+      console.log('Matomo, in test')
+      var _paq = _paq || []
+      _paq.push(['enableLinkTracking'])
+      ;(function() {
+        let u = '//matomo-test.fairdata.fi/'
+        _paq.push(['setTrackerUrl', u + 'matomo.php'])
+        _paq.push(['setSiteId', '3'])
+        let d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0]
+        g.type = 'text/javascript'
+        g.async = true
+        g.defer = true
+        g.src = u + 'matomo.js'
+        s.parentNode.insertBefore(g, s)
+      })()
     </script>
     <% } %>
-    <!-- End Matomo Code -->
+    <% if(process.env.NODE_ENV === 'production') { %>
+    <script>
+      console.log('Matomo, in production')
+      var _paq = _paq || []
+      _paq.push(['enableLinkTracking'])
+      ;(function() {
+        let u = '//matomo.rahtiapp.fi/'
+        _paq.push(['setTrackerUrl', u + 'piwik.php'])
+        _paq.push(['setSiteId', '3'])
+        let d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0]
+        g.type = 'text/javascript'
+        g.async = true
+        g.defer = true
+        g.src = u + 'piwik.js'
+        s.parentNode.insertBefore(g, s)
+      })()
+    </script>
+    <% } %>
   </head>
 
   <body>


### PR DESCRIPTION
- Changes needed in order to test the functionality of matomo-test.fairdata.fi
- Added new matomo tracking for test & development Node environments. Reused old code that had been created as inital setup for Matomo, 1 year ago.

- process.env.NODE_ENV === 'development'
  - Currently used for local_development & demo  (ToDo in the future: NODE_ENVs should be separated)
  - Tracker: matomo-test.fairdata.fi
  - siteId: 8
- process.env.NODE_ENV === 'test'
  - Currently used for test & stable (ToDo in the future: NODE_ENVs should be separated)
  - Tracker: matomo-test.fairdata.fi
  - siteId: 3
- process.env.NODE_ENV === 'production'
  - Currently used for production
  - Tracker: matomo.rahtiapp.fi
  - siteId: 3