### PR TITLE
CSCFAIRMETA-261: ADD: Download url in qvain-light

### DIFF
--- a/etsin_finder/frontend/__tests__/qvain.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.test.jsx
@@ -409,7 +409,8 @@ describe('Qvain.ExternalFiles', () => {
     stores.Qvain.saveExternalResource(ExternalResource(
       1,
       'External Resource Title',
-      'http://en.wikipedia.org'
+      'http://en.wikipedia.org',
+      'https://en.wikipedia.org/wiki/Portal:Arts'
     ))
     externalFiles.update()
     expect(externalFiles.find(ButtonGroup).length).toBe(1)

--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -109,6 +109,7 @@ export class ExternalFileFormBase extends Component {
         />
         <Label htmlFor="urlInput">
           <Translate content="qvain.files.external.form.url.label" />
+          <Translate component="p" content="qvain.files.external.form.url.infoText" />
         </Label>
         <Translate
           component={ResourceInput}
@@ -118,6 +119,20 @@ export class ExternalFileFormBase extends Component {
           onChange={(event) => { externalResource.url = event.target.value }}
           onBlur={this.handleOnUrlBlur}
           attributes={{ placeholder: 'qvain.files.external.form.url.placeholder' }}
+        />
+        <Label htmlFor="urlDownload">
+          <Translate content="qvain.files.external.form.downloadUrl.label" />
+          <Translate component="p" content="qvain.files.external.form.downloadUrl.infoText" />
+        </Label>
+
+        <Translate
+          component={ResourceInput}
+          type="text"
+          id="urlDownload"
+          value={externalResource.downloadUrl}
+          onChange={(event) => { externalResource.downloadUrl = event.target.value }}
+          onBlur={this.handleOnUrlBlur}
+          attributes={{ placeholder: 'qvain.files.external.form.downloadUrl.placeholder' }}
         />
         {externalResourceError && <ValidationError>{externalResourceError}</ValidationError>}
         <Translate

--- a/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFileForm.jsx
@@ -107,28 +107,27 @@ export class ExternalFileFormBase extends Component {
           onChange={(selection) => { externalResource.useCategory = selection }}
           attributes={{ placeholder: 'qvain.files.external.form.useCategory.placeholder' }}
         />
-        <Label htmlFor="urlInput">
-          <Translate content="qvain.files.external.form.url.label" />
-          <Translate component="p" content="qvain.files.external.form.url.infoText" />
+        <Label htmlFor="accessUrlInput">
+          <Translate content="qvain.files.external.form.accessUrl.label" />
+          <Translate component="p" content="qvain.files.external.form.accessUrl.infoText" />
         </Label>
         <Translate
           component={ResourceInput}
           type="text"
-          id="urlInput"
-          value={externalResource.url}
-          onChange={(event) => { externalResource.url = event.target.value }}
+          id="accessUrlInput"
+          value={externalResource.accessUrl}
+          onChange={(event) => { externalResource.accessUrl = event.target.value }}
           onBlur={this.handleOnUrlBlur}
-          attributes={{ placeholder: 'qvain.files.external.form.url.placeholder' }}
+          attributes={{ placeholder: 'qvain.files.external.form.accessUrl.placeholder' }}
         />
-        <Label htmlFor="urlDownload">
+        <Label htmlFor="downloadUrlInput">
           <Translate content="qvain.files.external.form.downloadUrl.label" />
           <Translate component="p" content="qvain.files.external.form.downloadUrl.infoText" />
         </Label>
-
         <Translate
           component={ResourceInput}
           type="text"
-          id="urlDownload"
+          id="downloadUrlInput"
           value={externalResource.downloadUrl}
           onChange={(event) => { externalResource.downloadUrl = event.target.value }}
           onBlur={this.handleOnUrlBlur}

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -70,7 +70,11 @@ export class ExternalFilesBase extends Component {
           {addedExternalResources.map((addedExternalResource) => (
             <ButtonGroup tabIndex="0" key={addedExternalResource.id}>
               <ButtonLabel>
-                {addedExternalResource.title} / {addedExternalResource.url.length > 38 ? addedExternalResource.url.substring(0, 38).concat('... ') : addedExternalResource.url} / {addedExternalResource.downloadUrl.length > 38 ? addedExternalResource.downloadUrl.substring(0, 38).concat('... ') : addedExternalResource.downloadUrl}
+                {addedExternalResource.title} / {addedExternalResource.url.length > 40 ?
+                addedExternalResource.url.substring(0, 40).concat('... ') :
+                addedExternalResource.url} / {addedExternalResource.downloadUrl.length > 40 ?
+                addedExternalResource.downloadUrl.substring(0, 40).concat('... ') :
+                addedExternalResource.downloadUrl}
               </ButtonLabel>
               <ButtonContainer>
                 <EditButton

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -70,7 +70,7 @@ export class ExternalFilesBase extends Component {
           {addedExternalResources.map((addedExternalResource) => (
             <ButtonGroup tabIndex="0" key={addedExternalResource.id}>
               <ButtonLabel>
-                {addedExternalResource.title} / {addedExternalResource.url}
+                {addedExternalResource.title} / {addedExternalResource.url.length > 38 ? addedExternalResource.url.substring(0, 38).concat('... ') : addedExternalResource.url} / {addedExternalResource.downloadUrl.length > 38 ? addedExternalResource.downloadUrl.substring(0, 38).concat('... ') : addedExternalResource.downloadUrl}
               </ButtonLabel>
               <ButtonContainer>
                 <EditButton

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -37,7 +37,7 @@ export class ExternalFilesBase extends Component {
   verifyURL = () => {
     const resource = this.props.Stores.Qvain.externalResourceInEdit
     externalResourceUrlSchema
-      .validate(resource.url)
+      .validate(resource.accessUrl)
       .then(() => {
         this.props.Stores.Qvain.resetInEditResource()
       })
@@ -70,9 +70,9 @@ export class ExternalFilesBase extends Component {
           {addedExternalResources.map((addedExternalResource) => (
             <ButtonGroup tabIndex="0" key={addedExternalResource.id}>
               <ButtonLabel>
-                {addedExternalResource.title} / {addedExternalResource.url.length > 40 ?
-                addedExternalResource.url.substring(0, 40).concat('... ') :
-                addedExternalResource.url} / {addedExternalResource.downloadUrl.length > 40 ?
+                {addedExternalResource.title} / {addedExternalResource.accessUrl.length > 40 ?
+                addedExternalResource.accessUrl.substring(0, 40).concat('... ') :
+                addedExternalResource.accessUrl} / {addedExternalResource.downloadUrl.length > 40 ?
                 addedExternalResource.downloadUrl.substring(0, 40).concat('... ') :
                 addedExternalResource.downloadUrl}
               </ButtonLabel>

--- a/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/externalFiles.jsx
@@ -16,7 +16,7 @@ import { EmptyExternalResource } from '../../../stores/view/qvain'
 import { Input, SelectedFilesTitle } from '../general/form'
 import { SlidingContent } from '../general/card'
 import ExternalFileForm from './externalFileForm'
-import { externalResourceUrlSchema } from '../utils/formValidation'
+import { externalResourceAccessUrlSchema } from '../utils/formValidation'
 
 export class ExternalFilesBase extends Component {
   static propTypes = {
@@ -36,7 +36,7 @@ export class ExternalFilesBase extends Component {
 
   verifyURL = () => {
     const resource = this.props.Stores.Qvain.externalResourceInEdit
-    externalResourceUrlSchema
+    externalResourceAccessUrlSchema
       .validate(resource.accessUrl)
       .then(() => {
         this.props.Stores.Qvain.resetInEditResource()

--- a/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/formValidation.js
@@ -234,14 +234,19 @@ const externalResourceUseCategorySchema = yup
   .string()
   .required(translate('qvain.validationMessages.externalResources.useCategory.required'))
 
-const externalResourceUrlSchema = yup
+const externalResourceAccessUrlSchema = yup
   .string()
-  .url(translate('qvain.validationMessages.externalResources.url.url'))
+  .url(translate('qvain.validationMessages.externalResources.accessUrl.validFormat'))
+
+const externalResourceDownloadUrlSchema = yup
+  .string()
+  .url(translate('qvain.validationMessages.externalResources.downloadUrl.validFormat'))
 
 const externalResourceSchema = yup.object().shape({
   title: externalResourceTitleSchema,
   useCategory: externalResourceUseCategorySchema,
-  url: externalResourceUrlSchema,
+  accessUrl: externalResourceAccessUrlSchema,
+  downloadUrl: externalResourceDownloadUrlSchema,
 })
 
 // ENTIRE ACTOR SCHEMAS
@@ -384,5 +389,6 @@ export {
   directoriesSchema,
   externalResourceSchema,
   externalResourceTitleSchema,
-  externalResourceUrlSchema,
+  externalResourceAccessUrlSchema,
+  externalResourceDownloadUrlSchema,
 }

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -244,7 +244,7 @@ class Qvain {
     const existing = this.externalResources.find(r => r.id === resource.id)
     if (existing !== undefined) {
       existing.title = resource.title
-      existing.url = resource.url
+      existing.accessUrl = resource.accessUrl
       existing.downloadUrl = resource.downloadUrl
       existing.useCategory = resource.useCategory
     } else {
@@ -253,7 +253,7 @@ class Qvain {
       const newResource = ExternalResource(
         newId,
         resource.title,
-        resource.url,
+        resource.accessUrl,
         resource.downloadUrl,
         resource.useCategory
       )
@@ -1039,10 +1039,10 @@ export const RestrictionGrounds = (name, identifier) => ({
   identifier,
 })
 
-export const ExternalResource = (id, title, url, downloadUrl, useCategory) => ({
+export const ExternalResource = (id, title, accessUrl, downloadUrl, useCategory) => ({
   id,
   title,
-  url,
+  accessUrl,
   downloadUrl,
   useCategory,
 })

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -222,6 +222,7 @@ class Qvain {
     if (existing !== undefined) {
       existing.title = resource.title
       existing.url = resource.url
+      existing.downloadUrl = resource.downloadUrl
       existing.useCategory = resource.useCategory
     } else {
       // Create an internal identifier for the resource to help with UI interaction
@@ -230,6 +231,7 @@ class Qvain {
         newId,
         resource.title,
         resource.url,
+        resource.downloadUrl,
         resource.useCategory
       )
       this.externalResources = [...this.externalResources, newResource]
@@ -674,6 +676,7 @@ class Qvain {
           remoteResources.indexOf(r),
           r.title,
           r.access_url ? r.access_url.identifier : undefined,
+          r.download_url ? r.download_url.identifier : undefined,
           r.use_category
             ? {
                 label: r.use_category.pref_label.en,
@@ -982,13 +985,14 @@ export const RestrictionGrounds = (name, identifier) => ({
   identifier,
 })
 
-export const ExternalResource = (id, title, url, useCategory) => ({
+export const ExternalResource = (id, title, url, downloadUrl, useCategory) => ({
   id,
   title,
   url,
+  downloadUrl,
   useCategory,
 })
 
-export const EmptyExternalResource = ExternalResource(undefined, '', '', '')
+ export const EmptyExternalResource = ExternalResource(undefined, '', '', '', '')
 
 export default new Qvain()

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -624,9 +624,11 @@ const english = {
         useCategory: {
           required: 'Remote resource use category is required.',
         },
-        url: {
-          required: 'Remote resource URL is required.',
-          url: 'Remote resource URL needs to be of valid URL format.',
+        accessUrl: {
+          validFormat: 'Access URL needs to be of valid URL format.',
+        },
+        downloadUrl: {
+          validFormat: 'Download URL needs to be of valid URL format.',
         },
       },
     },
@@ -847,7 +849,7 @@ const english = {
             label: 'Use Category',
             placeholder: 'Select option',
           },
-          url: {
+          accessUrl: {
             label: 'Access URL',
             placeholder: 'https://',
             infoText: 'Page where the link to the file / license information can be found'

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -801,7 +801,7 @@ const english = {
       external: {
         title: 'Remote resources (ATT)',
         infoText:
-          'Please insert Title and URL for the remote files. Qvain Light does not upload or store the files, but the URLs act as active links to the files.',
+          'Please insert Title, Use Category and URLs for the remote files. Qvain Light does not upload or store the files, but the URLs act as active links to the files. Access URL = link to the page where the link / license information is. Download URL = direct link to download the file.',
         help: 'Add link to remote files from here:',
         button: {
           label: 'Add link to remote files',
@@ -820,8 +820,14 @@ const english = {
             placeholder: 'Select option',
           },
           url: {
-            label: 'URL',
+            label: 'Access URL',
             placeholder: 'https://',
+            infoText: 'Page where the link to the file / license information can be found'
+          },
+          downloadUrl: {
+            label: 'Download URL',
+            placeholder: 'https://',
+            infoText: 'Direct link to start the download'
           },
           cancel: {
             label: 'Cancel',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -390,10 +390,13 @@ const finnish = {
         alreadyAdded: 'Tunniste on jo lisätty',
       },
       fieldOfScience: {
-        title: 'Tutkimusala',
+        title: 'Tieteenala',
         infoText:
           'Valitse tieteenala. Alasvetovalikkosa on Opetus- ja Kulttuuriministeriön mukainen luokitus tieteenaloille.',
         placeholder: 'Valitse vaihtoehto',
+        addButton: '+ Lisää tieteenala',
+        help:
+          'Voit lisätä useita tieteenaloja.',
       },
       keywords: {
         title: 'Avainsanat',
@@ -774,7 +777,7 @@ const finnish = {
       external: {
         title: 'Ulkoiset tiedostot (ATT)',
         infoText:
-          'Määritä tiedostolle otsikko, käyttökategoria (alasvetovalikosta) sekä, kerro, mistä tiedosto löytyy. Tiedosto ei ladata Qvain Lightiin, vaan antamasi URL toimii aktiivisena linkkinä ko. tiedostoon.',
+          'Määritä tiedostolle otsikko, käyttökategoria (alasvetovalikosta) sekä, kerro, mistä tiedosto / sen lisenssitieto löytyvät (sivun URL). Voit antaa myös suoran latauslinkin, jos sellainen on. Tiedostoa ei ladata Qvain Lightiin, vaan antamasi sivun URL toimii linkkinä sivulle, jossa tiedosto sijaitsee sekä tiedoston latauslinkin kauttaja pääsee suoraan aloittamaan tiedoston lataamisen omalle koneelleen.',
         help: 'Lisää linkkejä ulkoisiin tiedostoihin:',
         button: {
           label: 'Lisää linkki ulkoiseen tiedostoon',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -16,7 +16,7 @@ const finnish = {
     access_rights_description: {
       none: '',
       open: 'Kuka tahansa voi ladata datan.',
-      login: 'Käyttän pitää olla sisään kirjautunut ladatakseen datan.',
+      login: 'Käyttäjän pitää olla sisään kirjautunut ladatakseen datan.',
       embargo: 'Datan voi ladata vasta, kun embargo-pvm on ohitettu.',
       permit: 'Datan voi ladata ainoastaan hakemalla erillisen luvan lataamista varten. Luvan hakeminen vaatii kirjautumisen.',
       restricted: 'Data ei ladattavissa.'
@@ -629,9 +629,11 @@ const finnish = {
         useCategory: {
           required: 'Ulkoisen aineiston käyttökategoria on pakollinen kenttä.',
         },
-        url: {
-          required: 'Ulkoisen aineiston URL osoite on pakollinen kenttä.',
-          url: 'Ulkoisen aineiston URL osoitteen pitää olla oikeassa URL-formaatissa',
+        accessUrl: {
+          validFormat: 'Ulkoisen aineiston sivun URL pitää olla oikeassa URL-formaatissa.',
+        },
+        downloadUrl: {
+          validFormat: 'Ulkoisen aineiston latauslinkin URL pitää olla oikeassa URL-formaatissa.',
         },
       },
     },
@@ -820,9 +822,15 @@ const finnish = {
             label: 'Käyttökategoria',
             placeholder: 'Valitse vaihtoehto',
           },
-          url: {
-            label: 'URL',
+          accessUrl: {
+            label: 'Sivun URL',
             placeholder: 'https://',
+            infoText: 'Sivu, jossa tiedoston linkki ja tiedostoon mahdollisesti liittyvä lisenssitieto sijaitsevat'
+          },
+          downloadUrl: {
+            label: 'Latauslinkki',
+            placeholder: 'https://',
+            infoText: 'Linkki, jolla tiedoston saa ladattua suoraan omalle koneelle'
           },
           cancel: {
             label: 'Kumoa',

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -138,7 +138,7 @@ def remote_resources_data_to_metax(resources):
         metax_remote_resources_object["access_url"] = {}
         metax_remote_resources_object["download_url"] = {}
         metax_remote_resources_object["title"] = resource["title"]
-        metax_remote_resources_object["access_url"]["identifier"] = resource["url"]
+        metax_remote_resources_object["access_url"]["identifier"] = resource["accessUrl"]
         metax_remote_resources_object["download_url"]["identifier"] = resource["downloadUrl"]
         metax_remote_resources_object["use_category"]["identifier"] = resource["useCategory"]["value"]
         metax_remote_resources.append(metax_remote_resources_object)

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -136,8 +136,10 @@ def remote_resources_data_to_metax(resources):
         metax_remote_resources_object = {}
         metax_remote_resources_object["use_category"] = {}
         metax_remote_resources_object["access_url"] = {}
+        metax_remote_resources_object["download_url"] = {}
         metax_remote_resources_object["title"] = resource["title"]
         metax_remote_resources_object["access_url"]["identifier"] = resource["url"]
+        metax_remote_resources_object["download_url"]["identifier"] = resource["downloadUrl"]
         metax_remote_resources_object["use_category"]["identifier"] = resource["useCategory"]["value"]
         metax_remote_resources.append(metax_remote_resources_object)
     return metax_remote_resources


### PR DESCRIPTION
By accepting this PR, 
1) Etsin-finder will have new field download_url. which as name suggests, points to downloadable artifacts.
2) Modified translations