### PR TITLE
CSCFAIRMETA-458: add field for Language

### DIFF
--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.files.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.files.test.jsx.snap
@@ -32,6 +32,7 @@ Object {
   ],
   "cumulativeState": 0,
   "dataCatalog": "urn:nbn:fi:att:data-catalog-ida",
+  "datasetLanguage": Array [],
   "description": Object {
     "en": "",
     "fi": "Description",
@@ -183,6 +184,7 @@ Object {
   ],
   "cumulativeState": 0,
   "dataCatalog": "urn:nbn:fi:att:data-catalog-ida",
+  "datasetLanguage": Array [],
   "description": Object {
     "en": "",
     "fi": "Description",
@@ -334,6 +336,7 @@ Object {
   ],
   "cumulativeState": 0,
   "dataCatalog": "urn:nbn:fi:att:data-catalog-ida",
+  "datasetLanguage": Array [],
   "description": Object {
     "en": "",
     "fi": "Description",
@@ -485,6 +488,7 @@ Object {
   ],
   "cumulativeState": 0,
   "dataCatalog": "urn:nbn:fi:att:data-catalog-ida",
+  "datasetLanguage": Array [],
   "description": Object {
     "en": "",
     "fi": "Description",
@@ -636,6 +640,7 @@ Object {
   ],
   "cumulativeState": 0,
   "dataCatalog": "urn:nbn:fi:att:data-catalog-ida",
+  "datasetLanguage": Array [],
   "description": Object {
     "en": "",
     "fi": "Description",

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
@@ -74,6 +74,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
   <inject-IssuedDateField-with-Stores />
   <inject-OtherIdentifierField-with-Stores />
   <inject-FieldOfScienceField-with-Stores />
+  <inject-LanguageField-with-Stores />
   <inject-KeywordsField-with-Stores />
 </div>
 `;
@@ -163,6 +164,8 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -308,6 +311,8 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -453,6 +458,156 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
+        "deprecated": false,
+        "description": Object {
+          "en": "",
+          "fi": "",
+        },
+        "deselectChildren": [Function],
+        "deselectParents": [Function],
+        "embargoExpDate": undefined,
+        "existingDirectories": Array [],
+        "existingFiles": Array [],
+        "extResFormOpen": false,
+        "externalResourceInEdit": Object {
+          "accessUrl": "",
+          "downloadUrl": "",
+          "id": undefined,
+          "title": "",
+          "useCategory": "",
+        },
+        "externalResources": Array [],
+        "fieldOfScience": undefined,
+        "fieldOfScienceArray": Array [],
+        "fixDeprecatedModalOpen": false,
+        "hierarchy": Object {},
+        "idaPickerOpen": false,
+        "inEdit": undefined,
+        "infrastructure": undefined,
+        "infrastructures": Array [],
+        "issuedDate": undefined,
+        "keywordString": "",
+        "keywordsArray": Array [],
+        "license": Object {
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+          "name": undefined,
+        },
+        "mergeArraysByIdentifier": [Function],
+        "metadataModalFile": undefined,
+        "metaxApiV2": true,
+        "original": undefined,
+        "otherIdentifier": "",
+        "otherIdentifiersArray": Array [],
+        "otherIdentifiersValidationError": null,
+        "otherLicenseUrl": undefined,
+        "preservationState": 0,
+        "restrictionGrounds": Object {},
+        "selectedDirectories": Array [],
+        "selectedFiles": Array [],
+        "selectedProject": undefined,
+        "setOtherIdentifierValidationError": [Function],
+        "spatials": Array [],
+        "title": Object {
+          "en": "",
+          "fi": "",
+        },
+        "useDoi": false,
+      },
+    }
+  }
+/>
+`;
+
+
+exports[`Qvain.Description should render <LanguageField /> 1`] = `
+<LanguageField
+  Stores={
+    Object {
+      "Locale": Locale {},
+      "Qvain": Qvain {
+        "Actors": Actors {
+          "Qvain": [Circular],
+          "actorInEdit": null,
+          "actors": Array [],
+          "createActor": [Function],
+          "editDataset": [Function],
+          "getDatasetOrganizations": [Function],
+          "getReferenceOrganizations": [Function],
+          "getReferenceOrganizationsForActor": [Function],
+          "isActorEqual": [Function],
+          "isEqual": [Function],
+          "isOrganizationEqual": [Function],
+          "loadingReferenceOrganizations": Object {},
+          "referenceOrganizationErrors": Object {},
+          "referenceOrganizations": Object {},
+          "reset": [Function],
+          "toBackend": [Function],
+        },
+        "Files": Files {
+          "AddItemsView": AddItemsView {
+            "Files": [Circular],
+            "checkedState": Object {},
+            "defaultShowLimit": 20,
+            "getTopmostChecked": [Function],
+            "isOpen": [Function],
+            "openState": Object {},
+            "showLimitIncrement": 20,
+            "showLimitState": Object {},
+          },
+          "Qvain": [Circular],
+          "SelectedItemsView": SelectedItemsView {
+            "Files": [Circular],
+            "checkedState": Object {},
+            "defaultShowLimit": 20,
+            "getTopmostChecked": [Function],
+            "hideRemoved": false,
+            "isOpen": [Function],
+            "openState": Object {},
+            "showLimitIncrement": 20,
+            "showLimitState": Object {},
+          },
+          "cache": Object {},
+          "cancelOnReset": [Function],
+          "getItemByPath": [Function],
+          "inEdit": undefined,
+          "initialPagination": 10,
+          "loadingMetadata": null,
+          "loadingProjectInfo": null,
+          "loadingProjectRoot": null,
+          "metadataToMetax": [Function],
+          "originalMetadata": Object {},
+          "projectLocked": false,
+          "promiseManager": PromiseManager {
+            "add": [Function],
+            "promises": Array [],
+          },
+          "refreshModalDirectory": null,
+          "root": null,
+          "selectedExistingCounter": ChildItemCounter {
+            "root": Object {
+              "count": 0,
+              "directories": Object {},
+            },
+          },
+          "selectedExistingMetadata": Object {},
+          "selectedProject": undefined,
+        },
+        "Spatials": Spatials {
+          "Qvain": [Circular],
+          "toBackend": [Function],
+        },
+        "accessType": Object {
+          "name": undefined,
+          "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+        },
+        "changed": false,
+        "createExternalResourceUIId": [Function],
+        "cumulativeState": 0,
+        "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -598,6 +753,8 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
@@ -31,6 +31,7 @@ exports[`Qvain.Description should render <Description /> 1`] = `
   <inject-IssuedDateField-with-Stores />
   <inject-OtherIdentifierField-with-Stores />
   <inject-FieldOfScienceField-with-Stores />
+  <inject-LanguageField-with-Stores />
   <inject-KeywordsField-with-Stores />
 </div>
 `;
@@ -120,6 +121,8 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -265,6 +268,8 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -410,6 +415,8 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",
@@ -555,6 +562,8 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
         "createExternalResourceUIId": [Function],
         "cumulativeState": 0,
         "dataCatalog": undefined,
+        "datasetLanguage": undefined,
+        "datasetLanguageArray": Array [],
         "deprecated": false,
         "description": Object {
           "en": "",

--- a/etsin_finder/frontend/__tests__/qvain.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.test.jsx
@@ -8,6 +8,7 @@ import Description from '../js/components/qvain/description'
 import DescriptionField from '../js/components/qvain/description/descriptionField'
 import OtherIdentifierField from '../js/components/qvain/description/otherIdentifierField'
 import FieldOfScienceField from '../js/components/qvain/description/fieldOfScienceField'
+import LanguageField from '../js/components/qvain/description/languageField'
 import KeywordsField from '../js/components/qvain/description/keywordsField'
 import RightsAndLicenses from '../js/components/qvain/licenses'
 import { License } from '../js/components/qvain/licenses/licenses'
@@ -132,6 +133,10 @@ describe('Qvain.Description', () => {
   })
   it('should render <FieldOfScienceField />', () => {
     const component = shallow(<FieldOfScienceField Stores={getStores()} />)
+    expect(component).toMatchSnapshot()
+  })
+  it('should render <LanguageField />', () => {
+    const component = shallow(<LanguageField Stores={getStores()} />)
     expect(component).toMatchSnapshot()
   })
   it('should render <KeywordsField />', () => {

--- a/etsin_finder/frontend/js/components/qvain/description/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/index.jsx
@@ -5,6 +5,7 @@ import DescriptionField from './descriptionField'
 import IssuedDateField from './issuedDateField'
 import OtherIdentifierField from './otherIdentifierField'
 import FieldOfScienceField from './fieldOfScienceField'
+import LanguageField from './languageField'
 import KeywordsField from './keywordsField'
 import { SectionTitle } from '../general/section'
 import Tooltip from '../general/tooltip'
@@ -35,6 +36,7 @@ const Description = () => {
         <IssuedDateField />
         <OtherIdentifierField />
         <FieldOfScienceField />
+        <LanguageField />
         <KeywordsField />
       </React.Fragment>
     </div>

--- a/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
@@ -1,0 +1,131 @@
+import React, { Component } from 'react'
+
+import PropTypes from 'prop-types'
+import { inject, observer } from 'mobx-react'
+import Translate from 'react-translate-component'
+import styled from 'styled-components'
+import Select from 'react-select'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+
+import getReferenceData from '../utils/getReferenceData'
+import { onChange, getCurrentValue } from '../utils/select'
+import { DatasetLanguage } from '../../../stores/view/qvain'
+
+import Label from '../general/label'
+import Button from '../../general/button'
+import Card from '../general/card'
+import { LabelLarge } from '../general/form'
+
+
+class LanguageField extends Component {
+  promises = []
+
+  static propTypes = {
+    Stores: PropTypes.object.isRequired,
+  }
+
+  state = {
+    options: {
+      fi: [],
+      en: [],
+    },
+  }
+
+  componentDidMount() {
+    this.promises.push(
+      getReferenceData('language')
+        .then(resp => {
+          const { hits } = resp.data.hits
+          const en = hits.map((ref) => ({
+            value: ref._source.uri,
+            label: ref._source.label.en,
+          }))
+          const fi = hits.map((ref) => ({
+            value: ref._source.uri,
+            label: ref._source.label.fi || ref._source.label.und,
+          }))
+          this.setState({ options: { en, fi } })
+        })
+        .catch(error => {
+          if (error.response) {
+            // Error response from Metax
+            console.log(error.response.data)
+            console.log(error.response.status)
+            console.log(error.response.headers)
+          } else if (error.request) {
+            // No response from Metax
+            console.log(error.request)
+          } else {
+            // Something happened in setting up the request that triggered an Error
+            console.log('Error', error.message)
+          }
+        })
+    )
+  }
+
+  componentWillUnmount() {
+    this.promises.forEach((promise) => promise && promise.cancel && promise.cancel())
+  }
+
+  renderSelectedLanguages() {
+    const { lang } = this.props.Stores.Locale
+    const { datasetLanguageArray, removeDatasetLanguage } = this.props.Stores.Qvain
+    return datasetLanguageArray.map((selectedLanguage) => (
+      <Label color="#007fad" margin="0 0.5em 0.5em 0" key={selectedLanguage.url}>
+        <PaddedWord>{selectedLanguage.name[lang]}</PaddedWord>
+        <FontAwesomeIcon
+          onClick={() => removeDatasetLanguage(selectedLanguage)}
+          icon={faTimes}
+          size="xs"
+        />
+      </Label>
+    ))
+  }
+
+  render() {
+    const { lang } = this.props.Stores.Locale
+    const { options } = this.state
+    const { readonly, datasetLanguage, setDatasetLanguage, addDatasetLanguage } = this.props.Stores.Qvain
+    return (
+      <Card>
+        <LabelLarge htmlFor="datasetLanguage">
+          <Translate content="qvain.description.datasetLanguage.title" />
+        </LabelLarge>
+        <Translate component="p" content="qvain.description.datasetLanguage.help" />
+        { this.renderSelectedLanguages() }
+        <Translate
+          name="dataset-language"
+          inputId="datasetLanguage"
+          component={Select}
+          attributes={{ placeholder: 'qvain.description.datasetLanguage.placeholder' }}
+          options={options[lang]}
+          isDisabled={readonly}
+          value={getCurrentValue(datasetLanguage, options, lang)}
+          onChange={onChange(options, lang, setDatasetLanguage, DatasetLanguage)}
+          isSearchable
+          isClearable
+        />
+        <AddLanguageContainer>
+          <Button
+            onClick={() => addDatasetLanguage(datasetLanguage)}
+            disabled={readonly}
+          >
+            <Translate content="qvain.description.datasetLanguage.addButton" />
+          </Button>
+        </AddLanguageContainer>
+      </Card>
+    )
+  }
+}
+
+const PaddedWord = styled.span`
+  padding-right: 10px;
+`
+
+const AddLanguageContainer = styled.div`
+  text-align: right;
+  padding-top: 1rem;
+`
+
+export default inject('Stores')(observer(LanguageField))

--- a/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
@@ -39,7 +39,7 @@ class LanguageField extends Component {
           const { hits } = resp.data.hits
           const en = hits.map((ref) => ({
             value: ref._source.uri,
-            label: ref._source.label.en,
+            label: ref._source.label.en || ref._source.label.und,
           }))
           const fi = hits.map((ref) => ({
             value: ref._source.uri,

--- a/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/languageField.jsx
@@ -22,7 +22,6 @@ const LanguageField = ({ Stores }) => {
   const { lang } = Stores.Locale
   const { readonly, datasetLanguage, datasetLanguageArray, setDatasetLanguage, removeDatasetLanguage, addDatasetLanguage } = Stores.Qvain
 
-  datasetLanguageArray.forEach(e => console.log(e.url, e.name))
   const addedLanguages = datasetLanguageArray.map((selectedLanguage) => (
     <Label color="#007fad" margin="0 0.5em 0.5em 0" key={selectedLanguage.url}>
       <PaddedWord>{selectedLanguage.name[lang] || selectedLanguage.name.und }</PaddedWord>

--- a/etsin_finder/frontend/js/components/qvain/general/searchSelect.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/searchSelect.jsx
@@ -43,53 +43,35 @@ class Select extends Component {
     const { options } = this.state
     const { lang } = this.props.Stores.Locale
 
+    const props = {
+      ...this.props,
+      className: 'basic-single',
+      classNamePrefix: 'select',
+      inputId: `${name}-select`,
+      component: ReactSelect,
+      attributes: { placeholder },
+      isDisabled: readonly,
+      value: getCurrentValue(getter, options, lang),
+      onChange: onChange(options, lang, setter, model),
+      cacheOptions: true,
+      defaultOptions: [],
+      loadOptions: (inputValue =>
+        new Promise(async res => {
+          const opts = await getOptions(metaxIdentifier, inputValue)
+          this.setState({ options: opts })
+          res(opts[lang])
+        })
+      ),
+    }
+
     return inModal ? (
       <Translate
-        {...this.props}
-        name={name}
-        className="basic-single"
-        classNamePrefix="select"
-        inputId={`${name}-select`}
-        component={ReactSelect}
-        attributes={{ placeholder }}
-        isDisabled={readonly}
-        value={getCurrentValue(getter, options, lang)}
-        onChange={onChange(options, lang, setter, model)}
-        cacheOptions
-        defaultOptions={[]}
-        loadOptions={inputValue =>
-          new Promise(async res => {
-            const opts = await getOptions(metaxIdentifier, inputValue)
-            this.setState({ options: opts })
-            res(opts[lang])
-          })
-        }
+        {...props}
         menuPlacement="auto"
         menuPosition="fixed"
         menuShouldScrollIntoView={false}
       />
-    ) : (
-      <Translate
-        name={name}
-        className="basic-single"
-        classNamePrefix="select"
-        inputId={`${name}-select`}
-        component={ReactSelect}
-        attributes={{ placeholder }}
-        isDisabled={readonly}
-        value={getCurrentValue(getter, options, lang) || ''}
-        onChange={onChange(options, lang, setter, model)}
-        cacheOptions
-        defaultOptions={[]}
-        loadOptions={inputValue =>
-          new Promise(async res => {
-            const opts = await getOptions(metaxIdentifier, inputValue)
-            this.setState({ options: opts })
-            res(opts[lang])
-          })
-        }
-      />
-    )
+    ) : <Translate {...props} />
   }
 }
 

--- a/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
@@ -1,6 +1,9 @@
 const fieldsOfScienceToMetaxMethod = (fieldsOfScience) =>
   fieldsOfScience.map((fieldOfScience) => fieldOfScience.url)
 
+const datasetLanguageToMetax = datasetLanguage =>
+  datasetLanguage.map(language => language.url)
+
 const directoriesToMetax = (selectedDirectories, existingDirectories) => {
   const selectedDirectoryIdentifiers = selectedDirectories
     ? selectedDirectories.map((sd) => sd.identifier)
@@ -59,6 +62,7 @@ const handleSubmitToBackend = (values) => {
     issuedDate: values.issuedDate,
     identifiers: values.otherIdentifiersArray,
     fieldOfScience: fieldsOfScienceToMetaxMethod(values.fieldOfScienceArray),
+    datasetLanguage: datasetLanguageToMetax(values.datasetLanguageArray),
     keywords: values.keywordsArray,
     actors,
     infrastructure: values.infrastructures,

--- a/etsin_finder/frontend/js/components/qvain/utils/select.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/select.js
@@ -52,11 +52,11 @@ const parseRefResponse = res => {
   const refsFi = hits.map(hit => ({
     value: hit._source.uri,
     label: hit._source.label.fi || hit._source.label.und,
-  }))
+  })).sort((a, b) => a.label.localeCompare(b.label))
   const refsEn = hits.map(hit => ({
     value: hit._source.uri,
     label: hit._source.label.en || hit._source.label.und,
-  }))
+  })).sort((a, b) => a.label.localeCompare(b.label))
   return {
     en: refsEn,
     fi: refsFi,

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -233,8 +233,9 @@ class Qvain {
 
   @action
   addDatasetLanguage = (language) => {
-    if (!language) return
-    this.datasetLanguageArray.push(DatasetLanguage(language.name, language.url))
+    if (!language || !('name' in language) || !('url' in language)) return
+    const oldDatasetLanguages = this.datasetLanguageArray.filter(item => item.url !== language.url)
+    this.datasetLanguageArray = oldDatasetLanguages.concat([(DatasetLanguage(language.name, language.url))])
     this.setDatasetLanguage(undefined)
     this.changed = true
   }
@@ -741,7 +742,7 @@ class Qvain {
     this.datasetLanguage = []
     if (researchDataset.language !== undefined) {
       researchDataset.language.forEach(element => {
-        this.addDatasetLanguage(DatasetLanguage(element))
+        this.addDatasetLanguage(DatasetLanguage(element.title, element.identifier))
       })
     }
 

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -51,6 +51,10 @@ class Qvain {
 
   @observable fieldOfScienceArray = []
 
+  @observable datasetLanguage = undefined
+
+  @observable datasetLanguageArray = []
+
   @observable keywordString = ''
 
   @observable keywordsArray = []
@@ -87,6 +91,8 @@ class Qvain {
     this.otherIdentifiersValidationError = null
     this.fieldOfScience = undefined
     this.fieldOfScienceArray = []
+    this.datasetLanguage = undefined
+    this.datasetLanguageArray = []
     this.keywordString = ''
     this.keywordsArray = []
     this.infrastructure = undefined
@@ -214,6 +220,26 @@ class Qvain {
   }
 
   @action
+  setDatasetLanguage = (language) => {
+    this.datasetLanguage = language
+  }
+
+  @action
+  removeDatasetLanguage = (languageToRemove) => {
+    const languagesToRemain = this.datasetLanguageArray.filter(language => language.url !== languageToRemove.url)
+    this.datasetLanguageArray = languagesToRemain
+    this.changed = true
+  }
+
+  @action
+  addDatasetLanguage = (language) => {
+    if (!language) return
+    this.datasetLanguageArray.push(DatasetLanguage(language.name, language.url))
+    this.setDatasetLanguage(undefined)
+    this.changed = true
+  }
+
+  @action
   setKeywordString = (value) => {
     this.keywordString = value
   }
@@ -267,6 +293,9 @@ class Qvain {
     // the dataset is submitted.
     if (this.fieldOfScience !== undefined) {
       this.addFieldOfScience(this.fieldOfScience)
+    }
+    if (this.datasetLanguage !== undefined) {
+      this.addDatasetLanguage(this.datasetLanguage)
     }
     if (this.keywordString !== '') {
       this.addKeywordToKeywordArray()
@@ -708,6 +737,14 @@ class Qvain {
       })
     }
 
+    // Languages of dataset
+    this.datasetLanguage = []
+    if (researchDataset.language !== undefined) {
+      researchDataset.language.forEach(element => {
+        this.addDatasetLanguage(DatasetLanguage(element))
+      })
+    }
+
     // infrastructures
     this.infrastructures = []
     if (researchDataset.infrastructure !== undefined) {
@@ -1020,6 +1057,11 @@ const DatasetDirectory = (directory) => ({
 })
 
 export const FieldOfScience = (name, url) => ({
+  name,
+  url,
+})
+
+export const DatasetLanguage = (name, url) => ({
   name,
   url,
 })

--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -739,7 +739,8 @@ class Qvain {
     }
 
     // Languages of dataset
-    this.datasetLanguage = []
+    this.datasetLanguage = undefined
+    this.datasetLanguageArray = []
     if (researchDataset.language !== undefined) {
       researchDataset.language.forEach(element => {
         this.addDatasetLanguage(DatasetLanguage(element.title, element.identifier))

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -485,6 +485,13 @@ const english = {
         addButton: 'Add field of science',
         help: 'You can add multiple field of science.',
       },
+      datasetLanguage: {
+        title: 'Dataset language',
+        infoText: 'Select languages used in the dataset.',
+        placeholder: 'Select language',
+        addButton: 'Add language',
+        help: 'You can add multiple languages.'
+      },
       keywords: {
         title: 'Keywords',
         infoText: 'Set keywords that characterize the dataset.',

--- a/etsin_finder/frontend/locale/english.js
+++ b/etsin_finder/frontend/locale/english.js
@@ -488,7 +488,8 @@ const english = {
       datasetLanguage: {
         title: 'Dataset language',
         infoText: 'Select languages used in the dataset.',
-        placeholder: 'Select language',
+        placeholder: 'Type to search language',
+        noResults: 'No languages found',
         addButton: 'Add language',
         help: 'You can add multiple languages.'
       },

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -483,6 +483,13 @@ const finnish = {
         addButton: 'Lisää tieteenala',
         help: 'Voit lisätä useita tieteenaloja.',
       },
+      datasetLanguage: {
+        title: 'Aineiston kieli',
+        infoText: 'Valitse aineistossa käytetyt kielet.',
+        placeholder: 'Valitse kielet',
+        addButton: 'Lisää kieli',
+        help: 'Voit lisätä useita kieliä.'
+      },
       keywords: {
         title: 'Avainsanat',
         infoText:

--- a/etsin_finder/frontend/locale/finnish.js
+++ b/etsin_finder/frontend/locale/finnish.js
@@ -486,7 +486,8 @@ const finnish = {
       datasetLanguage: {
         title: 'Aineiston kieli',
         infoText: 'Valitse aineistossa käytetyt kielet.',
-        placeholder: 'Valitse kielet',
+        placeholder: 'Hae kieliä kirjoittamalla',
+        noResults: 'Ei hakutuloksia',
         addButton: 'Lisää kieli',
         help: 'Voit lisätä useita kieliä.'
       },

--- a/etsin_finder/qvain_light_dataset_schema.py
+++ b/etsin_finder/qvain_light_dataset_schema.py
@@ -87,6 +87,10 @@ class DatasetValidationSchema(Schema):
         fields.Str(),
         required=False
     )
+    datasetLanguage = fields.List(
+        fields.Str(),
+        required=False
+    )
     keywords = fields.List(
         fields.Str(),
         required=True,

--- a/etsin_finder/qvain_light_utils.py
+++ b/etsin_finder/qvain_light_utils.py
@@ -225,6 +225,7 @@ def data_to_metax(data, metadata_provider_org, metadata_provider_user):
             "issued": data.get("issuedDate") if "issuedDate" in data else "",
             "other_identifier": other_identifiers_to_metax(data.get("identifiers")),
             "field_of_science": _to_metax_field_of_science(data.get("fieldOfScience")),
+            "language": _to_metax_field_of_science(data.get("datasetLanguage")),
             "keyword": data.get("keywords"),
             "access_rights": access_rights_to_metax(data),
             "remote_resources": remote_resources_data_to_metax(data.get("remote_resources")) if data.get("dataCatalog") == DATA_CATALOG_IDENTIFIERS.get('att') else "",
@@ -285,6 +286,9 @@ def _to_metax_field_of_science(fieldOfScienceArray):
     return metax_fields_of_science
 
 
+def _to_metax_dataset_language(datasetLanguageArray):
+    return [{'identifier': language} for language in datasetLanguageArray]
+
 def _to_metax_infrastructure(infrastructures):
     metax_infrastructures = []
     for element in infrastructures:
@@ -318,6 +322,7 @@ def edited_data_to_metax(data, original):
         "issued": data.get("issuedDate") if "issuedDate" in data else "",
         "other_identifier": other_identifiers_to_metax(data.get("identifiers")),
         "field_of_science": _to_metax_field_of_science(data.get("fieldOfScience")),
+        "language": _to_metax_dataset_language(data.get("datasetLanguage")),
         "keyword": data.get("keywords"),
         "access_rights": access_rights_to_metax(data),
         "remote_resources": remote_resources_data_to_metax(data.get("remote_resources")) if data["dataCatalog"] == DATA_CATALOG_IDENTIFIERS.get('att') else "",


### PR DESCRIPTION
- Add field for dataset language

Language select fetches options from Metax when user types to search in select component, as there is thousands of language choices. Tested with submitting a new dataset and editing an existing dataset.

Minor changes:
- `qvain/general/searchSelect.jsx` refactored
- Select options sorted alphabetically by label (currently in frontend, is there a param to do this in Metax, probably more efficient to do this in backend)