### PR TITLE
CSCFAIRMETA-393, CSCFAIRMETA-394: Change when "Refresh Directory Content" button is shown

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -63,7 +63,7 @@ export class SelectedFilesBase extends Component {
               {s.projectIdentifier} / {s.directoryName || s.fileName}
             </FileLabel>
             <FileButtonsContainer>
-              { s.directoryName && (
+              { s.directoryName && existing && (
                 <RefreshDirectoryButton
                   type="button"
                   disabled={this.state.refreshLoading}

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -52,8 +52,10 @@ export class SelectedFilesBase extends Component {
   renderFiles = (selected, inEdit, existing, removable) => {
     const {
       toggleSelectedFile,
-      toggleSelectedDirectory
+      toggleSelectedDirectory,
+      cumulativeState
     } = this.props.Stores.Qvain
+    const isCumulative = cumulativeState === CumulativeStates.YES
     return (
       selected.map(s => (
         <Fragment key={`${s.id}-${randomStr()}`}>
@@ -63,7 +65,7 @@ export class SelectedFilesBase extends Component {
               {s.projectIdentifier} / {s.directoryName || s.fileName}
             </FileLabel>
             <FileButtonsContainer>
-              { s.directoryName && existing && (
+              {s.directoryName && existing && isCumulative && (
                 <RefreshDirectoryButton
                   type="button"
                   disabled={this.state.refreshLoading}


### PR DESCRIPTION
* CSCFAIRMETA-393: Show "Refresh Directory Content" only for published folders.
* CSCFAIRMETA-394: Show "Refresh Directory Content" only for cumulative datasets.