### PR TITLE
CSCFAIRMETA-244: Allow editing/fixing deprecated datasets in Qvain Light

### DIFF
--- a/etsin_finder/finder.py
+++ b/etsin_finder/finder.py
@@ -62,9 +62,12 @@ def add_restful_resources(app):
     from etsin_finder.resources import REMSApplyForPermission, Contact, Dataset, User, Session, Files, Download
     from etsin_finder.qvain_light_resources import (
         ProjectFiles, FileDirectory, FileCharacteristics, UserDatasets,
-        QvainDataset,  QvainDatasetEdit, QvainDatasetDelete
+        QvainDataset, QvainDatasetEdit, QvainDatasetDelete
     )
-    from etsin_finder.qvain_light_rpc import QvainDatasetChangeCumulativeState, QvainDatasetRefreshDirectoryContent
+    from etsin_finder.qvain_light_rpc import (
+        QvainDatasetChangeCumulativeState, QvainDatasetRefreshDirectoryContent,
+        QvainDatasetFixDeprecated
+    )
 
     api.add_resource(Dataset, '/api/dataset/<string:cr_id>')
     api.add_resource(Files, '/api/files/<string:cr_id>')
@@ -83,12 +86,14 @@ def add_restful_resources(app):
     # Qvain light API RPC endpoints
     api.add_resource(QvainDatasetChangeCumulativeState, '/api/rpc/datasets/change_cumulative_state')
     api.add_resource(QvainDatasetRefreshDirectoryContent, '/api/rpc/datasets/refresh_directory_content')
+    api.add_resource(QvainDatasetFixDeprecated, '/api/rpc/datasets/fix_deprecated')
     # REMS API endpoints
     api.add_resource(REMSApplyForPermission, '/api/rems/<string:cr_id>')
     # api.add_resource(REMSCreateUser, '/api/users/create')
     # api.add_resource(REMSGetEntitlements, '/api/entitlements')
     # api.add_resource(REMSGetApplications, '/api/applications/<string:application_id>')
     # api.add_resource(REMSCreateNewApplication, '/api/applications/create')
+
 
 app = create_app()
 add_restful_resources(app)

--- a/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
@@ -252,7 +252,10 @@ class DatasetTable extends Component {
                   <BodyCellWordWrap>
                     {dataset.research_dataset.title.en || dataset.research_dataset.title.fi}
                     {dataset.next_dataset_version !== undefined && (
-                      <Translate color="yellow" content="qvain.datasets.oldVersion" component={OldVersionLabel} />
+                      <Translate color="yellow" content="qvain.datasets.oldVersion" component={DatasetLabel} />
+                    )}
+                    {dataset.deprecated && (
+                      <Translate color="error" content="qvain.datasets.deprecated" component={DatasetLabel} />
                     )}
                     {(dataset.preservation_state > 0 || dataset.data_catalog.identifier === DataCatalogIdentifiers.PAS) &&
                       <PasLabel color={PreservationStates[dataset.preservation_state].color}>PAS</PasLabel>
@@ -297,7 +300,7 @@ class DatasetTable extends Component {
   }
 }
 
-const OldVersionLabel = styled(Label)`
+const DatasetLabel = styled(Label)`
   margin-left: 10px;
   text-transform: uppercase;
 `;

--- a/etsin_finder/frontend/js/components/qvain/deprecatedState.jsx
+++ b/etsin_finder/frontend/js/components/qvain/deprecatedState.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { inject, observer } from 'mobx-react'
+import Translate from 'react-translate-component'
+import { TableButton } from './general/buttons'
+
+// If we have a deprecated dataset, show information and button for fixing it.
+const DeprecatedState = (props) => {
+  const { deprecated, showFixDeprecatedModal } = props.Stores.Qvain
+  if (!deprecated) {
+    return null
+  }
+  return (
+    <DeprecationInfoText>
+      <Translate content="qvain.files.fixDeprecatedModal.statusText" />
+      <ButtonContainer>
+        <FixDeprecatedButton type="button" onClick={showFixDeprecatedModal}>
+          <Translate content="qvain.files.fixDeprecatedModal.buttons.show" />
+        </FixDeprecatedButton>
+      </ButtonContainer>
+    </DeprecationInfoText>
+  )
+}
+
+DeprecatedState.propTypes = {
+  Stores: PropTypes.object.isRequired,
+}
+
+const DeprecationInfoText = styled.div`
+  background-color: ${ props => props.theme.color.error};
+  text-align: center;
+  width: 100%;
+  color: white;
+  z-index: 2;
+  border-bottom: 1px solid rgba(0,0,0,0.3);
+  position: relative;
+  min-width: 300px;
+  padding: 0.5rem;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const FixDeprecatedButton = styled(TableButton)`
+  margin: 0;
+  margin-top: 11px;
+  width: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+`
+
+export default inject('Stores')(observer(DeprecatedState))

--- a/etsin_finder/frontend/js/components/qvain/files/cumulativeState.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/cumulativeState.jsx
@@ -6,10 +6,12 @@ import axios from 'axios'
 
 import { ContainerSubsectionBottom } from '../general/card'
 import { CumulativeStates } from '../utils/constants'
+import { getResponseError } from '../utils/responseError'
 import { LabelLarge, FormField, RadioInput, RadioContainer, Label, HelpField } from '../general/form'
 
 import Modal from '../../general/modal'
-import { TableButton, DangerButton,
+import {
+  TableButton, DangerButton,
   CumulativeStateButton,
   CumulativeStateButtonText,
 } from '../general/buttons'
@@ -79,18 +81,9 @@ class CumulativeState extends Component {
         }
       })
       .catch(err => {
-        let error = ''
-        if (err.response && err.response.data && err.response.data.detail) {
-          error = err.response.data.detail
-        } else if (err.response && err.response.data) {
-          error = err.response.data
-        } else {
-          error = err.response.errorMessage
-        }
-
         this.setState({
           response: {
-            error
+            error: getResponseError(err)
           }
         })
       })
@@ -197,7 +190,7 @@ class CumulativeState extends Component {
         {content}
         <Modal isOpen={this.state.modalOpen} onRequestClose={this.closeModal} contentLabel="changeCumulativeStateModal">
           <Translate component="h3" content="qvain.files.cumulativeState.modalHeader" />
-          { modalContent }
+          {modalContent}
         </Modal>
       </ContainerSubsectionBottom>
     )

--- a/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fileSelector.jsx
@@ -32,7 +32,8 @@ export class FileSelectorBase extends Component {
   drawFile = (f) => {
     const {
       toggleSelectedFile,
-      setMetadataModalFile
+      setMetadataModalFile,
+      canSelectFiles
     } = this.props.Stores.Qvain
 
     return (
@@ -40,6 +41,7 @@ export class FileSelectorBase extends Component {
         <Checkbox
           checked={f.selected}
           id={`${f.id}Checkbox`}
+          disabled={!canSelectFiles}
           type="checkbox"
           onChange={() => toggleSelectedFile(
             f,
@@ -53,7 +55,7 @@ export class FileSelectorBase extends Component {
           {f.fileName}
         </label>
         <FilePickerFileButton id={`${f.identifier}-open-metadata-modal`} type="button" onClick={() => setMetadataModalFile(f)}>
-          { translate('qvain.files.metadataModal.buttons.show') }
+          {translate('qvain.files.metadataModal.buttons.show')}
         </FilePickerFileButton>
       </li>
     )
@@ -63,6 +65,7 @@ export class FileSelectorBase extends Component {
   drawHierarchy = (h, root) => {
     const {
       toggleSelectedDirectory,
+      canSelectFiles
     } = this.props.Stores.Qvain
     return (
       <li key={h.identifier} style={{ paddingLeft: '20px' }}>
@@ -77,6 +80,7 @@ export class FileSelectorBase extends Component {
         <Checkbox
           aria-label={`${h.directoryName}`}
           checked={h.selected || false}
+          disabled={!canSelectFiles}
           id={`${h.id}Checkbox`}
           type="checkbox"
           onChange={() => toggleSelectedDirectory(

--- a/etsin_finder/frontend/js/components/qvain/files/fixDeprecatedModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/fixDeprecatedModal.jsx
@@ -1,0 +1,103 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { inject, observer } from 'mobx-react'
+import Translate from 'react-translate-component'
+import axios from 'axios'
+
+import Modal from '../../general/modal'
+import Response from './response'
+import { DangerButton, TableButton } from '../general/buttons'
+import { getResponseError } from '../utils/responseError'
+
+class FixDeprecatedModal extends Component {
+  static propTypes = {
+    Stores: PropTypes.object.isRequired,
+  }
+
+  state = {
+    response: null,
+    loading: false,
+  }
+
+  fixDeprecated = () => {
+    const { deprecated, original } = this.props.Stores.Qvain
+    if (!original || !deprecated) {
+      return
+    }
+    this.setState({
+      response: null,
+      loading: true
+    })
+
+    const obj = {
+      identifier: original.identifier,
+    }
+    axios.post('/api/rpc/datasets/fix_deprecated', obj)
+      .then(response => {
+        const data = response.data || {}
+        this.setState({
+          response: {
+            new_version_created: data.new_version_created
+          }
+        })
+      })
+      .catch(err => {
+        this.setState({
+          response: {
+            error: getResponseError(err)
+          }
+        })
+      })
+      .finally(() => {
+        this.setState({
+          loading: false
+        })
+      })
+  }
+
+  handleRequestClose = () => {
+    if (!this.state.loading) {
+      this.props.Stores.Qvain.closeFixDeprecatedModal()
+      this.setState({
+        response: null,
+      })
+    }
+  }
+
+  render() {
+    const { changed, fixDeprecatedModalOpen } = this.props.Stores.Qvain
+    return (
+      <Modal
+        isOpen={fixDeprecatedModalOpen}
+        onRequestClose={this.handleRequestClose}
+        contentLabel="fixDeprecatedModal"
+      >
+        <Translate component="h3" content="qvain.files.fixDeprecatedModal.header" />
+        {this.state.loading || this.state.response ?
+          <Response response={this.state.response} requestClose={this.handleRequestClose} />
+          : (
+            <>
+              <Translate component="p" content={'qvain.files.fixDeprecatedModal.help'} />
+              {changed && <Translate component="p" content={'qvain.files.fixDeprecatedModal.changes'} />}
+            </>
+          )}
+        {this.state.response ? (
+          <TableButton onClick={this.handleRequestClose}>
+            <Translate content={'qvain.files.fixDeprecatedModal.buttons.close'} />
+          </TableButton>
+        ) : (
+          <>
+            <TableButton disabled={this.state.loading} onClick={this.handleRequestClose}>
+              <Translate content={'qvain.files.fixDeprecatedModal.buttons.cancel'} />
+            </TableButton>
+            <DangerButton disabled={changed || this.state.loading} onClick={() => this.fixDeprecated()}>
+              <Translate content={'qvain.files.fixDeprecatedModal.buttons.ok'} />
+            </DangerButton>
+          </>
+        )}
+      </Modal>
+    )
+  }
+}
+
+export default inject('Stores')(observer(FixDeprecatedModal))

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
@@ -11,6 +11,7 @@ import { observable, action } from 'mobx'
 import Modal from '../../../general/modal'
 import getReferenceData from '../../utils/getReferenceData'
 import { fileMetadataSchema } from '../../utils/formValidation'
+import { getResponseError } from '../../utils/responseError'
 import { Label, HelpField, Input } from '../../general/form'
 import { DangerButton, TableButton } from '../../general/buttons'
 import Response from '../response'
@@ -215,25 +216,9 @@ class MetadataModal extends Component {
       })
       this.close()
     } catch (err) {
-      let error = ''
-      if (err.response && err.response.data && err.response.data.detail) {
-        error = err.response.data.detail
-      } else if (err.response && err.response.data) {
-        error = err.response.data
-      } else if (err.response && err.response.errorMessage) {
-        error = err.response.errorMessage
-      } else {
-        error = err.message
-      }
-      if (error.file_characteristics) {
-        error = error.file_characteristics
-      }
-      if (typeof error === 'object') {
-        error = JSON.stringify(error)
-      }
       this.setState({
         response: {
-          error
+          error: getResponseError(err)
         }
       })
     } finally {

--- a/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/refreshDirectoryModal.jsx
@@ -7,6 +7,7 @@ import axios from 'axios'
 import Modal from '../../general/modal'
 import Response from './response'
 import { CumulativeStates } from '../utils/constants'
+import { getResponseError } from '../utils/responseError'
 import { DangerButton, TableButton } from '../general/buttons'
 
 class RefreshDirectoryModal extends Component {
@@ -49,18 +50,9 @@ class RefreshDirectoryModal extends Component {
         })
       })
       .catch(err => {
-        let error = ''
-        if (err.response && err.response.data && err.response.data.detail) {
-          error = err.response.data.detail
-        } else if (err.response && err.response.data) {
-          error = err.response.data
-        } else {
-          error = err.response.errorMessage
-        }
-
         this.setState({
           response: {
-            error
+            error: getResponseError(err)
           }
         })
       })
@@ -91,12 +83,12 @@ class RefreshDirectoryModal extends Component {
         contentLabel="refreshDirectoryModal"
       >
         <Translate component="h3" content="qvain.files.refreshModal.header" />
-        {this.state.loading || this.state.response ?
+        {this.state.loading || this.state.response ? (
           <Response response={this.state.response} requestClose={this.handleRequestClose} />
-        : (
+        ) : (
           <>
             <Translate component="p" content={`qvain.files.refreshModal.${cumulativeKey}`} />
-            { changed && <Translate component="p" content={'qvain.files.refreshModal.changes'} /> }
+            {changed && <Translate component="p" content={'qvain.files.refreshModal.changes'} />}
           </>
         )}
         {this.state.response ? (

--- a/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/selectedFiles.jsx
@@ -6,6 +6,7 @@ import { faCopy, faFolder } from '@fortawesome/free-solid-svg-icons'
 import Translate from 'react-translate-component'
 import styled, { css } from 'styled-components';
 
+import Label from '../general/label'
 import { ButtonLabel, EditButton, DeleteButton, FileItem, ButtonContainer, TableButton } from '../general/buttons'
 import { SelectedFilesTitle } from '../general/form'
 import FileForm from './fileForm'
@@ -14,6 +15,7 @@ import { randomStr } from '../utils/fileHierarchy'
 import Modal from '../../general/modal'
 import { CumulativeStates } from '../utils/constants'
 import RefreshDirectoryModal from './refreshDirectoryModal';
+import FixDeprecatedModal from './fixDeprecatedModal';
 
 
 export class SelectedFilesBase extends Component {
@@ -54,7 +56,8 @@ export class SelectedFilesBase extends Component {
       toggleSelectedFile,
       toggleSelectedDirectory,
       cumulativeState,
-      canSelectFiles
+      canSelectFiles,
+      deprecated
     } = this.props.Stores.Qvain
     const isCumulative = cumulativeState === CumulativeStates.YES
     return (
@@ -65,8 +68,9 @@ export class SelectedFilesBase extends Component {
               <FontAwesomeIcon icon={(s.directoryName ? faFolder : faCopy)} style={{ marginRight: '8px' }} />
               {s.projectIdentifier} / {s.directoryName || s.fileName}
             </FileLabel>
+            {s.removed && <Translate component={DeletedLabel} content="qvain.files.deletedLabel" color="error" />}
             <FileButtonsContainer>
-              {s.directoryName && existing && isCumulative && canSelectFiles && (
+              {s.directoryName && existing && isCumulative && canSelectFiles && !deprecated && (
                 <RefreshDirectoryButton
                   type="button"
                   disabled={this.state.refreshLoading}
@@ -75,8 +79,8 @@ export class SelectedFilesBase extends Component {
                   <Translate component={RefreshDirectoryButtonText} content="qvain.files.refreshModal.buttons.show" />
                 </RefreshDirectoryButton>
               )}
-              <EditButton aria-label="Edit" onClick={this.handleEdit(s)} />
-              { removable && (
+              {!s.removed && <EditButton aria-label="Edit" onClick={this.handleEdit(s)} />}
+              {removable && (
                 <DeleteButton
                   aria-label="Remove"
                   onClick={(event) => {
@@ -112,7 +116,7 @@ export class SelectedFilesBase extends Component {
       cumulativeState,
       isPas,
       canSelectFiles,
-      readonly,
+      readonly
     } = this.props.Stores.Qvain
     const selected = [...selectedDirectories, ...selectedFiles]
     const existing = [...existingDirectories, ...existingFiles]
@@ -126,13 +130,13 @@ export class SelectedFilesBase extends Component {
 
     return (
       <Fragment>
-        { canSelectFiles && (
+        {canSelectFiles && (
           <>
             <Translate tabIndex="0" component={SelectedFilesTitle} content="qvain.files.selected.title" />
             {selected.length === 0 && <Translate tabIndex="0" component="p" content="qvain.files.selected.none" />}
             {this.renderFiles(selected, inEdit, false, true)}
           </>
-        ) }
+        )}
         <Translate tabIndex="0" component={SelectedFilesTitle} content="qvain.files.existing.title" />
         <Translate tabIndex="0" content={`qvain.files.existing.help.${existingHelpKey}`} />
         {this.renderFiles(existing, inEdit, true, canSelectFiles && !isCumulative)}
@@ -151,6 +155,8 @@ export class SelectedFilesBase extends Component {
           directory={this.state.refreshModalDirectory}
           onClose={() => this.setRefreshModalDirectory(null)}
         />
+
+        <FixDeprecatedModal />
       </Fragment>
     )
   }
@@ -218,5 +224,11 @@ const RefreshDirectoryButtonText = styled.span`
 `
 
 const isDirectory = (inEdit) => inEdit.directoryName !== undefined
+
+const DeletedLabel = styled(Label)`
+  margin-left: 10px;
+  text-transform: uppercase;
+`;
+
 
 export default inject('Stores')(observer(SelectedFilesBase))

--- a/etsin_finder/frontend/js/components/qvain/general/form.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/form.jsx
@@ -70,8 +70,11 @@ export const CheckboxStyles = styled.input`
   padding: 11px;
   line-height: 0;
   white-space: nowrap;
-  cursor: pointer;
   vertical-align: bottom;
+
+  :not(:disabled) {
+    cursor: pointer;
+  }
 `
 
 export const Checkbox = props => <CheckboxStyles {...props} type="checkbox" />

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -24,12 +24,14 @@ import {
   Container
 } from './general/card'
 import handleSubmitToBackend from './utils/handleSubmit'
+import { getResponseError } from './utils/responseError'
 import Title from './general/title'
 import SubmitResponse from './general/submitResponse'
 import Button, { InvertedButton } from '../general/button';
+import DeprecatedState from './deprecatedState';
+import PasState from './pasState'
 
 const EDIT_DATASET_URL = '/api/datasets/edit'
-import PasState from './pasState'
 
 class Qvain extends Component {
   promises = []
@@ -132,6 +134,12 @@ class Qvain extends Component {
     event.preventDefault();
   }
 
+  handlePublishError = err => {
+    this.setState({
+      response: getResponseError(err)
+    })
+  }
+
   handleCreate = e => {
     e.preventDefault()
     this.setState({ submitted: true })
@@ -142,7 +150,6 @@ class Qvain extends Component {
         axios
           .post('/api/dataset', obj)
           .then(res => {
-            console.log(res)
             const data = res.data
             this.setState({ response: { ...data, is_new: true } })
             // Open the created dataset without reloading the editor
@@ -151,45 +158,7 @@ class Qvain extends Component {
               this.props.Stores.Qvain.editDataset(data)
               this.props.history.replace(`/qvain/dataset/${data.identifier}`)
             }
-          })
-          .catch(err => {
-            console.log(err)
-            // Refreshing error header
-            this.setState({ response: null })
-
-            // If user is not logged in, display logged in error
-            if (err.response.data.PermissionError) {
-              this.setState({ response: [err.response.data.PermissionError] })
-
-            // If user is logged in...
-            } else if (err.response.data && err.response.data.Error_message) {
-              this.setState({
-                response: [err.response.data.Error_message]
-              })
-            } else if (err.response.data) {
-              // If no IDA projects are found, display an IDA error
-              if (err.response.data.IdaError) {
-                this.setState({
-                  response: [err.response.data.IdaError]
-                })
-              } else if (err.response.data.detail) { // ...else, try to format the Metax error
-                this.setState({
-                  response: err.response.data.detail
-                })
-              // If the Metax error message formatting cannot be done, just display the entire error
-              } else {
-                this.setState({
-                  response: [err.response.data]
-                })
-              }
-
-            // If error response is empty, just display 'Error...'
-            } else {
-              this.setState({
-                response: ['Error...']
-              })
-            }
-          })
+          }).catch(this.handlePublishError)
       })
       .catch(err => {
         console.log(err.errors)
@@ -216,42 +185,11 @@ class Qvain extends Component {
         axios
           .patch('/api/dataset', obj)
           .then(res => {
-            console.log(res)
             this.props.Stores.Qvain.moveSelectedToExisting()
             this.props.Stores.Qvain.setChanged(false)
             this.setState({ response: res.data })
           })
-          .catch(err => {
-            console.log(err.response)
-            // Refreshing error header
-            this.setState({ response: null })
-
-            // If user is not logged in, display logged in error
-            if (err.response.data.PermissionError) {
-              this.setState({ response: [err.response.data.PermissionError] })
-
-            // If user is logged in...
-            } else if (err.response.data) {
-            // ...try to format the Metax error
-            if (err.response.data.detail) {
-              this.setState({
-                response: err.response.data.detail
-              })
-
-            // If the Metax error message formatting cannot be done, just display the entire error
-            } else {
-              this.setState({
-                response: [err.response.data]
-              })
-            }
-
-            // If error response is empty, just display 'Error...'
-            } else {
-              this.setState({
-                response: ['Error...']
-              })
-            }
-          })
+          .catch(this.handlePublishError)
       })
       .catch(err => {
         console.log(err.errors)
@@ -328,6 +266,7 @@ class Qvain extends Component {
             </ButtonContainer>
           </StickySubHeader>
           <PasState />
+          <DeprecatedState />
           {this.state.submitted ? (
             <StickySubHeaderResponse>
               <SubmitResponse response={this.state.response} />

--- a/etsin_finder/frontend/js/components/qvain/utils/responseError.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/responseError.js
@@ -1,0 +1,29 @@
+const stringify = (value) => {
+  // Make the output cleaner by unpacking single-item arrays.
+  let val = value
+  if (Array.isArray(val) && val.length === 1) {
+    val = val[0]
+  }
+  // Convert value to string if needed
+  if (typeof val !== 'string') {
+    val = JSON.stringify(val)
+  }
+  return val
+}
+
+export const getResponseError = err => {
+  // Return an array of error strings based on an Axios error response.
+  const data = err.response && err.response.data
+  if (data) {
+    if (typeof data === 'object') {
+      // JSON error message
+      return Object.entries(data).map(([key, value]) => `${key}: ${stringify(value)}`)
+    }
+    // string error message
+    return [data]
+  }
+  // no response
+  return [`Error: ${err.message}`]
+}
+
+export default getResponseError

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -368,6 +368,7 @@ const english = {
       },
       oldVersion: 'Old',
       latestVersion: 'Latest',
+      deprecated: 'Deprecated',
       editButton: 'Edit',
       deleteButton: 'Delete',
       confirmDelete:
@@ -635,6 +636,7 @@ const english = {
       title: 'Files',
       infoTitle: 'Files info',
       infoText: 'Add text',
+      deletedLabel: 'Deleted',
       dataCatalog: {
         label: 'File origin',
         infoText:
@@ -687,6 +689,18 @@ const english = {
         buttons: {
           show: 'Refresh folder content',
           ok: 'Ok',
+          cancel: 'Cancel',
+          close: 'Close',
+        }
+      },
+      fixDeprecatedModal: {
+        statusText: 'This dataset is deprecated. Some of the files in the dataset are no longer available.',
+        header: 'Fix Deprecated Dataset',
+        help: 'This will fix the dataset by removing any included files and directories that are no longer available. A new dataset version will be created. The changes will take place immediately.',
+        changes: 'You need to save your changes to the dataset first.',
+        buttons: {
+          show: 'Fix deprecated dataset',
+          ok: 'Fix dataset',
           cancel: 'Cancel',
           close: 'Close',
         }

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -295,7 +295,7 @@ const finnish = {
       success: 'Aineisto julkaistu!',
       fail: 'Jotain meni pieleen...',
       editSuccess: 'Uusi aineisto versio luotu!',
-      editMetadataSuccess: 'Aineisto päivitys onnistui!',
+      editMetadataSuccess: 'Aineiston päivitys onnistui!',
     },
     pasInfo: {
       stateInfo: 'Tämä on PAS-aineisto. Aineiston tila on "%(state)s: %(description)s".',
@@ -365,8 +365,9 @@ const finnish = {
           years: ' vuotta sitten',
         },
       },
-      oldVersion: 'Vanha',
+      oldVersion: 'Vanha versio',
       latestVersion: 'Uusin',
+      deprecated: 'Vanhentunut',
       editButton: 'Muokkaa',
       deleteButton: 'Poista',
       confirmDelete:
@@ -640,6 +641,7 @@ const finnish = {
       title: 'Tiedostot',
       infoTitle: 'Tiedostot info',
       infoText: 'Lisää texti',
+      deletedLabel: 'Poistettu',
       dataCatalog: {
         label: 'Tiedoston lähde',
         infoText:
@@ -692,6 +694,18 @@ const finnish = {
         buttons: {
           show: 'Päivitä kansion tiedostot',
           ok: 'Päivitä',
+          cancel: 'Peruuta',
+          close: 'Sulje',
+        }
+      },
+      fixDeprecatedModal: {
+        statusText: 'Aineisto on vanhentunut. Jotkin aineiston tiedostot eivät ole enää saatavilla.',
+        header: 'Korjaa vanhentunut aineisto',
+        help: 'Tämä toiminto korjaa aineiston poistamalla siitä kaikki tiedostot ja hakemistot jotka eivät ole enää saatavilla. Aineistosta tehdään uusi versio.',
+        changes: 'Aineistoon tehdyt muutokset on tallennettava ennen tätä toimintoa.',
+        buttons: {
+          show: 'Korjaa vanhentunut aineisto',
+          ok: 'Korjaa aineisto',
           cancel: 'Peruuta',
           close: 'Sulje',
         }

--- a/etsin_finder/qvain_light_rpc.py
+++ b/etsin_finder/qvain_light_rpc.py
@@ -14,9 +14,10 @@ from flask_restful import abort, reqparse, Resource
 
 from etsin_finder.app_config import get_app_config
 from etsin_finder import authentication
-from etsin_finder.qvain_light_service import change_cumulative_state, refresh_directory_content
+from etsin_finder.qvain_light_service import change_cumulative_state, refresh_directory_content, fix_deprecated_dataset
 from etsin_finder.finder import app
 from etsin_finder.qvain_light_utils import get_dataset_creator
+from etsin_finder.utils import SAML_ATTRIBUTES
 
 log = app.logger
 
@@ -77,11 +78,11 @@ class QvainDatasetChangeCumulativeState(Resource):
             return {"PermissionError": "User not logged in."}, 401
 
         # only creator of the dataset is allowed to modify it
-        user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.16161.4.0.53"][0]
+        user = session["samlUserdata"][SAML_ATTRIBUTES["CSC_username"]][0]
         creator = get_dataset_creator(cr_id)
         if user != creator:
             log.warning('User: \"{0}\" is not the creator of the dataset. Changing cumulative state not allowed. Creator: \"{1}\"'.format(user, creator))
-            return {"PermissionError": "User not authorized to to change cumulative state of dataset."}, 403
+            return {"PermissionError": "User not authorized to change cumulative state of dataset."}, 403
         metax_response = change_cumulative_state(cr_id, cumulative_state)
         return metax_response
 
@@ -115,10 +116,49 @@ class QvainDatasetRefreshDirectoryContent(Resource):
             return {"PermissionError": "User not logged in."}, 401
 
         # only creator of the dataset is allowed to modify it
-        user = session["samlUserdata"]["urn:oid:1.3.6.1.4.1.16161.4.0.53"][0]
+        user = session["samlUserdata"][SAML_ATTRIBUTES["CSC_username"]][0]
         creator = get_dataset_creator(cr_identifier)
         if user != creator:
             log.warning('User: \"{0}\" is not the creator of the dataset. Refreshing directory is not allowed. Creator: \"{1}\"'.format(user, creator))
-            return {"PermissionError": "User not authorized to to refresh directory in dataset."}, 403
+            return {"PermissionError": "User not authorized to refresh directory in dataset."}, 403
         metax_response = refresh_directory_content(cr_identifier, dir_identifier)
+        return metax_response
+
+
+class QvainDatasetFixDeprecated(Resource):
+    """Metax RPC for fixing a deprecated dataset."""
+
+    def __init__(self):
+        """Setup endpoints"""
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument('identifier', type=str, required=True)
+
+    @log_request
+    def post(self):
+        """
+        Fix deprecated dataset using Metax fix_deprecated RPC.
+
+        Removes all files and directories that no longer exist from the dataset.
+        Creates a new, non-deprecated version.
+
+        Arguments:
+            identifier {string} -- The identifier of the dataset.
+
+        Returns:
+            [type] -- Metax response.
+
+        """
+        args = self.parser.parse_args()
+        cr_id = args['identifier']
+        is_authd = authentication.is_authenticated()
+        if not is_authd:
+            return {"PermissionError": "User not logged in."}, 401
+
+        # only creator of the dataset is allowed to modify it
+        user = session["samlUserdata"][SAML_ATTRIBUTES["CSC_username"]][0]
+        creator = get_dataset_creator(cr_id)
+        if user != creator:
+            log.warning('User: \"{0}\" is not the creator of the dataset. Fixing deprecated dataset not allowed. Creator: \"{1}\"'.format(user, creator))
+            return {"PermissionError": "User not authorized to fix deprecated dataset."}, 403
+        metax_response = fix_deprecated_dataset(cr_id)
         return metax_response

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -51,6 +51,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                         '/{0}'
             self.METAX_CHANGE_CUMULATIVE_STATE = 'https://{0}/rpc/datasets/change_cumulative_state'.format(metax_qvain_api_config['HOST'])
             self.METAX_REFRESH_DIRECTORY_CONTENT = 'https://{0}/rpc/datasets/refresh_directory_content'.format(metax_qvain_api_config['HOST'])
+            self.METAX_FIX_DEPRECATED = 'https://{0}/rpc/datasets/fix_deprecated'.format(metax_qvain_api_config['HOST'])
             self.user = metax_qvain_api_config['USER']
             self.pw = metax_qvain_api_config['PASSWORD']
             self.verify_ssl = metax_qvain_api_config.get('VERIFY_SSL', True)
@@ -461,6 +462,44 @@ class MetaxQvainLightAPIService(FlaskService):
         log.info('Refreshed dataset {} directory {}'.format(cr_identifier, dir_identifier))
         return (json_or_empty(metax_api_response) or metax_api_response.text), metax_api_response.status_code
 
+    def fix_deprecated_dataset(self, cr_identifier):
+        """
+        Call Metax fix_deprecated RPC.
+
+        Arguments:
+            cr_identifier {string} -- The identifier of the dataset.
+
+        Returns:
+            [type] -- Metax response.
+
+        """
+        req_url = self.METAX_FIX_DEPRECATED
+        params = {
+            "identifier": cr_identifier,
+        }
+        headers = {'Accept': 'application/json'}
+        try:
+            metax_api_response = requests.post( req_url,
+                                                headers=headers,
+                                                auth=(self.user, self.pw),
+                                                verify=self.verify_ssl,
+                                                params=params,
+                                                timeout=10)
+            metax_api_response.raise_for_status()
+        except Exception as e:
+            if isinstance(e, requests.HTTPError):
+                log.warning(
+                    "Failed to fix deprecated dataset {0}\nResponse status code: {1}\nResponse text: {2}".format(
+                        cr_identifier,
+                        metax_api_response.status_code,
+                        json_or_empty(metax_api_response) or metax_api_response.text
+                    ))
+            else:
+                log.error("Error fixing deprecated dataset {0} \n{1}".format(cr_identifier, e))
+            return {'detail': 'Error trying to send data to metax.'}, 500
+        log.info('Fixed deprecated dataset {}'.format(cr_identifier))
+        return (json_or_empty(metax_api_response) or metax_api_response.text), metax_api_response.status_code
+
 _metax_api = MetaxQvainLightAPIService(app)
 
 def get_directory(dir_id):
@@ -591,3 +630,16 @@ def refresh_directory_content(cr_identifier, dir_identifier):
 
     """
     return _metax_api.refresh_directory_content(cr_identifier, dir_identifier)
+
+def fix_deprecated_dataset(cr_id):
+    """
+    Call Metax fix_deprecated RPC.
+
+    Arguments:
+        cr_id {string} -- The identifier of the dataset.
+
+    Returns:
+        [type] -- Metax response.
+
+    """
+    return _metax_api.fix_deprecated_dataset(cr_id)


### PR DESCRIPTION
* Show message in top of editor for deprecated datasets.
* Below the message, show button that shows modal for fixing the dataset.
* Dataset fixing modal uses Metax RPC for fixing deprecated datasets.
* Remove metadata editing buttons from dataset files/directories that have been removed.
* Fix: Bug from not taking into account that removed files/folders don't have details.
* Refactor: Use reusable response error handler function to make displaying errors more reliable.