### PR TITLE
Qvain light bug fixes

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
@@ -47,6 +47,7 @@ class SubmitResponse extends Component {
 
     // If a new dataset has been created successfully.
     if (response &&
+      typeof response === 'object' &&
       'identifier' in response &&
       !('new_version_created' in response) &&
       response.is_new
@@ -74,6 +75,7 @@ class SubmitResponse extends Component {
     // If an existing datasets metadata has successfully been updated.
     if (
       response &&
+      typeof response === 'object' &&
       'identifier' in response &&
       !('new_version_created' in response) &&
       original !== undefined &&
@@ -104,7 +106,7 @@ class SubmitResponse extends Component {
     }
     // If an existing datasets files or directorys have changed and the update
     // creates a new version of the dataset with its own identifiers.
-    if (response && 'new_version_created' in response) {
+    if (response && typeof response === 'object' && 'new_version_created' in response) {
       const identifier = response.dataset_version_set
         ? response.dataset_version_set[0].identifier
         : response.identifier

--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -135,14 +135,13 @@ class Qvain extends Component {
     e.preventDefault()
     this.setState({ submitted: true })
     const obj = handleSubmitToBackend(this.props.Stores.Qvain)
-    console.log(JSON.stringify(obj, null, 4))
     qvainFormSchema
       .validate(obj, { abortEarly: false })
-      .then(val => {
-        console.log(val)
+      .then(() => {
         axios
           .post('/api/dataset', obj)
           .then(res => {
+            console.log(res)
             const data = res.data
             this.setState({ response: { ...data, is_new: true } })
             // Open the created dataset without reloading the editor
@@ -153,6 +152,7 @@ class Qvain extends Component {
             }
           })
           .catch(err => {
+            console.log(err)
             // Refreshing error header
             this.setState({ response: null })
 
@@ -205,19 +205,19 @@ class Qvain extends Component {
     this.setState({ submitted: true })
     const obj = handleSubmitToBackend(this.props.Stores.Qvain)
     obj.original = this.props.Stores.Qvain.original
-    console.log(JSON.stringify(obj, null, 4))
     qvainFormSchema
       .validate(obj, { abortEarly: false })
-      .then(val => {
-        console.log(val)
+      .then(() => {
         axios
           .patch('/api/dataset', obj)
           .then(res => {
+            console.log(res)
             this.props.Stores.Qvain.moveSelectedToExisting()
             this.props.Stores.Qvain.setChanged(false)
             this.setState({ response: res.data })
           })
           .catch(err => {
+            console.log(err.response)
             // Refreshing error header
             this.setState({ response: null })
 

--- a/etsin_finder/qvain_light_service.py
+++ b/etsin_finder/qvain_light_service.py
@@ -8,6 +8,7 @@
 """Used for performing operations related to Metax for Qvain Light"""
 
 import requests
+from flask import jsonify
 
 from etsin_finder.finder import app
 from etsin_finder.app_config import get_metax_qvain_api_config
@@ -170,11 +171,11 @@ class MetaxQvainLightAPIService(FlaskService):
 
         try:
             metax_qvain_api_response = requests.patch(req_url,
-                                                    headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
-                                                    data=json.dumps(data),
-                                                    auth=(self.user, self.pw),
-                                                    verify=self.verify_ssl,
-                                                    timeout=10)
+                                                      headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
+                                                      data=json.dumps(data),
+                                                      auth=(self.user, self.pw),
+                                                      verify=self.verify_ssl,
+                                                      timeout=10)
             metax_qvain_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
@@ -253,6 +254,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                                auth=(self.user, self.pw),
                                                verify=self.verify_ssl,
                                                timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(
@@ -260,15 +262,17 @@ class MetaxQvainLightAPIService(FlaskService):
                         metax_api_response.status_code,
                         json_or_empty(metax_api_response) or metax_api_response.text
                     ))
+                return metax_api_response.json(), metax_api_response.status_code
             else:
                 log.error("Error creating dataset\n{0}".format(e))
-            return {'Error_message': 'Error trying to send data to metax.'}
-        log.info('Created dataset with identifier: {}'.format(json.loads(metax_api_response.text)['identifier']))
-        return json_or_empty(metax_api_response) or metax_api_response.text, metax_api_response.status_code
+                return 'Error trying to send data to metax.', 500
+
+        log.info('Created dataset with identifier: {}'.format(json.loads(metax_api_response.text).get('identifier', 'COULD-NOT-GET-IDENTIFIER')))
+        return metax_api_response.json(), metax_api_response.status_code
 
     def update_dataset(self, data, cr_id):
         """
-        Update a dataset with the datat that the user has entered in Qvain-light.
+        Update a dataset with the data that the user has entered in Qvain-light.
 
         Arguments:
             data {object} -- Object with the dataset data that has been validated and converted to comply with the Metax schema.
@@ -287,6 +291,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                                 auth=(self.user, self.pw),
                                                 verify=self.verify_ssl,
                                                 timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(
@@ -295,12 +300,14 @@ class MetaxQvainLightAPIService(FlaskService):
                         metax_api_response.status_code,
                         json_or_empty(metax_api_response) or metax_api_response.text
                     ))
+                return metax_api_response.json(), metax_api_response.status_code
             else:
                 log.error("Error updating dataset {0}\n{1}"
                           .format(cr_id, e))
-            return {'Error_message': 'Error trying to send data to metax.'}
+            return 'Error trying to send data to metax.', 500
+
         log.info('Updated dataset with identifier: {}'.format(cr_id))
-        return json_or_empty(metax_api_response) or metax_api_response.text, metax_api_response.status_code
+        return metax_api_response.json(), metax_api_response.status_code
 
     def get_dataset(self, cr_id):
         """
@@ -321,6 +328,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                               auth=(self.user, self.pw),
                                               verify=self.verify_ssl,
                                               timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(
@@ -353,6 +361,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                                  auth=(self.user, self.pw),
                                                  verify=self.verify_ssl,
                                                  timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(
@@ -392,6 +401,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                                 verify=self.verify_ssl,
                                                 params=params,
                                                 timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(
@@ -431,6 +441,7 @@ class MetaxQvainLightAPIService(FlaskService):
                                                 verify=self.verify_ssl,
                                                 params=params,
                                                 timeout=10)
+            metax_api_response.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):
                 log.warning(


### PR DESCRIPTION
These bug fixes address issues reported in tickets: CSCFAIRMETA-470, CSCFAIMETA-455, CSCFAIMETA-457 and CSCFAIRMETA-426.

**Not all issues are resolved** since there is a bug in metax related to datasets with files and the use of `?file_details` query parameter. To get the datasets with files working the issue in metax has to be resolved or then Qvain Light has to be refactored to not use the `?file_details` parameter (which could be good but is a large task). The issue in metax will cause it to return: `('{"detail":["failed to publish updates to rabbitmq. request is aborted."]}', 503)` which should at least be handled.

The PR should fix CSCFAIRMETA-426 to the point of showing a metax error since REMS functionality is not implemented in Qvain Light (Before it would crash the page). The PR also should help handle other errors related to publishing and updating so it should be possible to create datasets without filed (folders seem OK) or non-REMS datasets. There is also added some logging to the frontend to better understand the errors.

What should be tested in this PR:
* Try to update dataset to have access_type "requires permission" (should give metax error instead of crash page)
* Try to create and update non-cumulative datasets without it failing (no files)
* Try to create and update cumulative dataset without failing (no files)
* Try to create and update  cumulative dataset with folder without failing (no files)
* Try to create and update a dataset with files and check if the error message is the same as mentioned above.
