### PR TITLE
CSCFAIRMETA-449: Disable watch in webpack.config.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: python
 python: 3.6

--- a/etsin_finder/frontend/webpack.config.js
+++ b/etsin_finder/frontend/webpack.config.js
@@ -47,7 +47,7 @@ const config = {
       favicon: 'static/images/favicon.png',
     }),
   ],
-  watch: true,
+  watch: false,
   watchOptions: {
     aggregateTimeout: 300,
     poll: 1000,


### PR DESCRIPTION
The watch target should be used instead:
https://github.com/CSCfi/etsin-finder/blob/test/etsin_finder/frontend/package.json#L20