### PR TITLE
CSCFAIRMETA-32-fixes

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
@@ -85,6 +85,13 @@ class DataCatalog extends Component {
               errorMessage: undefined,
               fileOrigin: selection.label,
             })
+
+            // Uncheck useDoi checkbox if data catalog is ATT
+            if (selection.value === 'urn:nbn:fi:att:data-catalog-att') {
+              this.setState({
+                useDoi: false,
+              })
+            }
           }}
           onBlur={this.handleOnBlur}
           attributes={{ placeholder: 'qvain.files.dataCatalog.placeholder' }}
@@ -97,7 +104,8 @@ class DataCatalog extends Component {
               id="doiSelector"
               onChange={this.handleDoiCheckboxChange}
               disabled={(this.state.fileOrigin !== 'IDA' || original !== undefined)}
-              defaultChecked={this.state.useDoi || ((original !== undefined) && (dataCatalog === 'urn:nbn:fi:att:data-catalog-ida'))}
+              checked={this.state.useDoi}
+              // defaultChecked={this.state.useDoi || ((original !== undefined) && (dataCatalog === 'urn:nbn:fi:att:data-catalog-ida'))}
             />
             <DoiLabel
               htmlFor="doiSelector"

--- a/etsin_finder/frontend/js/components/qvain/files/external/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/external/externalFiles.jsx
@@ -70,11 +70,20 @@ export class ExternalFilesBase extends Component {
           {addedExternalResources.map((addedExternalResource) => (
             <ButtonGroup tabIndex="0" key={addedExternalResource.id}>
               <ButtonLabel>
-                {addedExternalResource.title} / {addedExternalResource.accessUrl.length > 40 ?
-                addedExternalResource.accessUrl.substring(0, 40).concat('... ') :
-                addedExternalResource.accessUrl} / {addedExternalResource.downloadUrl.length > 40 ?
-                addedExternalResource.downloadUrl.substring(0, 40).concat('... ') :
-                addedExternalResource.downloadUrl}
+                {addedExternalResource.title }
+                {
+                  (typeof(addedExternalResource.accessUrl) !== 'undefined') ? ((' / ' +
+                  (' / ' + addedExternalResource.accessUrl.length > 40 ?
+                  addedExternalResource.accessUrl.substring(0, 40).concat('... ') :
+                  addedExternalResource.accessUrl))) : null
+                }
+                {
+                  (typeof(addedExternalResource.downloadUrl) !== 'undefined') ? ((' / ' +
+                  (' / ' + addedExternalResource.downloadUrl.length > 40 ?
+                  addedExternalResource.downloadUrl.substring(0, 40).concat('... ') :
+                  addedExternalResource.downloadUrl))) : null
+                }
+
               </ButtonLabel>
               <ButtonContainer>
                 <EditButton

--- a/etsin_finder/frontend/js/components/qvain/files/external/externalFiles.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/external/externalFiles.jsx
@@ -72,16 +72,19 @@ export class ExternalFilesBase extends Component {
               <ButtonLabel>
                 {addedExternalResource.title }
                 {
-                  (typeof(addedExternalResource.accessUrl) !== 'undefined') ? ((' / ' +
+                  // Disable lint rule because this syntax is more readable using concatenation
+                  /* eslint-disable prefer-template */
+                  (typeof addedExternalResource.accessUrl !== 'undefined') ? ((' / ' +
                   (' / ' + addedExternalResource.accessUrl.length > 40 ?
                   addedExternalResource.accessUrl.substring(0, 40).concat('... ') :
                   addedExternalResource.accessUrl))) : null
                 }
                 {
-                  (typeof(addedExternalResource.downloadUrl) !== 'undefined') ? ((' / ' +
+                  (typeof addedExternalResource.downloadUrl !== 'undefined') ? ((' / ' +
                   (' / ' + addedExternalResource.downloadUrl.length > 40 ?
                   addedExternalResource.downloadUrl.substring(0, 40).concat('... ') :
                   addedExternalResource.downloadUrl))) : null
+                  /* eslint-enable prefer-template */
                 }
 
               </ButtonLabel>

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -343,6 +343,11 @@ class Qvain {
   setDataCatalog = selectedDataCatalog => {
     this.dataCatalog = selectedDataCatalog
     this.changed = true
+
+    // Remove useDoi if dataCatalog is ATT
+    if (selectedDataCatalog === 'urn:nbn:fi:att:data-catalog-att') {
+      this.useDoi = false
+    }
   }
 
   @action

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -327,7 +327,7 @@ const finnish = {
       140: 'Saatavilla'
     },
     useDoiHeader: 'DOI-tunnisten luominen',
-    useDoiContent: 'Olet pyytänyt aineistollesi pysyväksi tunnisteeksi DOIn URN-tunnisteen sijaan. DOI vaatii määrittelyn julkaisupäivämäärän ja julkaisijan. DOI-tunniste rekisteröidään DataCite-palvelun tietokantaan, eikä toimintoa voi peruuttaa. Oletko varma?',
+    useDoiContent: 'Olet pyytänyt aineistollesi pysyväksi tunnisteeksi DOIn URN-tunnisteen sijaan. DOI vaatii, että julkaisupäivämäärä ja julkaisija on määritelty. DOI-tunniste rekisteröidään DataCite-palvelun tietokantaan, eikä toimintoa voi peruuttaa. Oletko varma?',
     useDoiAffirmative: 'Kyllä',
     useDoiNegative: 'Ei',
     unsuccessfullLogin: 'Kirjautuminen epäonnistui.',


### PR DESCRIPTION
**CSCFAIRMETA-527: Fix translation typo**

**CSCFAIRMETA-528: Error handling for remote resource URLs**
- If the URL variables were left empty and then published, the dataset would crash
- Error handling added

**CSCFAIRMETA-529: Uncheck use DOI for remote resources**
- DOI should not be available for remote resources
- Uncheck in local state and in data store