### PR TITLE
CSCFAIRMETA-482: Disable REMS button immediately if REMS is not enabled.

### DIFF
--- a/etsin_finder/frontend/__tests__/rems.test.jsx
+++ b/etsin_finder/frontend/__tests__/rems.test.jsx
@@ -45,7 +45,7 @@ describe('AskForAccess', () => {
 
 describe('REMSButton', () => {
   it('should render REMSButton as disabled', () => {
-    const wrapper = shallow(<REMSButton applicationState="Error" loading={false} />)
+    const wrapper = shallow(<REMSButton applicationState="disabled" loading={false} />)
     console.log(wrapper.debug())
     expect(wrapper.find('#rems-button-error').prop('disabled')).toEqual(true)
   })

--- a/etsin_finder/frontend/js/components/dataset/REMSButton.jsx
+++ b/etsin_finder/frontend/js/components/dataset/REMSButton.jsx
@@ -9,22 +9,6 @@ import Loader from '../general/loader'
 const REMSButton = props => {
   let button
   switch (props.applicationState) {
-    case 'Error':
-      button = (
-        <div aria-hidden="true" title={translate('dataset.access_unavailable')}>
-          <Button id="rems-button-error" disabled noMargin>
-            {props.loading ? (
-              <>
-                <Translate content="dataset.access_permission" />
-                <Loader color="white" active size="1.2em" />
-              </>
-            ) : (
-              <Translate content="dataset.access_permission" />
-            )}
-          </Button>
-        </div>
-      )
-      break
     case 'apply':
       button = (
         <Button id="rems-button-apply" onClick={props.onClick} noMargin>
@@ -113,6 +97,22 @@ const REMSButton = props => {
             <Translate content="dataset.access_denied" />
           )}
         </Button>
+      )
+      break
+    case 'disabled':
+      button = (
+        <div aria-hidden="true" title={translate('dataset.access_unavailable')}>
+          <Button id="rems-button-error" disabled noMargin>
+            {props.loading ? (
+              <>
+                <Translate content="dataset.access_permission" />
+                <Loader color="white" active size="1.2em" />
+              </>
+            ) : (
+              <Translate content="dataset.access_permission" />
+            )}
+          </Button>
+        </div>
       )
       break
     default:

--- a/etsin_finder/frontend/js/components/dataset/askForAccess.jsx
+++ b/etsin_finder/frontend/js/components/dataset/askForAccess.jsx
@@ -24,7 +24,7 @@ export class AskForAccess extends Component {
       })
       .catch(err => {
         console.log(err)
-        this.setState({ applicationState: 'Error' })
+        this.setState({ applicationState: 'disabled' })
       })
       .finally(() => {
         this.setState({ loading: false })

--- a/etsin_finder/rems_service.py
+++ b/etsin_finder/rems_service.py
@@ -216,7 +216,11 @@ def get_application_state_for_resource(cr, user_id):
         [string] -- The application state or False.
 
     """
-    state = 'apply'
+    _rems_api = RemsAPIService(app, user_id)
+    if _rems_api.ENABLED:
+        state = 'apply'
+    else:
+        return 'disabled'
     if not user_id or not cr:
         log.error('Failed to get user application state')
         return False
@@ -225,7 +229,7 @@ def get_application_state_for_resource(cr, user_id):
     if not pref_id:
         log.error('Could not get preferred identifier.')
         return False
-    _rems_api = RemsAPIService(app, user_id)
+
     user_applications = _rems_api.get_user_applications()
     if not isinstance(user_applications, list) or not user_applications:
         log.warning('Could not get any applications belonging to user.')


### PR DESCRIPTION
- Before the user could click the button once, and then it turned disabled.
  Now it is disabled from the start.
- Add check to backend that checks if REMS is enabled. and if not, sets
  the application state to 'disabled', which is checked in the frontend
  before rendering the button.
- No side effects.

How to test:
In your local environment disable REMS by editing app_config, and restart the server.
If you open a dataset that requires permission, the button should be disabled, and by hovering over it should say that you have to log in (if not logged in) or that it is disabled (if logged in).