### PR TITLE
CSCFAIRMETA-651 Hide cookie notification

### DIFF
--- a/etsin_finder/frontend/js/layout/index.jsx
+++ b/etsin_finder/frontend/js/layout/index.jsx
@@ -19,7 +19,6 @@ import SkipToContent from '../components/general/skipToContent'
 import Header from './header'
 import Footer from './footer'
 import Content from './content'
-import CookiesNotification from './cookiesNotification'
 
 export default class Layout extends Component {
   constructor(props) {
@@ -40,7 +39,6 @@ export default class Layout extends Component {
         <SkipToContent callback={this.focusContent} />
         <Header />
         <Content contentRef={this.content} />
-        <CookiesNotification />
         <Footer />
       </ErrorBoundary>
     )


### PR DESCRIPTION
This commit hides the cookie notification, implementation is still
present in the codebase. This modification should be reverted when we
want to display the cookie notification.