### PR TITLE
CSCFAIRMETA-246: Add missing font (Lato)

### DIFF
--- a/etsin_finder/frontend/static/index.template.ejs
+++ b/etsin_finder/frontend/static/index.template.ejs
@@ -10,6 +10,7 @@
     />
     <meta name="theme-color" content="#007FAD" />
     <link rel="manifest" href="/static/manifest.json" />
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700&display=swap" rel="stylesheet">
     <title>Etsin | Tutkimusaineistojen hakupalvelu</title>
     <style>
       .loader:empty {


### PR DESCRIPTION
- The Lato font is specified in the CSS styles (globalStyles.jsx), but hasn't been included previously
- Add a link to the Lato stylesheet, from fonts.googleapis.com