### PR TITLE
CSCFAIRMETA-546: [ADD] Missing asterisk & hover tooltip for actors

### DIFF
--- a/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
@@ -61,7 +61,11 @@ describe('Qvain.Actors', () => {
   })
 
   it('should list all added actors', () => {
-    const addedActors = mount(<AddedActorsBase Stores={stores} />)
+    const addedActors = mount(
+      <ThemeProvider theme={etsinTheme}>
+        <AddedActorsBase Stores={stores} />
+      </ThemeProvider>
+    )
     expect(addedActors.find(ButtonGroup).length).toBe(0)
     stores.Qvain.Actors.saveActor(
       Actor({

--- a/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react'
-import translate from 'counterpart'
 import Translate from 'react-translate-component'
 import styled from 'styled-components'
 import counterpart from 'counterpart'

--- a/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
@@ -37,7 +37,7 @@ export class AddedActorsBase extends Component {
     const { actors } = this.props.Stores.Qvain.Actors
     return (
       <>
-        <LabelLarge htmlFor="addedActors">
+        <LabelLarge>
           <Tooltip
             title={translate('qvain.description.fieldHelpTexts.requiredToPublish')}
             position="right"
@@ -51,7 +51,6 @@ export class AddedActorsBase extends Component {
         }
         {actors.map((addedActor) => (
           <ButtonGroup
-            id="addedActors"
             tabIndex="0"
             key={addedActor.uiid}
           >

--- a/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react'
+import translate from 'counterpart'
 import Translate from 'react-translate-component'
 import styled from 'styled-components'
-import counterpart from 'counterpart'
 
 import {
   ButtonGroup,
@@ -37,9 +37,9 @@ export class AddedActorsBase extends Component {
     const { actors } = this.props.Stores.Qvain.Actors
     return (
       <>
-        <LabelLarge tabIndex="0">
+        <LabelLarge htmlFor="addedActors">
           <Tooltip
-            title={counterpart('qvain.description.fieldHelpTexts.requiredToPublish', { locale: lang })}
+            title={translate('qvain.description.fieldHelpTexts.requiredToPublish')}
             position="right"
           >
             <Translate content="qvain.actors.added.title" /> *
@@ -50,10 +50,14 @@ export class AddedActorsBase extends Component {
           (<Translate tabIndex="0" component="p" content="qvain.actors.added.noneAddedNotice" />)
         }
         {actors.map((addedActor) => (
-          <ButtonGroup tabIndex="0" key={addedActor.uiid}>
+          <ButtonGroup
+            id="addedActors"
+            tabIndex="0"
+            key={addedActor.uiid}
+          >
             <ActorLabel>
               <ActorIcon actor={addedActor} style={{ marginRight: '8px' }} />
-              {getActorName(addedActor, lang)}{addedActor.roles.map(role => (` / ${counterpart(`qvain.actors.add.checkbox.${role}`)}`))}
+              {getActorName(addedActor, lang)}{addedActor.roles.map(role => (` / ${translate(`qvain.actors.add.checkbox.${role}`)}`))}
             </ActorLabel>
             <ButtonContainer>
               <Translate

--- a/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
@@ -4,6 +4,7 @@ import { inject, observer } from 'mobx-react'
 import translate from 'counterpart'
 import Translate from 'react-translate-component'
 import styled from 'styled-components'
+import counterpart from 'counterpart'
 
 import {
   ButtonGroup,
@@ -13,6 +14,8 @@ import {
   ButtonContainer
 } from '../general/buttons'
 import { getActorName, ActorIcon } from './common'
+import Tooltip from '../../general/tooltipHover'
+import { LabelLarge } from '../general/form'
 
 export class AddedActorsBase extends Component {
   static propTypes = {
@@ -35,11 +38,14 @@ export class AddedActorsBase extends Component {
     const { actors } = this.props.Stores.Qvain.Actors
     return (
       <>
-        <Translate
-          tabIndex="0"
-          component="h3"
-          content="qvain.actors.added.title"
-        />
+        <LabelLarge tabIndex="0">
+          <Tooltip
+            title={counterpart('qvain.description.fieldHelpTexts.requiredToPublish', { locale: lang })}
+            position="right"
+          >
+            <Translate content="qvain.actors.added.title" /> *
+          </Tooltip>
+        </LabelLarge>
         <Translate component="p" content="qvain.actors.add.help" />
         {actors.length === 0 &&
           (<Translate tabIndex="0" component="p" content="qvain.actors.added.noneAddedNotice" />)

--- a/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/addedActors.jsx
@@ -53,7 +53,7 @@ export class AddedActorsBase extends Component {
           <ButtonGroup tabIndex="0" key={addedActor.uiid}>
             <ActorLabel>
               <ActorIcon actor={addedActor} style={{ marginRight: '8px' }} />
-              {getActorName(addedActor, lang)}{addedActor.roles.map(role => (` / ${translate(`qvain.actors.add.checkbox.${role}`)}`))}
+              {getActorName(addedActor, lang)}{addedActor.roles.map(role => (` / ${counterpart(`qvain.actors.add.checkbox.${role}`)}`))}
             </ActorLabel>
             <ButtonContainer>
               <Translate


### PR DESCRIPTION
- Actors are mandatory (at least one actor) and should be displayed as such
- Display hover tooltip component also for the actors header
- Add asterisk