### PR TITLE
CSCFAIRMETA-556: Disable minification for babel-plugin-styled-components

### DIFF
--- a/etsin_finder/frontend/.babelrc
+++ b/etsin_finder/frontend/.babelrc
@@ -2,12 +2,12 @@
   "env": {
     "development": {
       "plugins": [
-        ["babel-plugin-styled-components"]
+        ["babel-plugin-styled-components", { "minify": false }]
       ]
     },
     "test": {
       "plugins": [
-        ["babel-plugin-styled-components"],
+        ["babel-plugin-styled-components", { "minify": false }],
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }],
         "@babel/plugin-syntax-dynamic-import",
@@ -20,7 +20,7 @@
     }
   },
   "plugins": [
-    ["babel-plugin-styled-components", { "displayName": false }],
+    ["babel-plugin-styled-components", { "displayName": false, "minify": false }],
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
     "@loadable/babel-plugin",

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
@@ -16,7 +16,16 @@ exports[`Qvain dataset list PreservationStates should render <TablePasState /> 1
           "componentId": "tablePasState__PasText-sc-1w7mbwe-1",
           "isStatic": true,
           "rules": Array [
-            "margin-left:10px;font-size:0.8em;:before{content:'(';}:after{content:')';}",
+            "
+  margin-left: 10px;
+  font-size: 0.8em;
+  :before {
+    content: '(';
+  }
+  :after {
+    content: ')';
+  }
+",
           ],
         },
         "displayName": "tablePasState__PasText",


### PR DESCRIPTION
The CSS minification enabled by default in the plugin seems to negatively affect some of the styles used in the old filepicker, and it's not entirely obvious why. It's probably better to disable the minification for now, as it wasn't the main point of installing the plugin anyways.