### PR TITLE
CSCFAIRMETA-359: Fix citation formatting

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/sidebar/special/citation.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/special/citation.jsx
@@ -1,4 +1,7 @@
 import React, { Component, Fragment } from 'react'
+import styled from 'styled-components'
+import Translate from 'react-translate-component'
+
 import DatasetQuery from '../../../../stores/view/datasetquery'
 import checkDataLang from '../../../../utils/checkDataLang'
 import checkNested from '../../../../utils/checkNested'
@@ -51,22 +54,26 @@ export default class Citation extends Component {
       })
     )
     cit.push(checkDataLang(this.state.title))
-    if (this.state.publisher) {
-      cit.push(checkDataLang(this.state.publisher))
-    }
+    cit.push(checkDataLang(this.state.publisher))
     cit.push(checkDataLang(this.state.release_date))
     cit.push(checkDataLang(this.state.pid))
-    return cit.join(', ')
-  }
-
-  render() {
-    if (this.state.citation) {
-      return <Fragment>{this.state.citation}</Fragment>
-    }
     return (
       <Fragment>
-        <span>{this.createCitation()}</span>
+        <span>{cit.filter(element => element).join(', ')}</span>
+        { !this.state.release_date &&
+          <TextMuted><Translate content="dataset.citationNoReleaseDate" /></TextMuted> }
       </Fragment>
     )
   }
+
+  render() {
+    if (this.state.citation) return this.state.citation
+    return this.createCitation()
+  }
 }
+
+const TextMuted = styled.div`
+  color: ${props => props.theme.color.gray};
+  font-size: .9rem;
+  margin-top: .3rem;
+`

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -33,6 +33,7 @@ const english = {
     catalog_publisher: 'Catalog publisher',
     citation: 'Citation / Reference',
     citation_formats: 'Show more citation formats',
+    citationNoReleaseDate: 'Publishing date not defined',
     contact: {
       access: 'Contact the curator on issues related to dataset access',
       contact: 'Contact',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -33,6 +33,7 @@ const finnish = {
     catalog_publisher: 'Katalogin julkaisija',
     citation: 'Sitaatti / Lähdeviite',
     citation_formats: 'Näytä lisää sitaattiehdotuksia',
+    citationNoReleaseDate: 'Julkaisupäivämäärää ei määritelty',
     contact: {
       access: 'Aineiston käyttöoikeuteen liittyvissä kyselyissä ota yhteyttä kuraattoriin.',
       contact: 'Ota yhteyttä',


### PR DESCRIPTION
Remove any extra commas from citation, included by missing elements (e.g. publishing date).
If publishing date is not available, include additional message about it bellow the citation.