### PR TITLE
CSCFAIRMETA-556: Enable babel-plugin-styled-components

### DIFF
--- a/etsin_finder/frontend/.babelrc
+++ b/etsin_finder/frontend/.babelrc
@@ -1,7 +1,13 @@
 {
   "env": {
+    "development": {
+      "plugins": [
+        ["babel-plugin-styled-components"]
+      ]
+    },
     "test": {
       "plugins": [
+        ["babel-plugin-styled-components"],
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }],
         "@babel/plugin-syntax-dynamic-import",
@@ -14,6 +20,7 @@
     }
   },
   "plugins": [
+    ["babel-plugin-styled-components", { "displayName": false }],
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
     "@loadable/babel-plugin",

--- a/etsin_finder/frontend/__tests__/__snapshots__/filterSection.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/filterSection.test.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FilterSection should render <FilterSection /> 1`] = `
-<styled.li>
-  <styled.button
+<filterSection__Section>
+  <filterSection__FilterCategory
     aria-expanded={false}
     onClick={[Function]}
   >
@@ -37,8 +37,8 @@ exports[`FilterSection should render <FilterSection /> 1`] = `
       title=""
       transform={null}
     />
-  </styled.button>
-  <styled.div
+  </filterSection__FilterCategory>
+  <filterSection__FilterItems
     aria-hidden={true}
     className=""
   >
@@ -61,6 +61,6 @@ exports[`FilterSection should render <FilterSection /> 1`] = `
     <inject-PasCheckBox-with-Stores
       aggr="data_catalog"
     />
-  </styled.div>
-</styled.li>
+  </filterSection__FilterItems>
+</filterSection__Section>
 `;

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.actors.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.actors.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Qvain.Actors should render correctly 1`] = `
 <div
   className="container"
 >
-  <styled.h2>
+  <title__SectionTitle>
     <Translate
       component="span"
       content="qvain.actors.title"
@@ -20,12 +20,12 @@ exports[`Qvain.Actors should render correctly 1`] = `
         onClick={[Function]}
       />
     </Tooltip>
-  </styled.h2>
+  </title__SectionTitle>
   <inject-ActorModalBase-with-Stores />
-  <styled.div>
+  <card__Container>
     <inject-AddedActorsBase-with-Stores />
-    <styled.div>
-      <Styled(styled.button)
+    <actors__ButtonContainer>
+      <actors__AddNewButton
         disabled={false}
         onClick={[Function]}
         type="button"
@@ -34,9 +34,9 @@ exports[`Qvain.Actors should render correctly 1`] = `
           component="span"
           content="qvain.actors.addButton"
         />
-      </Styled(styled.button)>
-    </styled.div>
-  </styled.div>
+      </actors__AddNewButton>
+    </actors__ButtonContainer>
+  </card__Container>
 </div>
 `;
 

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
@@ -2,36 +2,27 @@
 
 exports[`Qvain dataset list PreservationStates should render <TablePasState /> 1`] = `
 <Fragment>
-  <Styled(styled.div)
+  <tablePasState__PasLabel
     color="primary"
   >
     PAS
-  </Styled(styled.div)>
+  </tablePasState__PasLabel>
   <Translate
     component={
       Object {
         "$$typeof": Symbol(react.forward_ref),
         "attrs": Array [],
         "componentStyle": ComponentStyle {
-          "componentId": "sc-fgfRvd",
+          "componentId": "tablePasState__PasText-sc-1w7mbwe-1",
           "isStatic": true,
           "rules": Array [
-            "
-  margin-left: 10px;
-  font-size: 0.8em;
-  :before {
-    content: '(';
-  }
-  :after {
-    content: ')';
-  }
-",
+            "margin-left:10px;font-size:0.8em;:before{content:'(';}:after{content:')';}",
           ],
         },
-        "displayName": "styled.span",
+        "displayName": "tablePasState__PasText",
         "foldedComponentIds": Array [],
         "render": [Function],
-        "styledComponentId": "sc-fgfRvd",
+        "styledComponentId": "tablePasState__PasText-sc-1w7mbwe-1",
         "target": "span",
         "toString": [Function],
         "warnTooManyClasses": [Function],
@@ -53,7 +44,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
 <div
   className="container"
 >
-  <styled.h2>
+  <title__SectionTitle>
     <Translate
       component="span"
       content="qvain.description.title"
@@ -69,7 +60,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
         onClick={[Function]}
       />
     </Tooltip>
-  </styled.h2>
+  </title__SectionTitle>
   <inject-DescriptionField-with-Stores />
   <inject-IssuedDateField-with-Stores />
   <inject-OtherIdentifierField-with-Stores />
@@ -572,14 +563,14 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
 
 exports[`Qvain.RightsAndLicenses should render <AccessType /> 1`] = `
 <Card>
-  <styled.label
+  <form__LabelLarge
     htmlFor="accessTypeSelect"
   >
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.accessType.title"
     />
-  </styled.label>
+  </form__LabelLarge>
   <Translate
     attributes={
       Object {
@@ -601,20 +592,20 @@ exports[`Qvain.RightsAndLicenses should render <AccessType /> 1`] = `
       }
     }
   />
-  <styled.p />
+  <validationError__ValidationError />
 </Card>
 `;
 
 exports[`Qvain.RightsAndLicenses should render <Licenses /> 1`] = `
 <Card>
-  <styled.label
+  <form__LabelLarge
     htmlFor="licenseSelect"
   >
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.license.title"
     />
-  </styled.label>
+  </form__LabelLarge>
   <Translate
     attributes={
       Object {
@@ -643,7 +634,7 @@ exports[`Qvain.RightsAndLicenses should render <RightsAndLicenses /> 1`] = `
 <div
   className="container"
 >
-  <styled.h2>
+  <title__SectionTitle>
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.title"
@@ -659,7 +650,7 @@ exports[`Qvain.RightsAndLicenses should render <RightsAndLicenses /> 1`] = `
         onClick={[Function]}
       />
     </Tooltip>
-  </styled.h2>
+  </title__SectionTitle>
   <inject-License-with-Stores />
   <inject-AccessType-with-Stores />
 </div>

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
@@ -10,7 +10,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
 <div
   className="container"
 >
-  <styled.h2>
+  <title__SectionTitle>
     <Translate
       component="span"
       content="qvain.description.title"
@@ -26,7 +26,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
         onClick={[Function]}
       />
     </Tooltip>
-  </styled.h2>
+  </title__SectionTitle>
   <inject-DescriptionField-with-Stores />
   <inject-IssuedDateField-with-Stores />
   <inject-OtherIdentifierField-with-Stores />
@@ -529,14 +529,14 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
 
 exports[`Qvain.RightsAndLicenses should render <AccessType /> 1`] = `
 <Card>
-  <styled.label
+  <form__LabelLarge
     htmlFor="accessTypeSelect"
   >
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.accessType.title"
     />
-  </styled.label>
+  </form__LabelLarge>
   <Translate
     attributes={
       Object {
@@ -558,20 +558,20 @@ exports[`Qvain.RightsAndLicenses should render <AccessType /> 1`] = `
       }
     }
   />
-  <styled.p />
+  <validationError__ValidationError />
 </Card>
 `;
 
 exports[`Qvain.RightsAndLicenses should render <Licenses /> 1`] = `
 <Card>
-  <styled.label
+  <form__LabelLarge
     htmlFor="licenseSelect"
   >
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.license.title"
     />
-  </styled.label>
+  </form__LabelLarge>
   <Translate
     attributes={
       Object {
@@ -600,7 +600,7 @@ exports[`Qvain.RightsAndLicenses should render <RightsAndLicenses /> 1`] = `
 <div
   className="container"
 >
-  <styled.h2>
+  <title__SectionTitle>
     <Translate
       component="span"
       content="qvain.rightsAndLicenses.title"
@@ -616,7 +616,7 @@ exports[`Qvain.RightsAndLicenses should render <RightsAndLicenses /> 1`] = `
         onClick={[Function]}
       />
     </Tooltip>
-  </styled.h2>
+  </title__SectionTitle>
   <inject-License-with-Stores />
   <inject-AccessType-with-Stores />
 </div>

--- a/etsin_finder/frontend/package.json
+++ b/etsin_finder/frontend/package.json
@@ -79,6 +79,7 @@
     "axios-mock-adapter": "^1.17.0",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
+    "babel-plugin-styled-components": "^1.10.7",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.4",


### PR DESCRIPTION
Improves development experience by giving styled components and the related CSS styles readable names.