### PR TITLE
CSCFAIRMETA-651: Implement cookie notification message

### DIFF
--- a/etsin_finder/frontend/js/layout/cookiesNotification.jsx
+++ b/etsin_finder/frontend/js/layout/cookiesNotification.jsx
@@ -1,34 +1,58 @@
-import React from 'react'
+import React, { Component } from 'react'
 import styled from 'styled-components'
 import Translate from 'react-translate-component'
+import counterpart from 'counterpart'
 
 import Button from '../components/general/button'
 
 
-const CookiesNotification = () => {
-  const handleAcceptCookies = () =>
-    console.log('Cookies accepted')
+class CookiesNotification extends Component {
+  state = {
+    visible: !localStorage.getItem('cookiesAccepted'),
+  }
 
-  const isVisible = () => true
+  componentDidMount() {
+    counterpart.onLocaleChange(this.onLanguageChange)
+  }
 
-  return (
-    <Notification visible={isVisible()}>
-      <div className="container row no-gutters">
-        <div className="col-12 col-lg-7">
-          <Translate component="p" content="general.cookies.infoText" />
-          <a href="#"><Translate content="general.cookies.linkText" /></a>
+  componentWillUnmount() {
+    counterpart.offLocaleChange(this.onLanguageChange)
+  }
+
+  onLanguageChange = () => {
+    this.setState({
+      lang: counterpart.getLocale(),
+    })
+  }
+
+  getPrivacyUrl() {
+    return this.state.lang === 'en'
+      ? 'https://www.fairdata.fi/en/contracts-and-privacy/'
+      : 'https://www.fairdata.fi/sopimukset/'
+  }
+
+  handleAcceptCookies = () => {
+    localStorage.setItem('cookiesAccepted', true)
+    this.setState({ visible: false })
+  }
+
+  render() {
+    return (
+      <Notification visible={this.state.visible}>
+        <div className="container row no-gutters">
+          <div className="col-12 col-md-9">
+            <Translate component="p" content="general.cookies.infoText" />
+            <a href={this.getPrivacyUrl()} target="_blank" rel="noopener noreferrer"><Translate content="general.cookies.link" /></a>
+          </div>
+          <Actions className="col-12 col-md-3">
+            <Button onClick={this.handleAcceptCookies}>
+              <Translate content="general.cookies.accept" />
+            </Button>
+          </Actions>
         </div>
-        <Actions className="col-12 col-lg-5">
-          <Button>
-            <Translate content="general.cookies.settings" />
-          </Button>
-          <Button onClick={handleAcceptCookies}>
-            <Translate content="general.cookies.accept" />
-          </Button>
-        </Actions>
-      </div>
-    </Notification>
-  )
+      </Notification>
+    )
+  }
 }
 
 const Notification = styled.div`

--- a/etsin_finder/frontend/js/layout/cookiesNotification.jsx
+++ b/etsin_finder/frontend/js/layout/cookiesNotification.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
+import Translate from 'react-translate-component'
+
 import Button from '../components/general/button'
 
 
@@ -13,14 +15,16 @@ const CookiesNotification = () => {
     <Notification visible={isVisible()}>
       <div className="container row no-gutters">
         <div className="col-12 col-lg-7">
-          <p>
-            By using Fairdata’s services you agree to our Cookies Use. We use cookies to improve your experience and make our services work better.<br />
-            <a href="#">View the Fairdata Privacy Policy.</a>
-          </p>
+          <Translate component="p" content="general.cookies.infoText" />
+          <a href="#"><Translate content="general.cookies.linkText" /></a>
         </div>
         <Actions className="col-12 col-lg-5">
-          <Button>Cookie Settings</Button>
-          <Button onClick={handleAcceptCookies}>Accept all cookies</Button>
+          <Button>
+            <Translate content="general.cookies.settings" />
+          </Button>
+          <Button onClick={handleAcceptCookies}>
+            <Translate content="general.cookies.accept" />
+          </Button>
         </Actions>
       </div>
     </Notification>

--- a/etsin_finder/frontend/js/layout/cookiesNotification.jsx
+++ b/etsin_finder/frontend/js/layout/cookiesNotification.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import styled from 'styled-components'
+import Button from '../components/general/button'
+
+
+const CookiesNotification = () => {
+  const handleAcceptCookies = () =>
+    console.log('Cookies accepted')
+
+  const isVisible = () => true
+
+  return (
+    <Notification visible={isVisible()}>
+      <div className="container row no-gutters">
+        <div className="col-12 col-lg-7">
+          <p>
+            By using Fairdata’s services you agree to our Cookies Use. We use cookies to improve your experience and make our services work better.<br />
+            <a href="#">View the Fairdata Privacy Policy.</a>
+          </p>
+        </div>
+        <Actions className="col-12 col-lg-5">
+          <Button>Cookie Settings</Button>
+          <Button onClick={handleAcceptCookies}>Accept all cookies</Button>
+        </Actions>
+      </div>
+    </Notification>
+  )
+}
+
+const Notification = styled.div`
+  display: ${props => (props.visible ? 'flex' : 'none')};
+  position: fixed;
+  justify-content: center;
+  align-items: center;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #F3F2F1;
+  padding: 2rem 3rem;
+
+  p {
+    margin: 0;
+  }
+`
+
+const Actions = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-evenly;
+
+  @media only screen and (max-width: 992px) {
+    padding-top: 1.5rem;
+  }
+
+  @media only screen and (max-width: 576px) {
+    padding: .5rem;
+    flex-direction: column;
+    align-items: initial;
+  }
+`
+
+export default CookiesNotification

--- a/etsin_finder/frontend/js/layout/index.jsx
+++ b/etsin_finder/frontend/js/layout/index.jsx
@@ -19,6 +19,7 @@ import SkipToContent from '../components/general/skipToContent'
 import Header from './header'
 import Footer from './footer'
 import Content from './content'
+import CookiesNotification from './cookiesNotification'
 
 export default class Layout extends Component {
   constructor(props) {
@@ -39,6 +40,7 @@ export default class Layout extends Component {
         <SkipToContent callback={this.focusContent} />
         <Header />
         <Content contentRef={this.content} />
+        <CookiesNotification />
         <Footer />
       </ErrorBoundary>
     )

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -234,9 +234,8 @@ const english = {
     },
     cookies: {
       accept: 'Accept all cookies',
-      settings: 'Cookie settings',
       infoText: 'By using Fairdata’s services you agree to our Cookies Use. We use cookies to improve your experience and make our services work better.',
-      linkText: 'View the Fairdata Privacy Policy.',
+      link: 'View the Fairdata Privacy Policy.',
     }
   },
   home: {

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -232,6 +232,12 @@ const english = {
     language: {
       toggleLabel: 'Toggle language',
     },
+    cookies: {
+      accept: 'Accept all cookies',
+      settings: 'Cookie settings',
+      infoText: 'By using Fairdata’s services you agree to our Cookies Use. We use cookies to improve your experience and make our services work better.',
+      linkText: 'View the Fairdata Privacy Policy.',
+    }
   },
   home: {
     title: 'Search datasets',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -230,6 +230,12 @@ const finnish = {
     language: {
       toggleLabel: 'Vaihda kieltä',
     },
+    cookies: {
+      accept: 'Hyväksy evästeet',
+      settings: 'Evästeasetukset',
+      infoText: 'Finnish info text here.',
+      linkText: 'Lue Fairdata-palvelujen tietosuojasta.',
+    }
   },
   home: {
     title: 'Etsi aineistoa',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -232,9 +232,8 @@ const finnish = {
     },
     cookies: {
       accept: 'Hyväksy evästeet',
-      settings: 'Evästeasetukset',
-      infoText: 'Finnish info text here.',
-      linkText: 'Lue Fairdata-palvelujen tietosuojasta.',
+      infoText: 'Käyttämällä Fairdata-palveluja hyväksyt evästiden käytön. Käytämme evästeitä palvelun kehittömiseen ja käyttökokemuksen parantamiseen.',
+      link: 'Fairdata-palvelujen tietosuoja.',
     }
   },
   home: {


### PR DESCRIPTION
Implement a notification for describing cookie usage on Etsin and Qvain Light.
Cookie acceptance is saved to local storage and the notification will not be displayed if acceptance is present in the local storage.

**Note:** User acceptance should be refactored when integrated to Matomo and SSO. Currently acceptance is saved for the sake of not displaying the notification every time when a user visits the site. 

- Finnish translations should be approved before deploying to production