### PR TITLE
CSCFAIRMETA-523: Update pref_id to rems_identifier

### DIFF
--- a/etsin_finder/cr_service.py
+++ b/etsin_finder/cr_service.py
@@ -224,6 +224,15 @@ def get_catalog_record_preferred_identifier(cr):
     """
     return cr.get('research_dataset', {}).get('preferred_identifier', '')
 
+def get_catalog_record_REMS_identifier(cr):
+    """
+    Get REMS identifier for a catalog record.
+
+    :param cr:
+    :return:
+    """
+    return cr.get('rems_identifier', '')
+
 
 def is_rems_catalog_record(catalog_record):
     """

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -288,7 +288,7 @@ class REMSApplyForPermission(Resource):
         log.info('rems_identifier: {0}'.format(rems_identifier))
         if not rems_identifier:
             log.warning('No rems_identifier found for resource: {0}'.format(pref_id))
-            return 'No rems_identifier found for resource', 500 
+            return 'No rems_identifier found for resource', 500
         res_get_catalogue_item = _rems_api.get_catalogue_item_for_resource(rems_identifier)
         log.debug('res_get_catalogue_item: {0}'.format(res_get_catalogue_item))
 

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -282,9 +282,14 @@ class REMSApplyForPermission(Resource):
         cr = cr_service.get_catalog_record(cr_id, False, False)
         if cr and cr_service.is_rems_catalog_record(cr):
             pref_id = cr_service.get_catalog_record_preferred_identifier(cr)
+            rems_identifier = cr_service.get_catalog_record_REMS_identifier(cr)
 
         log.info('Get catalog item id for resource: {0}'.format(pref_id))
-        res_get_catalogue_item = _rems_api.get_catalogue_item_for_resource(pref_id)
+        log.info('rems_identifier: {0}'.format(rems_identifier))
+        if not rems_identifier:
+            log.warning('No rems_identifier found for resource: {0}'.format(pref_id))
+            return 'No rems_identifier found for resource', 500 
+        res_get_catalogue_item = _rems_api.get_catalogue_item_for_resource(rems_identifier)
         log.debug('res_get_catalogue_item: {0}'.format(res_get_catalogue_item))
 
         if not res_get_catalogue_item:


### PR DESCRIPTION
- The use of pref_id in REMS is deprecated and changed to its own REMS
  identifier.
- Get catalog items with rems_identifier instead of pref_id. If there is
  no catalog item with the identifier, return error. This can happen to
  old rems catalogs that don't have the rems_identifier.
- Effects applying access ro REMS catalogs.