### PR TITLE
CSCFAIRMETA-530 & 537: [FIX] Issued date validation fix + typo fixes

### DIFF
--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -326,7 +326,7 @@ const finnish = {
       130: 'Siirto katkesi',
       140: 'Saatavilla'
     },
-    useDoiHeader: 'DOI-tunnisten luominen',
+    useDoiHeader: 'DOI-tunnisteen luominen',
     useDoiContent: 'Olet pyytänyt aineistollesi pysyväksi tunnisteeksi DOIn URN-tunnisteen sijaan. DOI vaatii, että julkaisupäivämäärä ja julkaisija on määritelty. DOI-tunniste rekisteröidään DataCite-palvelun tietokantaan, eikä toimintoa voi peruuttaa. Oletko varma?',
     useDoiAffirmative: 'Kyllä',
     useDoiNegative: 'Ei',
@@ -670,7 +670,7 @@ const finnish = {
           'Ennenkuin pääset linkittämään tiedostoja aineistoosi, sinun tulee valita, linkitätkö tiedostoja IDAsta vai annatko ulkopuolisen palvelun URL-osoitteet, joista tiedostot löytyvät.',
         explanation:
           'Valitse "IDA", jos tiedostot on tallennettu Fairdata IDA -palveluun. Valitse "Ulkoinen lähde" jos tiedostot sijaitsevat muualla.',
-        doiSelection: 'Haluan aineistolleni DOI -tunnusteen (digital object identifier) URN - tunnusteen sijaan.',
+        doiSelection: 'Haluan aineistolleni DOI -tunnisteen (digital object identifier) URN - tunnisteen sijaan.',
         placeholder: 'Valitse vaihtoehto',
         ida: 'IDA',
         att: 'Ulkoinen lähde',

--- a/etsin_finder/qvain_light_resources.py
+++ b/etsin_finder/qvain_light_resources.py
@@ -275,7 +275,7 @@ class QvainDataset(Resource):
     @log_request
     def patch(self):
         """
-        Updete existing detaset.
+        Update existing dataset.
 
         Returns:
             object -- The response from metax or if error an error message.

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -310,7 +310,7 @@ def edited_data_to_metax(data, original):
         "curator": alter_role_data(data["actors"], "curator"),
         "rights_holder": alter_role_data(data["actors"], "rights_holder"),
         "contributor": alter_role_data(data["actors"], "contributor"),
-        "issued": data["issuedDate"],
+        "issued": data["issuedDate"] if "issuedDate" in data else "",
         "other_identifier": other_identifiers_to_metax(data["identifiers"]),
         "field_of_science": _to_metax_field_of_science(data.get("fieldOfScience")),
         "keyword": data["keywords"],


### PR DESCRIPTION
- CSCFAIRMETA-530: Bug fix: Issued date now allows for empty values when updating a dataset, this should be possible if the dataset isn't a DOI dataset
- CSCFAIRMETA-537: Small typo fixes