### PR TITLE
CSCFAIRMETA-103: PAS metadata editing

### DIFF
--- a/etsin_finder/finder.py
+++ b/etsin_finder/finder.py
@@ -60,7 +60,7 @@ def add_restful_resources(app):
     """
     api = Api(app)
     from etsin_finder.resources import Contact, Dataset, User, Session, Files, Download
-    from etsin_finder.qvain_light_resources import ProjectFiles, FileDirectory, UserDatasets, QvainDataset, QvainDatasetDelete
+    from etsin_finder.qvain_light_resources import ProjectFiles, FileDirectory, FileCharacteristics, UserDatasets, QvainDataset, QvainDatasetDelete
     from etsin_finder.qvain_light_rpc import QvainDatasetChangeCumulativeState, QvainDatasetRefreshDirectoryContent
 
     api.add_resource(Dataset, '/api/dataset/<string:cr_id>')
@@ -72,6 +72,7 @@ def add_restful_resources(app):
     # Qvain light API endpoints
     api.add_resource(ProjectFiles, '/api/files/project/<string:pid>')
     api.add_resource(FileDirectory, '/api/files/directory/<string:dir_id>')
+    api.add_resource(FileCharacteristics, '/api/files/file_characteristics/<string:file_id>')
     api.add_resource(UserDatasets, '/api/datasets/<string:user_id>')
     api.add_resource(QvainDatasetDelete, '/api/dataset/<string:cr_id>')
     api.add_resource(QvainDataset, '/api/dataset')

--- a/etsin_finder/frontend/__tests__/metadataModal.test.jsx
+++ b/etsin_finder/frontend/__tests__/metadataModal.test.jsx
@@ -1,0 +1,244 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import ReactModal from 'react-modal'
+import { ThemeProvider } from 'styled-components'
+import { Provider } from 'mobx-react'
+import axios from 'axios'
+import '../locale/translations.js'
+import { when } from 'mobx'
+
+import etsinTheme from '../js/styles/theme'
+import FileSelector from '../js/components/qvain/files/fileSelector'
+import MetadataModal from '../js/components/qvain/files/metadataModal'
+import QvainStore, {
+  Directory
+} from '../js/stores/view/qvain'
+import LocaleStore from '../js/stores/view/language'
+
+jest.mock('axios')
+
+const getStores = () => ({
+  Qvain: QvainStore,
+  Locale: LocaleStore
+})
+
+const testFile = {
+  description: 'File',
+  title: 'testfile',
+  existing: false,
+  file_name: 'test.pdf',
+  file_path: '/test/test.pdf',
+  identifier: 'test_file',
+  project_identifier: 'project_y',
+  file_characteristics: {
+    file_format: 'text/csv',
+    format_version: '',
+    encoding: 'UTF-8',
+    csv_has_header: true,
+    csv_record_separator: 'LF',
+    csv_quoting_char: '"',
+  }
+}
+
+const testFile2 = {
+  description: 'File2',
+  title: 'testfile2',
+  existing: false,
+  file_name: 'test2.pdf',
+  file_path: '/test/test2.pdf',
+  identifier: 'test_file2',
+  project_identifier: 'project_y',
+  file_characteristics: {
+    file_format: 'text/csv',
+    format_version: 'format_not_allowed_here',
+    encoding: 'UTF-8',
+    csv_has_header: true,
+    csv_record_separator: 'LF',
+    csv_quoting_char: '"',
+  }
+}
+
+const testFile3 = {
+  description: 'File3',
+  title: 'testfile3',
+  existing: false,
+  file_name: 'test3.pdf',
+  file_path: '/test/test3.pdf',
+  identifier: 'test_file3',
+  project_identifier: 'project_y',
+  file_characteristics: {
+    file_format: 'application/pdf',
+    format_version: '1.6',
+    encoding: 'UTF-8',
+    csv_has_header: false,
+    csv_record_separator: 'LF',
+    csv_quoting_char: '"',
+  }
+}
+
+const testFile4 = {
+  description: 'File4',
+  title: 'testfile4',
+  existing: false,
+  file_name: 'test4.pdf',
+  file_path: '/test/test4.pdf',
+  identifier: 'test_file4',
+  project_identifier: 'project_y',
+  file_characteristics: {
+    file_format: 'application/pdf',
+    format_version: 'invalid_format_version',
+    encoding: 'UTF-8',
+    csv_has_header: true,
+    csv_record_separator: 'LF',
+    csv_quoting_char: '"',
+  }
+}
+
+const fileFormats = {
+  data: {
+    hits: {
+      hits: [
+        {
+          "_source": {
+            "input_file_format" : "text/csv",
+            "output_format_version" : "",
+            "label" : {
+              "und" : "file_format_version_text_csv"
+            },
+          }
+        },
+        {
+          "_source" : {
+            "input_file_format" : "application/pdf",
+            "output_format_version" : "1.6",
+          }
+        },
+      ],
+    }
+  }
+}
+
+describe('Qvain.MetadataModal', () => {
+
+  let helper, wrapper, stores
+
+  beforeEach(() => {
+    // Mock file format list request
+    axios.get.mockReturnValue(fileFormats)
+
+    helper = document.createElement('div')
+    ReactModal.setAppElement(helper)
+    stores = getStores()
+    wrapper = mount(
+      (
+        <Provider Stores={stores}>
+          <ThemeProvider theme={etsinTheme}>
+            <>
+              <FileSelector />
+              <MetadataModal />
+            </>
+          </ThemeProvider>
+        </Provider>
+      ), { attachTo: helper }
+    )
+
+    // Set directory hierarchy
+    stores.Qvain.selectedDirectories = []
+    stores.Qvain.selectedProject = 'project_y'
+    stores.Qvain.hierarchy = Directory(
+      {
+        id: 'test1',
+        identifier: 'test-ident-1',
+        project_identifier: 'project_y',
+        directory_name: 'root',
+        directories: [
+          {
+            id: 'test2',
+            identifier: 'test-ident-2',
+            project_identifier: 'project_y',
+            directory_name: 'directory2',
+            directories: [],
+            files: []
+          }
+        ],
+        files: [
+          testFile, testFile2, testFile3, testFile4
+        ]
+      },
+      undefined,
+      false,
+      true
+    )
+    wrapper.update()
+  })
+
+  afterEach(() => {
+    wrapper.detach()
+  })
+
+  it('opens file on click and validates the metadata', async () => {
+    // Open modal, wait until versions have been fetched
+    wrapper.find('button#test_file-open-metadata-modal').simulate('click')
+    const instance = wrapper.find(MetadataModal).instance().wrappedInstance
+    await when(() => instance.formatFetchStatus !== 'loading')
+
+    // Expect no version for text/csv
+    expect(instance.state.fileIdentifier).toBe('test_file')
+    expect(instance.state.csvHasHeader).toBe(true)
+    expect(instance.validateMetadata).not.toThrow()
+
+    // Versions forbidden for text/csv
+    wrapper.find('button#test_file2-open-metadata-modal').simulate('click')
+    expect(instance.state.fileIdentifier).toBe('test_file2')
+    expect(instance.validateMetadata).toThrow()
+
+    // Accepted version for application/pdf
+    wrapper.find('button#test_file3-open-metadata-modal').simulate('click')
+    expect(instance.state.fileIdentifier).toBe('test_file3')
+    expect(instance.state.csvHasHeader).toBe(false)
+    expect(instance.validateMetadata).not.toThrow()
+
+    // Invalid version for application/pdf
+    wrapper.find('button#test_file4-open-metadata-modal').simulate('click')
+    expect(instance.state.fileIdentifier).toBe('test_file4')
+    expect(instance.validateMetadata).toThrow()
+  })
+
+  it('allows modifying the pas metadata of files in hierarchy', async () => {
+    // Open modal, wait until versions have been fetched
+    wrapper.find('button#test_file4-open-metadata-modal').simulate('click')
+    const instance = wrapper.find(MetadataModal).instance().wrappedInstance
+    await when(() => instance.formatFetchStatus !== 'loading')
+    expect(instance.state.fileIdentifier).toBe('test_file4')
+    expect(instance.state.formatVersion).not.toBe('1.6')
+
+    // Change to accepted version
+    instance.setFormatVersion( { value: '1.6' } )
+    expect(instance.state.formatVersion).toBe('1.6')
+
+    // Mock the patch RPC used by save
+    axios.patch.mockImplementationOnce((url, data) => {
+      return {
+        data: {
+          ...testFile4,
+          file_characteristics: {
+            ...testFile4.file_characteristics,
+            ...data
+          }
+        }
+      }
+    })
+    await instance.saveChanges()
+
+    // Clear modal file
+    stores.Qvain.setMetadataModalFile(null)
+    expect(instance.state.fileIdentifier).not.toBe('test_file4')
+    expect(instance.state.formatVersion).not.toBe('1.6')
+
+    // Reopen file from hierarchy, should now validate correctly
+    wrapper.find('button#test_file4-open-metadata-modal').simulate('click')
+    expect(instance.state.fileIdentifier).toBe('test_file4')
+    expect(instance.state.formatVersion).toBe('1.6')
+    expect(instance.validateMetadata).not.toThrow()
+  })
+})

--- a/etsin_finder/frontend/js/components/dataset/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/index.jsx
@@ -11,7 +11,6 @@
    * @license   MIT
    */
 }
-require('@babel/polyfill')
 
 import React from 'react'
 import PropTypes from 'prop-types'

--- a/etsin_finder/frontend/js/components/general/modal.jsx
+++ b/etsin_finder/frontend/js/components/general/modal.jsx
@@ -73,7 +73,7 @@ export default class Modal extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.updateBlur()
   }
 
@@ -89,12 +89,16 @@ export default class Modal extends Component {
 
   showBlur() {
     const root = document.getElementById('root')
-    root.classList.add('blur')
+    if (root) {
+      root.classList.add('blur')
+    }
   }
 
   hideBlur() {
     const root = document.getElementById('root')
-    root.classList.remove('blur')
+    if (root) {
+      root.classList.remove('blur')
+    }
   }
 
   updateBlur() {

--- a/etsin_finder/frontend/js/components/general/modal.jsx
+++ b/etsin_finder/frontend/js/components/general/modal.jsx
@@ -71,41 +71,50 @@ export default class Modal extends Component {
     this.state = {
       styles: { overlay: overlayStyle, content: contentStyle },
     }
-
-    this.afterOpen = this.afterOpen.bind(this)
-    this.onClose = this.onClose.bind(this)
   }
 
-  onClose() {
-    const root = document.getElementById('root')
-    root.classList.remove('blur')
-    this.props.onRequestClose()
+  componentWillMount() {
+    this.updateBlur()
   }
 
-   // eslint-disable-next-line camelcase
-   UNSAFE_componentWillReceiveProps(newProps) {
-    if (newProps.isOpen === false && this.props.isOpen === true) {
-      const root = document.getElementById('root')
-      root.classList.remove('blur')
+  componentDidUpdate(prevProps) {
+    if (this.props.isOpen !== prevProps.isOpen) {
+      this.updateBlur()
     }
   }
 
-  afterOpen() {
-    this.props.onAfterOpen()
+  componentWillUnmount() {
+    this.hideBlur()
+  }
+
+  showBlur() {
     const root = document.getElementById('root')
     root.classList.add('blur')
+  }
+
+  hideBlur() {
+    const root = document.getElementById('root')
+    root.classList.remove('blur')
+  }
+
+  updateBlur() {
+    if (this.props.isOpen) {
+      this.showBlur()
+    } else {
+      this.hideBlur()
+    }
   }
 
   render() {
     return (
       <ReactModal
         isOpen={this.props.isOpen}
-        onAfterOpen={this.afterOpen}
-        onRequestClose={this.onClose}
+        onAfterOpen={this.props.onAfterOpen}
+        onRequestClose={this.props.onRequestClose}
         style={this.state.styles}
         contentLabel={this.props.contentLabel}
       >
-        <CloseButton onClick={this.onClose} noMargin>
+        <CloseButton onClick={this.props.onRequestClose} noMargin>
           <Translate className="sr-only" content="dataset.dl.close_modal" />
           <span aria-hidden>X</span>
         </CloseButton>

--- a/etsin_finder/frontend/js/components/qvain/files/cumulativeState.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/cumulativeState.jsx
@@ -85,7 +85,7 @@ class CumulativeState extends Component {
         } else if (err.response && err.response.data) {
           error = err.response.data
         } else {
-          error = this.response.errorMessage
+          error = err.response.errorMessage
         }
 
         this.setState({

--- a/etsin_finder/frontend/js/components/qvain/files/fileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fileForm.jsx
@@ -2,6 +2,8 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react'
 import Translate from 'react-translate-component'
+import styled from 'styled-components';
+
 import {
   SaveButton,
   CancelButton
@@ -108,6 +110,11 @@ class FileForm extends Component {
     })
   }
 
+  handleEditMetadata = (event) => {
+    event.preventDefault()
+    this.props.Stores.Qvain.setMetadataModalFile(this.props.Stores.Qvain.inEdit)
+  }
+
   getFormatVersions = (fileFormat) => {
     if (fileFormat !== undefined) {
       return this.state.formatVersions.get(fileFormat.value)
@@ -196,8 +203,15 @@ class FileForm extends Component {
           />
           <p style={{ marginLeft: '10px' }}>{this.props.Stores.Qvain.inEdit.identifier}</p>
           {fileError !== undefined && <ValidationError>{fileError}</ValidationError>}
-          <Translate component={CancelButton} onClick={this.handleCancel} content="qvain.common.cancel" />
-          <Translate component={SaveButton} onClick={this.handleSave} content="qvain.common.save" />
+          <Buttons>
+            <div>
+              <Translate component={CancelButton} onClick={this.handleCancel} content="qvain.common.cancel" />
+              <Translate component={SaveButton} onClick={this.handleSave} content="qvain.common.save" />
+            </div>
+            <div>
+              <Translate component={EditMetadataButton} onClick={this.handleEditMetadata} content="qvain.files.metadataModal.buttons.show" />
+            </div>
+          </Buttons>
         </FileContainer>
       </Fragment>
     )
@@ -213,5 +227,25 @@ const getUseCategory = (fi, en, stores) => {
   }
   return uc
 }
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`
+
+const EditMetadataButton = styled(SaveButton)`
+  border-radius: 4px;
+  border: solid 1px #007fad;
+  background-color: #007fad;
+  &:hover {
+    background-color: #007fad;
+  }
+  font-size: 20px;
+  font-weight: bold;
+  color: #fff;
+  margin-left: auto;
+  padding: 10px 25px;
+`
 
 export default inject('Stores')(observer(FileForm))

--- a/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react'
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFolder, faChevronRight, faChevronDown, faEdit } from '@fortawesome/free-solid-svg-icons'
+import { faFolder, faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { Checkbox } from '../general/form'
 import {
   FileIcon,
@@ -54,7 +54,6 @@ export class FileSelectorBase extends Component {
         </label>
         <FilePickerFileButton id={`${f.identifier}-open-metadata-modal`} type="button" onClick={() => setMetadataModalFile(f)}>
           { translate('qvain.files.metadataModal.buttons.show') }
-          <FileEditIcon style={{ height: '16px', width: '16px', marginLeft: '4px', color: 'red' }} />
         </FilePickerFileButton>
       </li>
     )
@@ -126,18 +125,5 @@ const LinkButton = styled.button`
    font: inherit;
    cursor: pointer;
 `;
-
-const FileEditIconStyles = styled(FontAwesomeIcon)`
-  width: 5%;
-  color: inherit;
-  margin-left: 0px;
-  margin-right: 0px;
-  display: inline-block;
-  height: 18px;
-  font-size: 18px;
-  vertical-align: top;
-`;
-
-export const FileEditIcon = () => <FileEditIconStyles icon={faEdit} />
 
 export default inject('Stores')(observer(FileSelectorBase))

--- a/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
@@ -1,14 +1,15 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
+import translate from 'counterpart'
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react'
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFolder, faChevronRight, faChevronDown } from '@fortawesome/free-solid-svg-icons'
+import { faFolder, faChevronRight, faChevronDown, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { Checkbox } from '../general/form'
 import {
   FileIcon,
+  FilePickerFileButton
 } from '../general/buttons'
-import { List, ListItem } from '../general/list'
 
 export class FileSelectorBase extends Component {
   static propTypes = {
@@ -28,97 +29,85 @@ export class FileSelectorBase extends Component {
     }
   }
 
+  drawFile = (f) => {
+    const {
+      toggleSelectedFile,
+      setMetadataModalFile
+    } = this.props.Stores.Qvain
+
+    return (
+      <li key={f.identifier} style={{ paddingLeft: '20px', display: 'flex', alignItems: 'center' }}>
+        <Checkbox
+          checked={f.selected}
+          id={`${f.id}Checkbox`}
+          type="checkbox"
+          onChange={() => toggleSelectedFile(
+            f,
+            !f.selected
+          )}
+          style={{ marginRight: '8px' }}
+        />
+
+        <FileIcon />
+        <label htmlFor={`${f.id}Checkbox`} style={{ flexGrow: 1, cursor: 'pointer', fontSize: '85%' }}>
+          {f.fileName}
+        </label>
+        <FilePickerFileButton id={`${f.identifier}-open-metadata-modal`} type="button" onClick={() => setMetadataModalFile(f)}>
+          { translate('qvain.files.metadataModal.buttons.show') }
+          <FileEditIcon style={{ height: '16px', width: '16px', marginLeft: '4px', color: 'red' }} />
+        </FilePickerFileButton>
+      </li>
+    )
+  }
+
   // recursive function to draw the entire file hierarchy, if so desired
   drawHierarchy = (h, root) => {
     const {
       toggleSelectedDirectory,
-      toggleSelectedFile
     } = this.props.Stores.Qvain
     return (
-      <Fragment key={h.identifier}>
-        <li style={{ paddingLeft: '20px' }}>
-          <LinkButton
-            aria-label={h.open ? 'Close directory' : 'Open directory'}
-            type="button"
-            onKeyPress={this.handleOpenDirectory(h.id, root, !h.open)}
-            onClick={this.handleOpenDirectory(h.id, root, !h.open)}
-          >
-            <FontAwesomeIcon icon={h.open ? faChevronDown : faChevronRight} />
-          </LinkButton>
-          <Checkbox
-            aria-label={`${h.directoryName}`}
-            checked={h.selected || false}
-            id={`${h.id}Checkbox`}
-            type="checkbox"
-            onChange={() => toggleSelectedDirectory(
-              { ...h },
-              !h.selected
-            )}
-          />
-          <DirectoryIcon />
-          {h.directoryName}
-          <ul>
-            {(h.directories && h.open) && (
-              <Fragment>{h.directories.map(dir => (this.drawHierarchy(dir, h)))}</Fragment>
-            )}
-            {(h.files && h.open) && (
-              <Fragment>
-                {h.files.map(f => (
-                  <li key={f.identifier} style={{ paddingLeft: '20px' }}>
-                    <Checkbox
-                      checked={f.selected}
-                      id={`${f.id}Checkbox`}
-                      type="checkbox"
-                      onChange={() => toggleSelectedFile(
-                        f,
-                        !f.selected
-                      )}
-                    />
-                    <FileIcon style={{ paddingLeft: '8px' }} />
-                    {f.fileName}
-                  </li>
-                ))}
-              </Fragment>
-            )}
-          </ul>
-        </li>
-      </Fragment>
+      <li key={h.identifier} style={{ paddingLeft: '20px' }}>
+        <LinkButton
+          aria-label={h.open ? 'Close directory' : 'Open directory'}
+          type="button"
+          onKeyPress={this.handleOpenDirectory(h.id, root, !h.open)}
+          onClick={this.handleOpenDirectory(h.id, root, !h.open)}
+        >
+          <FontAwesomeIcon icon={h.open ? faChevronDown : faChevronRight} />
+        </LinkButton>
+        <Checkbox
+          aria-label={`${h.directoryName}`}
+          checked={h.selected || false}
+          id={`${h.id}Checkbox`}
+          type="checkbox"
+          onChange={() => toggleSelectedDirectory(
+            { ...h },
+            !h.selected
+          )}
+        />
+        <DirectoryIcon />
+        {h.directoryName}
+        <ul>
+          {(h.directories && h.open) &&
+            h.directories.map(dir => (this.drawHierarchy(dir, h)))
+          }
+          {(h.files && h.open) && h.files.map(this.drawFile)}
+        </ul>
+      </li>
     )
   }
 
   render() {
     const {
-      toggleSelectedFile,
       hierarchy,
     } = this.props.Stores.Qvain
     return (
-      <Fragment>
-        <List style={{ marginBottom: '20px' }}>
-          {hierarchy.directories && (
-            <Fragment>
-              {hierarchy.directories.map(dir => this.drawHierarchy(dir, hierarchy))}
-            </Fragment>
-          )}
-          {hierarchy.files && (
-            <Fragment>
-              {hierarchy.files.map(file => (
-                <ListItem key={file.id}>
-                  <Checkbox
-                    checked={file.selected || false}
-                    id={`${file.id}Checkbox`}
-                    type="checkbox"
-                    onChange={() => toggleSelectedFile(file, !file.selected)}
-                  />
-                  <label htmlFor={`${file.id}Checkbox`}>
-                    <FileIcon style={{ paddingLeft: '8px' }} />
-                    {file.fileName}
-                  </label>
-                </ListItem>
-              ))}
-            </Fragment>
-          )}
-        </List>
-      </Fragment>
+      <ul style={{ marginBottom: '20px' }}>
+        {hierarchy.directories &&
+          hierarchy.directories.map(dir => this.drawHierarchy(dir, hierarchy))
+        }
+        {hierarchy.files && hierarchy.files.map(this.drawFile)}
+      </ul>
     )
   }
 }
@@ -130,12 +119,25 @@ const DirectoryIconStyles = styled(FontAwesomeIcon)`
 const DirectoryIcon = (props) => <DirectoryIconStyles {...props} icon={faFolder} />
 
 const LinkButton = styled.button`
-   background: none!important;
+   background: none !important;
    color: inherit;
    border: none;
    padding: 0!important;
    font: inherit;
    cursor: pointer;
 `;
+
+const FileEditIconStyles = styled(FontAwesomeIcon)`
+  width: 5%;
+  color: inherit;
+  margin-left: 0px;
+  margin-right: 0px;
+  display: inline-block;
+  height: 18px;
+  font-size: 18px;
+  vertical-align: top;
+`;
+
+export const FileEditIcon = () => <FileEditIconStyles icon={faEdit} />
 
 export default inject('Stores')(observer(FileSelectorBase))

--- a/etsin_finder/frontend/js/components/qvain/files/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/index.jsx
@@ -13,6 +13,7 @@ import CumulativeState from './cumulativeState'
 import { DataCatalogIdentifiers } from '../utils/constants'
 import Tooltip from '../general/tooltip'
 import FilesInfo from './filesInfo'
+import MetadataModal from './metadataModal'
 
 class Files extends Component {
   static propTypes = {
@@ -69,6 +70,7 @@ class Files extends Component {
         </SectionTitle>
         <DataCatalog />
         {data}
+        <MetadataModal />
       </ContainerLight>
     )
   }

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
@@ -1,0 +1,488 @@
+import React, { Component } from 'react'
+import Translate from 'react-translate-component'
+import translate from 'counterpart'
+import PropTypes from 'prop-types'
+import { inject, observer } from 'mobx-react'
+import styled from 'styled-components'
+import axios from 'axios'
+
+import { observable, action } from 'mobx'
+
+import Modal from '../../../general/modal'
+import getReferenceData from '../../utils/getReferenceData'
+import { fileMetadataSchema } from '../../utils/formValidation'
+import { Label, HelpField, Input } from '../../general/form'
+import { DangerButton, TableButton } from '../../general/buttons'
+import Response from '../response'
+
+import { separatorOptions, delimiterOptions, encodingOptions, hasheaderOptions,
+  getDefaultOptions, makeOption, findOption } from './options'
+import { MetadataSelect, selectStylesNarrow, labelStyle } from './select'
+
+
+const patchFileCharacteristics = (identifier, data) => axios.patch(`/api/files/file_characteristics/${identifier}`, data,
+  {
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+)
+
+class MetadataModal extends Component {
+  @observable
+  formatFetchStatus = 'loading'
+
+  static propTypes = {
+    Stores: PropTypes.object.isRequired,
+  }
+
+  state = {
+    formatVersionsMap: {},
+    formatOptions: [],
+    response: null,
+    fileChanged: false,
+    confirmClose: false,
+    criticalError: false,
+    fileIdentifier: null,
+
+    // PAS Metadata
+    fileFormat: undefined,
+    formatVersion: undefined,
+    encoding: undefined,
+    csvDelimiter: undefined,
+    csvRecordSeparator: undefined,
+    csvQuotingChar: undefined,
+    csvHasHeader: undefined,
+  }
+
+  async componentDidMount() {
+    this.initialize()
+    await this.fetchformatVersions()
+  }
+
+  @action
+  setFormatFetchStatus(value) {
+    this.formatFetchStatus = value
+  }
+
+  getformatVersionOptions() {
+    return (this.state.formatVersionsMap[this.state.fileFormat] || []).map(
+      v => ({ value: v, label: v })
+    )
+  }
+
+  setFileFormat = (formatOption) => {
+    this.setState({
+      fileFormat: formatOption.value,
+      formatVersion: '',
+      fileChanged: true
+    })
+  }
+
+  setFormatVersion = (versionOption) => {
+    this.setState({
+      formatVersion: versionOption.value,
+      fileChanged: true
+    })
+  }
+
+  setEncoding = (encodingOption) => {
+    this.setState({
+      encoding: encodingOption.value,
+      fileChanged: true
+    })
+  }
+
+  setCsvDelimiter = (csvDelimiterOption) => {
+    this.setState({
+      csvDelimiter: csvDelimiterOption.value,
+      fileChanged: true
+    })
+  }
+
+  setCsvRecordSeparator = (csvRecordSeparatorOption) => {
+    this.setState({
+      csvRecordSeparator: csvRecordSeparatorOption.value,
+      fileChanged: true
+    })
+  }
+
+  setCsvHasHeader = (csvHasHeaderOption) => {
+    this.setState({
+      csvHasHeader: csvHasHeaderOption.value,
+      fileChanged: true
+    })
+  }
+
+  handleChangeCsvQuotingChar = (event) => {
+    this.setState({
+      csvQuotingChar: event.target.value,
+      fileChanged: true
+    })
+  }
+
+  requestClose = () => {
+    if (this.state.loading) {
+      return
+    }
+
+    if (!this.state.fileChanged) {
+      this.close()
+    } else {
+      this.showConfirmClose()
+    }
+  }
+
+  showConfirmClose = () => {
+    this.setState({
+      confirmClose: true
+    })
+  }
+
+  hideConfirmClose = () => {
+    this.setState({
+      confirmClose: false
+    })
+  }
+
+  clearError = () => {
+    this.setState({
+      response: null
+    })
+  }
+
+  close = () => {
+    this.props.Stores.Qvain.setMetadataModalFile(null)
+  }
+
+  validateMetadata = () => {
+    fileMetadataSchema.validate(this.state)
+
+    // Additional validation for formatVersion
+    const versions = this.state.formatVersionsMap[this.state.fileFormat] || []
+
+    if (versions.length === 0) {
+      if (this.state.formatVersion) {
+        throw new Error(translate('qvain.files.metadataModal.errors.formatVersionNotAllowed'))
+      }
+    } else if (!versions.includes(this.state.formatVersion)) {
+      throw new Error(translate('qvain.files.metadataModal.errors.formatVersionRequired'))
+    }
+  }
+
+  saveChanges = async () => {
+    if (this.state.loading) {
+      return
+    }
+
+    try {
+      this.validateMetadata()
+    } catch (error) {
+      this.setState({
+        response: {
+          error: error.message
+        }
+      })
+      return
+    }
+
+    try {
+      this.setState({
+        loading: true
+      })
+
+      const response = await patchFileCharacteristics(this.state.fileIdentifier, {
+        file_format: this.state.fileFormat,
+        format_version: this.state.formatVersion,
+        encoding: this.state.encoding,
+        csv_has_header: this.state.csvHasHeader,
+        csv_delimiter: this.state.csvDelimiter,
+        csv_record_separator: this.state.csvRecordSeparator,
+        csv_quoting_char: this.state.csvQuotingChar
+      })
+
+      // Update file hierarchy with response data, close modal
+      this.props.Stores.Qvain.updateFileMetadata(response.data)
+      this.setState({
+        fileChanged: false
+      })
+      this.close()
+    } catch (err) {
+      let error = ''
+      if (err.response && err.response.data && err.response.data.detail) {
+        error = err.response.data.detail
+      } else if (err.response && err.response.data) {
+        error = err.response.data
+      } else {
+        error = err.response.errorMessage
+      }
+      if (error.file_characteristics) {
+        error = error.file_characteristics
+      }
+      if (typeof error === 'object') {
+        error = JSON.stringify(error)
+      }
+      this.setState({
+        response: {
+          error
+        }
+      })
+    } finally {
+      this.setState({
+        loading: false
+      })
+    }
+  }
+
+  componentWillReact = async () => {
+    const file = this.props.Stores.Qvain.metadataModalFile || {}
+    if (file.identifier !== this.state.fileIdentifier) {
+      this.initialize()
+      if (this.formatFetchStatus === 'error') {
+        await this.fetchformatVersions()
+      }
+    }
+  }
+
+  async fetchformatVersions() {
+    this.setFormatFetchStatus('loading')
+    try {
+      // Create a list of available versions for each supported file format.
+      const resp = await getReferenceData('file_format_version')
+      const fileFormatVersions = resp.data.hits.hits.map(v => v._source)
+
+      // get array of available versions for each file format
+      const formatVersionsMap = {}
+      fileFormatVersions.forEach(formatVersion => {
+        if (formatVersionsMap[formatVersion.input_file_format] === undefined) {
+          formatVersionsMap[formatVersion.input_file_format] = []
+        }
+        if (formatVersion.output_format_version !== '') {
+          formatVersionsMap[formatVersion.input_file_format].push(formatVersion.output_format_version)
+        }
+      })
+
+      // use natural sort order for version numbers
+      const sortArray = (arr => arr.sort(
+        (a, b) => a.localeCompare(b, undefined, { numeric: true })
+      ))
+      Object.values(formatVersionsMap).forEach(versions => sortArray(versions))
+      const formatOptions = Object.keys(formatVersionsMap)
+      sortArray(formatOptions)
+
+      this.setState({
+        formatOptions: formatOptions.map(v => ({ value: v, label: v })),
+        formatVersionsMap
+      })
+
+      this.setFormatFetchStatus('done')
+    } catch (e) {
+      this.setState({
+        criticalError: true,
+        response: {
+          error: translate('qvain.files.metadataModal.errors.loadingFileFormats')
+        }
+      })
+
+      this.setFormatFetchStatus('error')
+    }
+  }
+
+  initialize() {
+    const file = this.props.Stores.Qvain.metadataModalFile || {}
+    const newState = {
+      response: null,
+      fileChanged: false,
+      confirmClose: false,
+      criticalError: false,
+      fileIdentifier: file.identifier,
+      fileFormat: file.fileFormat,
+      formatVersion: file.formatVersion,
+      encoding: file.encoding,
+      csvDelimiter: file.csvDelimiter,
+      csvRecordSeparator: file.csvRecordSeparator,
+      csvQuotingChar: file.csvQuotingChar,
+      csvHasHeader: file.csvHasHeader
+    }
+
+    // Replace null/undefined metadata with defaults
+    const defaults = getDefaultOptions()
+    for (const key in defaults) {
+      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+        if (newState[key] == null) {
+          newState[key] = defaults[key]
+        }
+      }
+    }
+    this.setState(newState)
+  }
+
+  render() {
+    const { metadataModalFile } = this.props.Stores.Qvain
+
+    return (
+      <Modal
+        contentLabel="metadatamodal"
+        isOpen={!!metadataModalFile}
+        onRequestClose={this.requestClose}
+        customStyles={modalStyles}
+      >
+        <h2 style={{ marginBottom: 0 }}>Edit PAS Metadata</h2>
+        <Translate content="qvain.files.metadataModal.help" component={HelpField} />
+
+        <MetadataSelect
+          inputId="pas_file_format"
+          options={this.state.formatOptions}
+          value={makeOption(this.state.fileFormat)}
+          onChange={this.setFileFormat}
+          isLoading={this.state.formatVersionsMap.length === 0}
+          field="fileFormat"
+        />
+
+        <MetadataSelect
+          inputId="pas_format_version"
+          options={this.getformatVersionOptions()}
+          value={makeOption(this.state.formatVersion)}
+          onChange={this.setFormatVersion}
+          isLoading={this.state.formatVersionsMap.length === 0}
+          isSearchable={false}
+          field="formatVersion"
+        />
+
+        <MetadataSelect
+          inputId="pas_file_encoding"
+          options={encodingOptions}
+          value={findOption(this.state.encoding, encodingOptions)}
+          onChange={this.setEncoding}
+          field="encoding"
+        />
+
+        <h3 style={{ marginBottom: 0, marginTop: '0.3rem' }}>CSV Options</h3>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', maxWidth: '26em' }}>
+          <MetadataSelect
+            inputId="pas_csv_delimiter"
+            options={delimiterOptions}
+            value={findOption(this.state.csvDelimiter, delimiterOptions)}
+            onChange={this.setCsvDelimiter}
+            styles={selectStylesNarrow}
+            field="csvDelimiter"
+          />
+
+          <MetadataSelect
+            inputId="pas_csv_record_separator"
+            options={separatorOptions}
+            value={findOption(this.state.csvRecordSeparator, separatorOptions)}
+            onChange={this.setCsvRecordSeparator}
+            styles={selectStylesNarrow}
+            field="csvRecordSeparator"
+          />
+
+          <Label
+            htmlFor="pas_csv_quoting_char"
+            style={labelStyle}
+          >{ translate('qvain.files.metadataModal.fields.csvQuotingChar') }
+            <div style={selectStylesNarrow.control()}>
+              <Input
+                id="pas_csv_quoting_char"
+                placeholder="Type a character"
+                type="text"
+                value={this.state.csvQuotingChar}
+                onChange={this.handleChangeCsvQuotingChar}
+              />
+            </div>
+          </Label>
+
+          <MetadataSelect
+            inputId="pas_csv_has_header"
+            options={hasheaderOptions}
+            value={findOption(this.state.csvHasHeader, hasheaderOptions)}
+            onChange={this.setCsvHasHeader}
+            styles={selectStylesNarrow}
+            field="csvHasHeader"
+          />
+        </div>
+
+        <TableButton disabled={this.state.loading} onClick={this.requestClose}>
+          <Translate content={'qvain.files.metadataModal.buttons.close'} />
+        </TableButton>
+        <DangerButton disabled={this.state.loading} onClick={this.saveChanges}>
+          <Translate content={'qvain.files.metadataModal.buttons.save'} />
+        </DangerButton>
+
+        { this.state.confirmClose && (
+          <ResponseOverlay>
+            <div style={{ width: '100%' }}>
+              <Translate content={'qvain.files.metadataModal.warning'} component="p" />
+              <AutoWidthTableButton disabled={this.state.loading} onClick={this.hideConfirmClose}>
+                <Translate content={'qvain.files.metadataModal.buttons.cancelClose'} />
+              </AutoWidthTableButton>
+              <DangerButton disabled={this.state.loading} onClick={this.close}>
+                <Translate content={'qvain.files.metadataModal.buttons.confirmClose'} />
+              </DangerButton>
+            </div>
+          </ResponseOverlay>
+        )}
+
+        {(this.state.loading || this.state.response) && (
+          <ResponseOverlay>
+            <div style={{ width: '100%' }}>
+              <Response response={this.state.response} />
+              { !this.state.loading && (
+                this.state.criticalError ? (
+                  <AutoWidthTableButton onClick={this.close}>
+                    <Translate content={'qvain.files.metadataModal.buttons.close'} />
+                  </AutoWidthTableButton>
+                ) : (
+                  <AutoWidthTableButton onClick={this.clearError}>
+                    <Translate content={'qvain.files.metadataModal.buttons.hideError'} />
+                  </AutoWidthTableButton>
+                )
+              )}
+            </div>
+          </ResponseOverlay>
+        )}
+      </Modal>
+    )
+  }
+}
+
+
+export const modalStyles = {
+  content: {
+    top: '0',
+    bottom: '0',
+    left: '0',
+    right: '0',
+    position: 'relative',
+    minWidth: '32vw',
+    maxWidth: '30em',
+    margin: '0.5em',
+    border: 'none',
+    padding: '2em',
+    boxShadow: '0px 6px 12px -3px rgba(0, 0, 0, 0.15)',
+    overflow: 'auto',
+  },
+  overlay: {
+    zIndex: '100',
+  }
+}
+
+const ResponseOverlay = styled.div`
+  display: flex;
+  position: absolute;
+  background: rgba(255,255,255,0.95);
+  width: 100%;
+  top: 0;
+  left: 0;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  padding: 2em;
+`
+
+export const AutoWidthTableButton = styled(TableButton)`
+  width: auto;
+`;
+
+export default inject('Stores')(observer(MetadataModal))

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
@@ -15,8 +15,7 @@ import { Label, HelpField, Input } from '../../general/form'
 import { DangerButton, TableButton } from '../../general/buttons'
 import Response from '../response'
 
-import { separatorOptions, delimiterOptions, encodingOptions, hasheaderOptions,
-  getDefaultOptions, makeOption, findOption } from './options'
+import { getOptions, getDefaultOptions, makeOption, findOption } from './options'
 import { MetadataSelect, selectStylesNarrow, labelStyle } from './select'
 
 
@@ -213,8 +212,10 @@ class MetadataModal extends Component {
         error = err.response.data.detail
       } else if (err.response && err.response.data) {
         error = err.response.data
-      } else {
+      } else if (err.response && err.response.errorMessage) {
         error = err.response.errorMessage
+      } else {
+        error = err.message
       }
       if (error.file_characteristics) {
         error = error.file_characteristics
@@ -319,6 +320,7 @@ class MetadataModal extends Component {
 
   render() {
     const { metadataModalFile } = this.props.Stores.Qvain
+    const options = getOptions()
 
     return (
       <Modal
@@ -327,7 +329,7 @@ class MetadataModal extends Component {
         onRequestClose={this.requestClose}
         customStyles={modalStyles}
       >
-        <h2 style={{ marginBottom: 0 }}>Edit PAS Metadata</h2>
+        <Translate content="qvain.files.metadataModal.header" component="h2" style={{ marginBottom: 0 }} />
         <Translate content="qvain.files.metadataModal.help" component={HelpField} />
 
         <MetadataSelect
@@ -351,19 +353,19 @@ class MetadataModal extends Component {
 
         <MetadataSelect
           inputId="pas_file_encoding"
-          options={encodingOptions}
-          value={findOption(this.state.encoding, encodingOptions)}
+          options={options.encoding}
+          value={findOption(this.state.encoding, options.encoding)}
           onChange={this.setEncoding}
           field="encoding"
         />
 
-        <h3 style={{ marginBottom: 0, marginTop: '0.3rem' }}>CSV Options</h3>
+        <Translate content="qvain.files.metadataModal.csvOptions" component="h3" style={{ marginBottom: 0, marginTop: '0.3rem' }} />
 
         <div style={{ display: 'flex', flexWrap: 'wrap', maxWidth: '26em' }}>
           <MetadataSelect
             inputId="pas_csv_delimiter"
-            options={delimiterOptions}
-            value={findOption(this.state.csvDelimiter, delimiterOptions)}
+            options={options.delimiter}
+            value={findOption(this.state.csvDelimiter, options.delimiter)}
             onChange={this.setCsvDelimiter}
             styles={selectStylesNarrow}
             field="csvDelimiter"
@@ -371,8 +373,8 @@ class MetadataModal extends Component {
 
           <MetadataSelect
             inputId="pas_csv_record_separator"
-            options={separatorOptions}
-            value={findOption(this.state.csvRecordSeparator, separatorOptions)}
+            options={options.separator}
+            value={findOption(this.state.csvRecordSeparator, options.separator)}
             onChange={this.setCsvRecordSeparator}
             styles={selectStylesNarrow}
             field="csvRecordSeparator"
@@ -385,7 +387,7 @@ class MetadataModal extends Component {
             <div style={selectStylesNarrow.control()}>
               <Input
                 id="pas_csv_quoting_char"
-                placeholder="Type a character"
+                placeholder={translate('qvain.files.metadataModal.placeholders.csvQuotingChar')}
                 type="text"
                 value={this.state.csvQuotingChar}
                 onChange={this.handleChangeCsvQuotingChar}
@@ -395,8 +397,8 @@ class MetadataModal extends Component {
 
           <MetadataSelect
             inputId="pas_csv_has_header"
-            options={hasheaderOptions}
-            value={findOption(this.state.csvHasHeader, hasheaderOptions)}
+            options={options.hasHeader}
+            value={findOption(this.state.csvHasHeader, options.hasHeader)}
             onChange={this.setCsvHasHeader}
             styles={selectStylesNarrow}
             field="csvHasHeader"

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/options.js
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/options.js
@@ -1,0 +1,47 @@
+export const separatorOptions = [
+  { value: 'LF', label: 'LF' },
+  { value: 'CRLF', label: 'CRLF' },
+  { value: 'CR', label: 'CR' },
+]
+
+export const delimiterOptions = [
+  { value: '\t', label: 'Tab' },
+  { value: ' ', label: 'Space' },
+  { value: ';', label: 'Semicolon ;' },
+  { value: ',', label: 'Comma ,' },
+  { value: ':', label: 'Colon :' },
+  { value: '.', label: 'Dot .' },
+  { value: '|', label: 'Pipe |' },
+]
+
+export const encodingOptions = [
+  { value: 'UTF-8', label: 'UTF-8' },
+  { value: 'UTF-16', label: 'UTF-16' },
+  { value: 'UTF-32', label: 'UTF-32' },
+  { value: 'ISO-8859-15', label: 'ISO-8859-15' },
+]
+
+export const hasheaderOptions = [
+  { value: false, label: 'No' },
+  { value: true, label: 'Yes' },
+]
+
+export const getDefaultOptions = () => ({
+  fileFormat: 'text/csv',
+  formatVersion: '',
+  encoding: 'UTF-8',
+  csvDelimiter: ',',
+  csvRecordSeparator: 'LF',
+  csvQuotingChar: ',',
+  csvHasHeader: true,
+})
+
+// Turn a plain value into an option object for react-select
+export const makeOption = (value) => (
+  value ? { value, label: value } : null
+)
+
+// Find option object by value
+export const findOption = (value, options) => (
+  options.find(v => v.value === value)
+)

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/options.js
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/options.js
@@ -1,30 +1,31 @@
-export const separatorOptions = [
-  { value: 'LF', label: 'LF' },
-  { value: 'CRLF', label: 'CRLF' },
-  { value: 'CR', label: 'CR' },
-]
+import translate from 'counterpart'
 
-export const delimiterOptions = [
-  { value: '\t', label: 'Tab' },
-  { value: ' ', label: 'Space' },
-  { value: ';', label: 'Semicolon ;' },
-  { value: ',', label: 'Comma ,' },
-  { value: ':', label: 'Colon :' },
-  { value: '.', label: 'Dot .' },
-  { value: '|', label: 'Pipe |' },
-]
-
-export const encodingOptions = [
-  { value: 'UTF-8', label: 'UTF-8' },
-  { value: 'UTF-16', label: 'UTF-16' },
-  { value: 'UTF-32', label: 'UTF-32' },
-  { value: 'ISO-8859-15', label: 'ISO-8859-15' },
-]
-
-export const hasheaderOptions = [
-  { value: false, label: 'No' },
-  { value: true, label: 'Yes' },
-]
+export const getOptions = () => ({
+  separator: [
+    { value: 'LF', label: 'LF' },
+    { value: 'CRLF', label: 'CRLF' },
+    { value: 'CR', label: 'CR' },
+  ],
+  delimiter: [
+    { value: '\t', label: translate('qvain.files.metadataModal.options.delimiter.tab') },
+    { value: ' ', label: translate('qvain.files.metadataModal.options.delimiter.space') },
+    { value: ';', label: translate('qvain.files.metadataModal.options.delimiter.semicolon') },
+    { value: ',', label: translate('qvain.files.metadataModal.options.delimiter.comma') },
+    { value: ':', label: translate('qvain.files.metadataModal.options.delimiter.colon') },
+    { value: '.', label: translate('qvain.files.metadataModal.options.delimiter.dot') },
+    { value: '|', label: translate('qvain.files.metadataModal.options.delimiter.pipe') },
+  ],
+  encoding: [
+    { value: 'UTF-8', label: 'UTF-8' },
+    { value: 'UTF-16', label: 'UTF-16' },
+    { value: 'UTF-32', label: 'UTF-32' },
+    { value: 'ISO-8859-15', label: 'ISO-8859-15' },
+  ],
+  hasHeader: [
+    { value: false, label: translate('qvain.files.metadataModal.options.header.false') },
+    { value: true, label: translate('qvain.files.metadataModal.options.header.true') }
+  ]
+})
 
 export const getDefaultOptions = () => ({
   fileFormat: 'text/csv',

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/select.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/select.jsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import translate from 'counterpart'
+import PropTypes from 'prop-types'
+
+import Select from 'react-select'
+import { Label } from '../../general/form'
+
+export const MetadataSelect = (props) => {
+  const noOptions = !props.options || props.options.length === 0
+  return (
+    <Label
+      htmlFor={props.inputId}
+      style={labelStyle}
+    >{props.children || translate(`qvain.files.metadataModal.fields.${props.field}`)}
+      <Select
+        styles={!props.selectStyles && selectStyles}
+        menuPlacement="auto"
+        menuPosition="fixed"
+        menuShouldScrollIntoView={false}
+        name={props.inputId}
+        isDisabled={noOptions}
+        placeholder={noOptions ? 'No options available' : props.placeholder || 'Select an option'}
+        {...props}
+      />
+    </Label>
+  )
+}
+
+MetadataSelect.propTypes = {
+  ...Select.propTypes,
+  selectStyles: PropTypes.object,
+  field: PropTypes.string
+}
+
+
+MetadataSelect.defaultProps = {
+  selectStyles: null,
+  field: null,
+}
+
+const selectStyles = {
+  control: (provided) => ({
+      ...provided,
+  }),
+  option: (provided) => ({
+    ...provided,
+    padding: '2px 8px',
+    borderBottom: '1px solid #eee'
+}),
+}
+
+export const selectStylesNarrow = {
+  container: () => ({
+    minWidth: '10em',
+  }),
+  control: (provided) => ({
+      ...provided,
+      minWidth: '10em',
+      flexGrow: 1,
+      marginBottom: 0,
+  }),
+  option: (provided) => ({
+    ...provided,
+    padding: '2px 8px',
+    borderBottom: '1px solid #eee'
+}),
+}
+
+export const labelStyle = {
+  flexGrow: 1,
+  flexBasis: '10em',
+  marginTop: '0.2rem'
+}
+
+export default MetadataSelect

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/select.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/select.jsx
@@ -19,7 +19,10 @@ export const MetadataSelect = (props) => {
         menuShouldScrollIntoView={false}
         name={props.inputId}
         isDisabled={noOptions}
-        placeholder={noOptions ? 'No options available' : props.placeholder || 'Select an option'}
+        placeholder={noOptions ?
+          translate('qvain.files.metadataModal.placeholders.noOptions') :
+          props.placeholder || translate('qvain.files.metadataModal.placeholders.selectOption')
+        }
         {...props}
       />
     </Label>

--- a/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
@@ -55,7 +55,7 @@ class RefreshDirectoryModal extends Component {
         } else if (err.response && err.response.data) {
           error = err.response.data
         } else {
-          error = this.response.errorMessage
+          error = err.response.errorMessage
         }
 
         this.setState({

--- a/etsin_finder/frontend/js/components/qvain/files/response.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/response.jsx
@@ -101,6 +101,7 @@ const ResponseContainerContent = styled.div`
   text-align: left;
   display: inline-block;
   padding-left: 30px;
+  padding-right: 20px;
   padding-top: 20px;
   white-space: pre-line;
 `

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -64,7 +64,11 @@ export class SelectedFilesBase extends Component {
             </FileLabel>
             <FileButtonsContainer>
               { s.directoryName && (
-                <RefreshDirectoryButton disabled={this.state.refreshLoading} type="button" onClick={() => this.setRefreshModalDirectory(s.identifier)}>
+                <RefreshDirectoryButton
+                  type="button"
+                  disabled={this.state.refreshLoading}
+                  onClick={() => this.setRefreshModalDirectory(s.identifier)}
+                >
                   <Translate component={RefreshDirectoryButtonText} content="qvain.files.refreshModal.buttons.show" />
                 </RefreshDirectoryButton>
               )}

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -247,6 +247,27 @@ export const FilePickerButtonInverse = styled(FilePickerButton)`
   background-color: #fff;
 `;
 
+export const FilePickerFileButton = styled.button`
+  background-color: ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  color: #fff;
+  height: 22px;
+  border-radius: 2px;
+  border: solid 1px ${props => (
+    props.disabled ? '#7fbfd6' : '#007fad'
+  )};
+  text-transform: none;
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  ${props => !props.disabled && css`
+    cursor: pointer;
+  `}
+`;
+
 export const FilePickerButtonText = styled.span`
   width: 90%;
   text-align: left;

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -251,6 +251,7 @@ export const FilePickerFileButton = styled.button`
   background-color: ${props => (
     props.disabled ? '#7fbfd6' : '#007fad'
   )};
+  font-size: 0.9em;
   color: #fff;
   height: 22px;
   border-radius: 2px;

--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -203,6 +203,19 @@ const directorySchema = yup.object().shape({
 
 const directoriesSchema = yup.array().of(directorySchema)
 
+// PAS METADATA VALIDATION
+
+export const fileMetadataSchema = yup.object().shape({
+  fileFormat: yup.string().required(),
+  formatVersion: yup.string(),
+  encoding: yup.string().required(),
+  csvHasHeader: yup.boolean().required(),
+  csvDelimiter: yup.string().required(),
+  csvRecordSeparator: yup.string().required(),
+  csvQuotingChar: yup.string().required()
+})
+
+
 // EXTERNAL RESOURCES VALIDATION
 
 const externalResourceTitleSchema = yup

--- a/etsin_finder/frontend/js/components/qvain/utils/object.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/object.js
@@ -1,7 +1,7 @@
 
 // gets deep nested values within objects.
 // Param: array that acts as an "address" for the value, ex: ['path', 'to', 'object']
-export const get = (p, o) => p.reduce((xs, x) => ((xs && xs[x]) ? xs[x] : undefined), o)
+export const get = (p, o) => p.reduce((xs, x) => ((xs && xs[x] !== undefined) ? xs[x] : undefined), o)
 
 // returns deep nested value by dotted address
 // ex. getPath('path.to.value', object)

--- a/etsin_finder/frontend/js/index.jsx
+++ b/etsin_finder/frontend/js/index.jsx
@@ -10,6 +10,8 @@
    */
 }
 
+require('@babel/polyfill')
+
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -81,6 +81,9 @@ class Qvain {
     this.existingDirectories = []
     this.hierarchy = {}
     this.inEdit = undefined
+
+    this.metadataModalFile = undefined
+
     // Reset External resources related data
     this.externalResources = []
     this.externalResourceInEdit = EmptyExternalResource
@@ -276,6 +279,8 @@ class Qvain {
 
   @observable inEdit = undefined
 
+  @observable metadataModalFile = undefined
+
   @action
   setDataCatalog = selectedDataCatalog => {
     this.dataCatalog = selectedDataCatalog
@@ -462,6 +467,19 @@ class Qvain {
 
   @action setInEdit = selectedItem => {
     this.inEdit = selectedItem
+  }
+
+  @action setMetadataModalFile = file => {
+    this.metadataModalFile = file
+  }
+
+  @action updateFileMetadata = file => {
+    // After editing file metadata, update the file in the hierarchy if possible.
+    const flat = getFiles(this.hierarchy)
+    const existing = flat.find(f => f.identifier === file.identifier)
+    if (existing) {
+      Object.assign(existing, File(file, existing.parentDirectory, existing.selected))
+    }
   }
 
   @computed
@@ -698,7 +716,6 @@ class Qvain {
   // roles together to get one actor with multiple roles.
   // Returns a nw array with the merged actors.
   mergeTheSameActors = actors => {
-    console.groupCollapsed('Actor object comparison DEBUG')
     if (actors.length <= 1) return actors
     const mergedActors = []
     actors.forEach(actor1 => {
@@ -710,7 +727,6 @@ class Qvain {
       })
       mergedActors.push(actor1)
     })
-    console.groupEnd()
     return mergedActors
   }
 
@@ -879,7 +895,16 @@ const File = (file, parent, selected) => ({
   fileType: getPath('file_characteristics.file_type', file),
   description: getPath('file_characteristics.description', file) || 'File',
   title: getPath('file_characteristics.title', file) || file.file_name,
-  existing: false
+  existing: false,
+
+  // PAS metadata
+  fileFormat: getPath('file_characteristics.file_format', file),
+  formatVersion: getPath('file_characteristics.format_version', file),
+  encoding: getPath('file_characteristics.encoding', file),
+  csvHasHeader: getPath('file_characteristics.csv_has_header', file),
+  csvDelimiter: getPath('file_characteristics.csv_delimiter', file),
+  csvRecordSeparator: getPath('file_characteristics.csv_record_separator', file),
+  csvQuotingChar: getPath('file_characteristics.csv_quoting_char', file)
 })
 
 const DatasetFile = file => ({

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -475,10 +475,27 @@ class Qvain {
 
   @action updateFileMetadata = file => {
     // After editing file metadata, update the file in the hierarchy if possible.
+    // The input file comes from a Metax response so needs to be transformed into Qvain light format.
     const flat = getFiles(this.hierarchy)
-    const existing = flat.find(f => f.identifier === file.identifier)
-    if (existing) {
-      Object.assign(existing, File(file, existing.parentDirectory, existing.selected))
+    const hierarchyFile = flat.find(f => f.identifier === file.identifier)
+    if (hierarchyFile) {
+      Object.assign(hierarchyFile, File(file, hierarchyFile.parentDirectory, hierarchyFile.selected))
+    }
+
+    // Update existing file if available.
+    const existingFile = this.existingFiles.find(f => f.identifier === file.identifier)
+    if (existingFile) {
+      const parsed = File(file, existingFile.parentDirectory, existingFile.selected)
+      const newMetadata = {
+        fileFormat: parsed.fileFormat,
+        formatVersion: parsed.formatVersion,
+        encoding: parsed.encoding,
+        csvHasHeader: parsed.csvHasHeader,
+        csvDelimiter: parsed.csvDelimiter,
+        csvRecordSeparator: parsed.csvRecordSeparator,
+        csvQuotingChar: parsed.csvQuotingChar,
+      }
+      Object.assign(existingFile, newMetadata)
     }
   }
 
@@ -907,7 +924,7 @@ const File = (file, parent, selected) => ({
   csvQuotingChar: getPath('file_characteristics.csv_quoting_char', file)
 })
 
-const DatasetFile = file => ({
+export const DatasetFile = file => ({
   ...File(file.details, file.details.parent_directory, true),
   identifier: file.identifier,
   useCategory: getPath('use_category.identifier', file),

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -633,8 +633,35 @@ const english = {
           close: 'Close',
         }
       },
-      help:
-        'Files associated with this dataset. A dataset can only have either IDA files or remote files. File metadata will not be associated with datasets, so remember to save edits to file metadata.',
+      metadataModal: {
+        header: 'Edit PAS Metadata',
+        help: 'Help text for pas metadata editing',
+        csvOptions: 'CSV Options',
+        fields: {
+          fileFormat: 'File format',
+          formatVersion: 'File format version',
+          encoding: 'Encoding',
+          csvDelimiter: 'Delimiter',
+          csvRecordSeparator: 'Record separator',
+          csvQuotingChar: 'Quoting character',
+          csvHasHeader: 'Has header'
+        },
+        warning: 'You have unsaved changes. Are you sure you want to discard your changes?',
+        errors: {
+          formatVersionRequired: 'Invalid or missing file format version.',
+          formatVersionNotAllowed: 'File format version is not allowed for selected file format.',
+          loadingFileFormats: 'Failed to load list of allowed file formats.'
+        },
+        buttons: {
+          show: 'Edit PAS metadata',
+          close: 'Close',
+          save: 'Save changes',
+          confirmClose: 'Yes, discard changes',
+          cancelClose: 'No, continue editing',
+          hideError: 'Continue editing'
+        }
+      },
+      help: 'Files associated with this dataset. A dataset can only have either IDA files or remote files. File metadata will not be associated with datasets, so remember to save edits to file metadata.',
       ida: {
         title: 'Fairdata IDA files',
         infoText: "Project dropdown will show all your IDA projects. Select the project from which you want to link your files. Note! One dataset can have files or folder from only one project. After you have chosen the project, you'll get a list of all files and folders that are FROZEN in that project. Select all files and folders you wish to link to your dataset. If you select a folder, ALL files and subfolders in that folder will be linked. In that case, do not select individual files or subfolders from that folder.",

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -635,7 +635,7 @@ const english = {
       },
       metadataModal: {
         header: 'Edit PAS Metadata',
-        help: 'Help text for pas metadata editing',
+        help: 'Saving the data will change the file metadata regardless of whether the file is in your dataset or not.',
         csvOptions: 'CSV Options',
         fields: {
           fileFormat: 'File format',
@@ -659,6 +659,26 @@ const english = {
           confirmClose: 'Yes, discard changes',
           cancelClose: 'No, continue editing',
           hideError: 'Continue editing'
+        },
+        options: {
+          delimiter: {
+            tab: 'Tab',
+            space: 'Space',
+            semicolon: 'Semicolon ;',
+            comma: 'Comma ,',
+            colon: 'Colon :',
+            dot: 'Dot .',
+            pipe: 'Pipe |'
+          },
+          header: {
+            false: 'No',
+            true: 'Yes'
+          }
+        },
+        placeholders: {
+          noOptions: 'No options available',
+          selectOption: 'Select an option',
+          csvQuotingChar: 'Type a character'
         }
       },
       help: 'Files associated with this dataset. A dataset can only have either IDA files or remote files. File metadata will not be associated with datasets, so remember to save edits to file metadata.',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -637,6 +637,54 @@ const finnish = {
           close: 'Sulje',
         }
       },
+      metadataModal: {
+        header: 'Muokkaa PAS-metadataa',
+        help: 'Datan tallentaminen päivittää tiedoston metadatan riippumatta siitä onko se aineistossa.',
+        csvOptions: 'CSV-määritykset',
+        fields: {
+          fileFormat: 'Tiedostomuoto',
+          formatVersion: 'Tiedostomuodon versio',
+          encoding: 'Merkistökoodaus',
+          csvDelimiter: 'Sarake-erotin',
+          csvRecordSeparator: 'Rivierotin',
+          csvQuotingChar: 'Lainausmerkki',
+          csvHasHeader: 'Sisältää otsikkorivin'
+        },
+        warning: 'Sinulla on tallentamattomia muutoksia. Perutaanko muutokset?',
+        errors: {
+          formatVersionRequired: 'Versio puuttuu tai on epäkelpo valitulle tiedostomuodolle.',
+          formatVersionNotAllowed: 'Valitulle tiedostomuodolle ei voi asettaa versiota.',
+          loadingFileFormats: 'Tiedostomuotolistan hakeminen epäonnistui.'
+        },
+        buttons: {
+          show: 'Muokkaa PAS-metadataa',
+          close: 'Sulje',
+          save: 'Tallenna muutokset',
+          confirmClose: 'Kyllä, peru muutokset',
+          cancelClose: 'Ei, jatka muokkausta',
+          hideError: 'Jatka muokkausta'
+        },
+        options: {
+          delimiter: {
+            tab: 'Tab',
+            space: 'Välilyönti',
+            semicolon: 'Puolipiste ;',
+            comma: 'Pilkku ,',
+            colon: 'Kaksoispiste :',
+            dot: 'Piste .',
+            pipe: 'Pystyviiva |'
+          },
+          header: {
+            false: 'Ei',
+            true: 'Kyllä'
+          }
+        },
+        placeholders: {
+          noOptions: 'Ei vaihtoehtoja saatavilla',
+          selectOption: 'Valitse yksi',
+          csvQuotingChar: 'Kirjoita merkki'
+        }
+      },
       help:
         'Aineistoon kuuluvat tiedostot. Aineistoon voi kuulua vain joko IDAssa olevia tiedostoja tai ulkopuolisia tiedostoja. Tiedostojen metadata ei ole osa aineistojen metadataa, joten muista tallentaa muutokset jotka teet tiedostojen metadataan.',
       ida: {

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -132,7 +132,7 @@ class FileDirectory(Resource):
         return '', 404
 
 class FileCharacteristics(Resource):
-    """File/directory related REST endpoints for getting a directory"""
+    """REST endpoint for updating file_characteristics of a file."""
 
     def __init__(self):
         """Setup arguments"""
@@ -141,10 +141,14 @@ class FileCharacteristics(Resource):
     @log_request
     def patch(self, file_id):
         """
-        Get files and directory objects for frontend.
+        Update file_characteristics of a file.
 
-        :param file_id:
-        :return:
+        Arguments:
+            file {object} -- File object as json, should contain a file_characteristics object that will be updated.
+
+        Returns:
+            [type] -- Metax response.
+
         """
         if request.content_type != 'application/json':
             return 'Expected content-type application/json', 403

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -78,7 +78,6 @@ class ProjectFiles(Resource):
         :param pid:
         :return:
         """
-
         # Return data only if user is a member of the project
         user_ida_projects = get_user_ida_projects() or []
         if pid in user_ida_projects:
@@ -147,7 +146,6 @@ class FileCharacteristics(Resource):
         :param file_id:
         :return:
         """
-
         if request.content_type != 'application/json':
             return 'Expected content-type application/json', 403
 

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -36,7 +36,7 @@ class MetaxQvainLightAPIService(FlaskService):
             self.METAX_GET_DIRECTORY = 'https://{0}/rest/directories'.format(metax_qvain_api_config['HOST']) + \
                                        '/{0}/files'
             self.METAX_GET_FILE = 'https://{0}/rest/files'.format(metax_qvain_api_config['HOST']) + \
-                                '/{0}'
+                                  '/{0}'
             self.METAX_GET_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \
                                                '?metadata_provider_user={0}&file_details&ordering=-date_created'
             self.METAX_GET_ALL_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \
@@ -112,7 +112,6 @@ class MetaxQvainLightAPIService(FlaskService):
 
         return metax_qvain_api_response.json()
 
-
     def get_file(self, file_identifier):
         """
         Get a specific file with file's id
@@ -146,7 +145,9 @@ class MetaxQvainLightAPIService(FlaskService):
 
     def patch_file(self, file_identifier, data):
         """
-        Patch metadata for a file with given data. Useful for updating file_characteristics. Can be also used to change other fields
+        Patch metadata for a file with given data.
+
+        Useful for updating file_characteristics. Can be also used to change other fields
         such as identifier, so be careful when passing user input to avoid data corruption.
 
         Arguments:
@@ -157,8 +158,8 @@ class MetaxQvainLightAPIService(FlaskService):
 
         Returns:
             [type] -- The response from Metax.
-        """
 
+        """
         req_url = self.METAX_GET_FILE.format(file_identifier)
 
         try:

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -34,7 +34,9 @@ class MetaxQvainLightAPIService(FlaskService):
             self.METAX_GET_DIRECTORY_FOR_PROJECT_URL = 'https://{0}/rest/directories'.format(metax_qvain_api_config['HOST']) + \
                                                        '/files?project={0}&path=%2F'
             self.METAX_GET_DIRECTORY = 'https://{0}/rest/directories'.format(metax_qvain_api_config['HOST']) + \
-                                       '/{0}/files?project={0}&path=%2F'
+                                       '/{0}/files'
+            self.METAX_GET_FILE = 'https://{0}/rest/files'.format(metax_qvain_api_config['HOST']) + \
+                                '/{0}'
             self.METAX_GET_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \
                                                '?metadata_provider_user={0}&file_details&ordering=-date_created'
             self.METAX_GET_ALL_DATASETS_FOR_USER = 'https://{0}/rest/datasets'.format(metax_qvain_api_config['HOST']) + \
@@ -107,6 +109,78 @@ class MetaxQvainLightAPIService(FlaskService):
                 log.error("Failed to get data for directory \"{0}\" from Metax API\n{1}".
                           format(dir_identifier, e))
             return None
+
+        return metax_qvain_api_response.json()
+
+
+    def get_file(self, file_identifier):
+        """
+        Get a specific file with file's id
+
+        :param file_identifier:
+        :return:
+        """
+        req_url = self.METAX_GET_FILE.format(file_identifier)
+
+        try:
+            metax_qvain_api_response = requests.get(req_url,
+                                                    headers={'Accept': 'application/json'},
+                                                    auth=(self.user, self.pw),
+                                                    verify=self.verify_ssl,
+                                                    timeout=10)
+            metax_qvain_api_response.raise_for_status()
+        except Exception as e:
+            if isinstance(e, requests.HTTPError):
+                log.warning(
+                    "Failed to get data for file \"{0}\" from Metax API\nResponse status code: {1}\nResponse text: {2}".format(
+                        file_identifier,
+                        metax_qvain_api_response.status_code,
+                        json_or_empty(metax_qvain_api_response) or metax_qvain_api_response.text
+                    ))
+            else:
+                log.error("Failed to get data for file \"{0}\" from Metax API\n{1}".
+                          format(file_identifier, e))
+            return None
+
+        return metax_qvain_api_response.json()
+
+    def patch_file(self, file_identifier, data):
+        """
+        Patch metadata for a file with given data. Useful for updating file_characteristics. Can be also used to change other fields
+        such as identifier, so be careful when passing user input to avoid data corruption.
+
+        Arguments:
+            file_identifier {data} -- The identifier of the file.
+            data {dict} -- Dictionary of fields that will be replaced in file metadata, other fields directly under the file will be
+                preserved. For example, data = { 'file_characteristics': { 'csv_has_header': True } } would enable
+                file_characteristics.csv_has_header and remove any other fields nested under file_characteristics.
+
+        Returns:
+            [type] -- The response from Metax.
+        """
+
+        req_url = self.METAX_GET_FILE.format(file_identifier)
+
+        try:
+            metax_qvain_api_response = requests.patch(req_url,
+                                                    headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
+                                                    data=json.dumps(data),
+                                                    auth=(self.user, self.pw),
+                                                    verify=self.verify_ssl,
+                                                    timeout=10)
+            metax_qvain_api_response.raise_for_status()
+        except Exception as e:
+            if isinstance(e, requests.HTTPError):
+                log.warning(
+                    "Failed to patch file \"{0}\" from Metax API\nResponse status code: {1}\nResponse text: {2}".format(
+                        file_identifier,
+                        metax_qvain_api_response.status_code,
+                        json_or_empty(metax_qvain_api_response) or metax_qvain_api_response.text
+                    ))
+            else:
+                log.error("Failed to patch file \"{0}\" from Metax API\n{1}".
+                          format(file_identifier, e))
+            return (json_or_empty(metax_qvain_api_response) or metax_qvain_api_response.text), metax_qvain_api_response.status_code
 
         return metax_qvain_api_response.json()
 
@@ -352,6 +426,24 @@ def get_directory_for_project(project_id):
     :return:
     """
     return _metax_api.get_directory_for_project(project_id)
+
+def get_file(file_identifier):
+    """
+    Get a specific file with file's id
+
+    :param file_identifier:
+    :return:
+    """
+    return _metax_api.get_file(file_identifier)
+
+def patch_file(file_identifier, data):
+    """
+    Patch a specific file with file's id
+
+    :param file_identifier:
+    :return:
+    """
+    return _metax_api.patch_file(file_identifier, data)
 
 def get_datasets_for_user(user_id, limit, offset, no_pagination):
     """

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -296,6 +296,19 @@ def edited_data_to_metax(data, original):
     }
     return clean_empty_keyvalues_from_dict(edited_data)
 
+def get_user_ida_projects():
+    user_ida_groups = get_user_ida_groups()
+    if user_ida_groups is None:
+        log.error('Could not get user IDA projects.\n')
+        return None
+
+    try:
+        return [project.split(":")[1] for project in user_ida_groups]
+    except IndexError as e:
+        log.error('Index error while parsing user IDA projects:\n{0}'.format(e))
+        return None
+
+
 def check_if_data_in_user_IDA_project(data):
     """
     Check if the user creating a dataset belongs to the project that the files/folders belongs to.
@@ -307,13 +320,9 @@ def check_if_data_in_user_IDA_project(data):
         [bool] -- True if data belongs to user, and False is not.
 
     """
-    user_ida_projects = get_user_ida_groups()
-    try:
-        user_ida_projects_ids = [project.split(":")[1] for project in user_ida_projects]
-    except IndexError as e:
-        log.error('Index error while parsing user IDA projects:\n{0}'.fromat(e))
-        return False
-    if not user_ida_projects:
+
+    user_ida_projects_ids = get_user_ida_projects()
+    if not user_ida_projects_ids:
         log.warning('Could not get user IDA groups.')
         return False
     log.debug('User IDA groups: {0}'.format(user_ida_projects_ids))

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -259,7 +259,7 @@ def remove_deleted_datasets_from_results(result):
 
 def edited_data_to_metax(data, original):
     """
-    Alter the researsh_dataset field to contain the new changes from editing.
+    Alter the research_dataset field to contain the new changes from editing.
 
     Arguments:
         data {object} -- Data from frontend.
@@ -297,6 +297,13 @@ def edited_data_to_metax(data, original):
     return clean_empty_keyvalues_from_dict(edited_data)
 
 def get_user_ida_projects():
+    """
+    List IDA projects for current user without the prefix.
+
+    Returns:
+        list(str) -- List of projects.
+
+    """
     user_ida_groups = get_user_ida_groups()
     if user_ida_groups is None:
         log.error('Could not get user IDA projects.\n')
@@ -320,7 +327,6 @@ def check_if_data_in_user_IDA_project(data):
         [bool] -- True if data belongs to user, and False is not.
 
     """
-
     user_ida_projects_ids = get_user_ida_projects()
     if not user_ida_projects_ids:
         log.warning('Could not get user IDA groups.')


### PR DESCRIPTION
* Add modal for editing PAS metadata, accessible from file selector and also from editing selected/existing files
* Fixed issue where modal background blur was removed on close attempt even if modal was prevented from actually closing
* Fixed issue where getPath() returned undefined for all falsy values
* Move require('@babel/polyfill') to top of the app entrypoint as suggested in the docs (having it elsewhere caused some issues in testing)