### PR TITLE
CSCFAIRMETA-532 & 533: [FIX] Add useDoi to data store

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/dataCatalog.jsx
@@ -105,7 +105,6 @@ class DataCatalog extends Component {
               onChange={this.handleDoiCheckboxChange}
               disabled={(this.state.fileOrigin !== 'IDA' || original !== undefined)}
               checked={this.state.useDoi}
-              // defaultChecked={this.state.useDoi || ((original !== undefined) && (dataCatalog === 'urn:nbn:fi:att:data-catalog-ida'))}
             />
             <DoiLabel
               htmlFor="doiSelector"

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -692,7 +692,7 @@ class Qvain {
       this.license = undefined
     }
 
-    // restriction grounds
+    // Restriction grounds
     const rg = researchDataset.access_rights.restriction_grounds
       ? researchDataset.access_rights.restriction_grounds[0]
       : undefined
@@ -727,15 +727,22 @@ class Qvain {
     }
     this.actors = this.mergeTheSameActors(actors)
 
-    // load data catalog
+    // Load data catalog
     this.dataCatalog =
       dataset.data_catalog !== undefined ? dataset.data_catalog.identifier : undefined
 
-    // load preservation state
+    // Load preservation state
     this.preservationState = dataset.preservation_state
 
-    // load cumulative state
+    // Load cumulative state
     this.cumulativeState = dataset.cumulative_state
+
+    // Load DOI
+    if (researchDataset.preferred_identifier.startsWith('doi')) {
+      this.useDoi = true
+    } else {
+      this.useDoi = false
+    }
 
     // Load files
     const dsFiles = researchDataset.files
@@ -782,7 +789,7 @@ class Qvain {
 
     this.Files.editDataset(dataset)
 
-    // external resources
+    // External resources
     const remoteResources = researchDataset.remote_resources
     if (remoteResources !== undefined) {
       this.externalResources = remoteResources.map(r =>


### PR DESCRIPTION
- The app should be aware of the DOI status of an existing dataset
- Add DOI status to the React store, which solves CSCFAIRMETA-532 and CSCFAIRMETA-533 issues where the user could remove issued date and publisher for DOI datasets and update the dataset, causing the app to crash