### PR TITLE
CSCFAIRMETA-652: [FIX] Change citation/reference to include issued date

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/sidebar/special/citation.jsx
+++ b/etsin_finder/frontend/js/components/dataset/sidebar/special/citation.jsx
@@ -14,7 +14,10 @@ export default class Citation extends Component {
       creators: Data.research_dataset.creator && Data.research_dataset.creator,
       contributors: Data.research_dataset.contributor && Data.research_dataset.contributor,
       publisher: Data.research_dataset.publisher && Data.research_dataset.publisher.name,
-      release_date: Data.research_dataset.modified,
+
+      // This is the issued date of the source material, as defined in Qvain Light/Heavy
+      date_issued: Data.research_dataset.issued,
+
       title: Data.research_dataset.title,
       pid: Data.research_dataset.preferred_identifier,
       citation: Data.research_dataset.bibliographic_citation,
@@ -55,13 +58,13 @@ export default class Citation extends Component {
     )
     cit.push(checkDataLang(this.state.title))
     cit.push(checkDataLang(this.state.publisher))
-    cit.push(checkDataLang(this.state.release_date))
+    cit.push(checkDataLang(this.state.date_issued))
     cit.push(checkDataLang(this.state.pid))
     return (
       <Fragment>
         <span>{cit.filter(element => element).join(', ')}</span>
-        { !this.state.release_date &&
-          <TextMuted><Translate content="dataset.citationNoReleaseDate" /></TextMuted> }
+        { !this.state.date_issued &&
+          <TextMuted><Translate content="dataset.citationNoDateIssued" /></TextMuted> }
       </Fragment>
     )
   }

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -33,7 +33,7 @@ const english = {
     catalog_publisher: 'Catalog publisher',
     citation: 'Citation / Reference',
     citation_formats: 'Show more citation formats',
-    citationNoReleaseDate: 'Publishing date not defined',
+    citationNoDateIssued: 'Issued date not defined',
     contact: {
       access: 'Contact the curator on issues related to dataset access',
       contact: 'Contact',

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -33,7 +33,7 @@ const finnish = {
     catalog_publisher: 'Katalogin julkaisija',
     citation: 'Sitaatti / Lähdeviite',
     citation_formats: 'Näytä lisää sitaattiehdotuksia',
-    citationNoReleaseDate: 'Julkaisupäivämäärää ei määritelty',
+    citationNoDateIssued: 'Julkaisupäivämäärää ei määritelty',
     contact: {
       access: 'Aineiston käyttöoikeuteen liittyvissä kyselyissä ota yhteyttä kuraattoriin.',
       contact: 'Ota yhteyttä',


### PR DESCRIPTION
- Previously, the timestamp "modified" (related to the metadata) was specified in the citation, which was often empty
- Now, issued date is instead defined, which is much more useful for researchers and users
- Issued date is (for instance) required for all DOI datasets
- Related to previous PR https://github.com/CSCfi/etsin-finder/pull/485