### PR TITLE
CSCFAIRMETA-514: Add subject heading links

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/index.jsx
@@ -86,13 +86,27 @@ class Sidebar extends Component {
     return null
   }
 
-  keywordsAndTheme() {
+  keywords() {
     const labels = []
-    if (this.state.theme) {
-      labels.push(...this.state.theme.map((theme) => checkDataLang(theme.pref_label)))
-    }
     if (this.state.keyword) labels.push(...this.state.keyword)
     return labels.join(', ')
+  }
+
+  subjectHeading() {
+    const labels = []
+    if (this.state.theme) {
+    labels.push(...this.state.theme.map((theme) => (
+      <SubjectHeaderLink
+        href={theme.identifier}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={theme.identifier}
+      >
+        {checkDataLang(theme.pref_label)}
+      </SubjectHeaderLink>
+      )))
+    }
+    return labels
   }
 
   render() {
@@ -156,7 +170,13 @@ class Sidebar extends Component {
             {/* KEYWORDS */}
 
             <SidebarItem component="dd" trans="dataset.keywords" hideEmpty="true">
-              {this.keywordsAndTheme()}
+              {this.keywords()}
+            </SidebarItem>
+
+            {/* SUBJECT HEADING */}
+
+            <SidebarItem component="dd" trans="dataset.subjectHeading" hideEmpty="true">
+              {this.subjectHeading()}
             </SidebarItem>
 
             {/* LANGUAGE */}
@@ -356,6 +376,10 @@ const HorizontalLine = styled.hr`
   border-style: solid;
   border-color: ${(props) => props.theme.color.lightgray};
   margin: 20px 0;
+`
+
+const SubjectHeaderLink = styled.a`
+  display: block;
 `
 
 const ListItem = styled.dd``

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -159,6 +159,7 @@ const english = {
     issued: 'Release date',
     modified: 'Dataset modification date',
     keywords: 'Keywords',
+    subjectHeading: 'Subject heading',
     license: 'License',
     loading: 'Loading dataset',
     harvested: 'Harvested',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -161,6 +161,7 @@ const finnish = {
     harvested: 'Haravoitu',
     cumulative: 'Kumulatiivinen',
     keywords: 'Avainsanat',
+    subjectHeading: 'Asiasanat',
     license: 'Lisenssi',
     loading: 'Ladataan aineistoa',
     go_to_original: 'Siirry alkuperäiseen',


### PR DESCRIPTION
- The subject heading words where previously mixed with keywords and
  only represented as text. Now they have their own field and they are
  links to the correct koko ontology.
- Created new field for the subject headings if present.
- No side effects.