### PR TITLE
CSCFAIRMETA-649: Fix overlapping navigation buttons

### DIFF
--- a/etsin_finder/frontend/js/layout/header.jsx
+++ b/etsin_finder/frontend/js/layout/header.jsx
@@ -76,6 +76,7 @@ const Positioner = styled.div`
 `
 
 const NaviCont = styled.nav`
+  margin-left: auto;
   display: none;
   justify-content: center;
   align-items: center;
@@ -83,10 +84,13 @@ const NaviCont = styled.nav`
   @media screen and (min-width: ${p => p.theme.breakpoints.lg}) {
     display: flex;
   }
+
+  @media screen and (min-width: ${p => p.theme.breakpoints.xl}) {
+    margin-right: 4em;
+  }
 `
 
 const Right = styled.nav`
-  width: 12em;
   display: flex;
   justify-content: flex-end;
   align-items: center;


### PR DESCRIPTION
A nav element in the header had a fixed width that was smaller than the size of its contents. This caused navigation elements to overlap when window width was between 992 and 1200 px and language was set to Finnish.