### PR TITLE
CSCFAIRMETA-549: Fix error updating dataset

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/index.jsx
@@ -144,7 +144,8 @@ class Qvain extends Component {
       console.error(err)
     }
     this.setState({
-      response: getResponseError(err)
+      response: getResponseError(err),
+      datasetLoading: false,
     })
   }
 

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -47,10 +47,10 @@ def alter_role_data(actor_list, role):
 
     """
     actors = []
-    actor_list_with_role = [x for x in actor_list if role in x["roles"] ]
+    actor_list_with_role = [x for x in actor_list if role in x.get("roles", []) ]
     for actor_object in actor_list_with_role:
         actor_object = deepcopy(actor_object)
-        organizations = actor_object["organizations"]
+        organizations = actor_object.get("organizations", [])
 
         for org in organizations:
             org["@type"] = "Organization"
@@ -63,17 +63,16 @@ def alter_role_data(actor_list, role):
             organization = org
 
         if actor_object["type"] == "person":
-            person = actor_object["person"]
+            person = actor_object.get("person", {})
             actor = {
                 "@type": "Person",
-                "name": person["name"]
+                "name": person.get("name")
             }
             if "email" in person:
-                actor["email"] = person["email"]
+                actor["email"] = person.get("email")
             if "identifier" in person:
-                actor["identifier"] = person["identifier"]
+                actor["identifier"] = person.get("identifier")
 
-            actor["identifier"] = actor_object["person"]["identifier"]
             actor["member_of"] = organization
         else:
             actor = organization


### PR DESCRIPTION
- There was an unhandled error updating older datasets. The cause was some
  duplicate code where an object key was eventually not checked if it
  existed.
- remove line actor_object["person"]["identifier"] in qvain_light_utils.py
  since it is already done in the conditional above. This line caused a
  KeyError if the actor person did  not have an identifier. Also refactored
  the function to use the 'get' method to get dict attributes because it does
  not throw an error and crash if the attribute is not present.
- no side effects