### PR TITLE
CSCFAIRMETA-588: Only owner can view draft in Etsin

### DIFF
--- a/etsin_finder/authentication.py
+++ b/etsin_finder/authentication.py
@@ -131,7 +131,6 @@ def get_user_csc_name():
     csc_name = session.get('samlUserdata', {}).get(SAML_ATTRIBUTES.get('CSC_username', None), False)
 
     return csc_name[0] if csc_name else not_found('csc_name')
-    return None
 
 
 def get_user_haka_identifier():

--- a/etsin_finder/cr_service.py
+++ b/etsin_finder/cr_service.py
@@ -254,7 +254,7 @@ def is_draft(catalog_record):
     :param catalog_record:
     :return:
     """
-    if catalog_record.get('state', 'draft'):
+    if catalog_record.get('state') == 'draft':
         return True
     return False
 

--- a/etsin_finder/cr_service.py
+++ b/etsin_finder/cr_service.py
@@ -247,6 +247,31 @@ def is_rems_catalog_record(catalog_record):
     return False
 
 
+def is_draft(catalog_record):
+    """
+    Is the catalog record a draft or not.
+
+    :param catalog_record:
+    :return:
+    """
+    if catalog_record.get('state', 'draft'):
+        return True
+    return False
+
+
+def is_catalog_record_owner(catalog_record, user_id):
+    """
+    Does user_id own catalog_record.
+
+    :param catalog_record:
+    :param user_id:
+    :return:
+    """
+    if catalog_record.get('metadata_provider_user') == user_id:
+        return True
+    return False
+
+
 def _get_cr_from_metax(cr_id, check_removed_if_not_exist):
     cr = _metax_api.get_catalog_record_with_file_details(cr_id)
     if not cr and check_removed_if_not_exist:

--- a/etsin_finder/frontend/js/components/dataset/description.jsx
+++ b/etsin_finder/frontend/js/components/dataset/description.jsx
@@ -84,19 +84,20 @@ class Description extends Component {
   }
 
   render() {
+    const versions = this.props.dataset.dataset_version_set
+    const datasetIdentifier = this.props.dataset.identifier
+    const isVersion = versions && versions.length > 0 && versions.some(version => version.identifier === datasetIdentifier)
+
     return (
       <div className="dsContent">
         <Labels>
           <Flex>
-            {this.props.dataset.data_catalog.catalog_json.dataset_versioning &&
-              this.props.dataset.dataset_version_set &&
-              this.props.dataset.dataset_version_set[0] &&
-              this.props.dataset.dataset_version_set.length > 1 && (
-                <VersionChanger
-                  versionSet={this.props.dataset.dataset_version_set}
-                  idn={this.props.dataset.identifier}
-                />
-              )}
+            {this.props.dataset.data_catalog.catalog_json.dataset_versioning && isVersion && (
+              <VersionChanger
+                versionSet={versions}
+                idn={datasetIdentifier}
+              />
+            )}
             {(this.props.dataset.data_catalog.catalog_json.identifier ===
               'urn:nbn:fi:att:data-catalog-pas' ||
               this.props.dataset.preservation_state === 80) && (
@@ -123,7 +124,7 @@ class Description extends Component {
             <ErrorBoundary>
               {this.checkEmails(this.props.emails) && !this.props.harvested && (
                 <Contact
-                  datasetID={this.props.dataset.identifier}
+                  datasetID={datasetIdentifier}
                   emails={this.props.emails}
                   // TEMPORARY: rems check won't be needed in contact later.
                   isRems={
@@ -133,7 +134,7 @@ class Description extends Component {
                 />
               )}
             </ErrorBoundary>
-            <AskForAccess cr_id={this.props.dataset.identifier} />
+            <AskForAccess cr_id={datasetIdentifier} />
           </Flex>
         </Labels>
         <section>

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -264,7 +264,7 @@ def get_dataset_creator(cr_id):
     Get creator of dataset.
 
     Arguments:
-        cr_id {string} -- Identifier of datset.
+        cr_id {string} -- Identifier of dataset.
 
     Returns:
         [type] -- [description]

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -80,6 +80,10 @@ class Dataset(Resource):
         if not cr:
             abort(400, message="Unable to get catalog record from Metax")
 
+        user_id = authentication.get_user_id()
+        if cr_service.is_draft(cr) and not cr_service.is_catalog_record_owner(cr, user_id):
+            abort(404)
+
         # Sort data items
         sort_array_of_obj_by_key(cr.get('research_dataset', {}).get('remote_resources', []), 'title')
         sort_array_of_obj_by_key(cr.get('research_dataset', {}).get('directories', []), 'details', 'directory_name')
@@ -88,7 +92,7 @@ class Dataset(Resource):
         ret_obj = {'catalog_record': authorization.strip_information_from_catalog_record(cr, is_authd),
                    'email_info': get_email_info(cr)}
         if cr_service.is_rems_catalog_record(cr) and is_authd and get_fairdata_rems_api_config(app.testing) is not None:
-            state = rems_service.get_application_state_for_resource(cr, authentication.get_user_id())
+            state = rems_service.get_application_state_for_resource(cr, user_id)
             ret_obj['application_state'] = state
             ret_obj['has_permit'] = state == 'approved'
 
@@ -119,6 +123,10 @@ class DatasetMetadata(Resource):
         if not cr:
             abort(400, message="Unable to get catalog record")
 
+        user_id = authentication.get_user_id()
+        if cr_service.is_draft(cr) and not cr_service.is_catalog_record_owner(cr, user_id):
+            abort(404)
+
         return download_metadata(cr_id, metadata_format)
 
 class Files(Resource):
@@ -146,6 +154,10 @@ class Files(Resource):
 
         cr = cr_service.get_catalog_record(cr_id, False, False)
         dir_api_obj = cr_service.get_directory_data_for_catalog_record(cr_id, dir_id, file_fields, directory_fields)
+
+        user_id = authentication.get_user_id()
+        if cr_service.is_draft(cr) and not cr_service.is_catalog_record_owner(cr, user_id):
+            abort(404)
 
         if cr and dir_api_obj:
             # Sort the items
@@ -208,6 +220,10 @@ class Contact(Resource):
 
         # Get the full catalog record from Metax
         cr = cr_service.get_catalog_record(cr_id, False, False)
+
+        user_id = authentication.get_user_id()
+        if cr_service.is_draft(cr) and not cr_service.is_catalog_record_owner(cr, user_id):
+            abort(404)
 
         # Ensure dataset is not harvested
         harvested = get_harvest_info(cr)


### PR DESCRIPTION
* Limit access to draft dataset and related Etsin views so only the owner can access them
* Also fixes bug where unpublished new version fails in Etsin due to not being in its own dataset_version_set