### PR TITLE
CSCFAIRMETA-678: Fix Auth store tests

### DIFF
--- a/etsin_finder/frontend/__tests__/authStore.test.jsx
+++ b/etsin_finder/frontend/__tests__/authStore.test.jsx
@@ -6,47 +6,87 @@ import Auth from '../js/stores/domain/auth'
 // This sets the mock adapter on the default instance
 const mock = new MockAdapter(axios)
 
-describe('Auth Store', () => {
-  mock
-    .onGet('/api/user')
-    .reply(200, { is_authenticated: true })
+const mockUser = {
+  is_authenticated: true,
+  is_authenticated_CSC_user: true,
+  home_organization_id: 'example.com/org',
+  home_organization_name: 'organisaatio',
+  user_ida_groups: ['IDA:project_x', 'IDA:project_y'],
+  is_using_rems: true,
+  user_csc_name: 'Testi Käyttäjä',
+}
 
-  it('Should be logged in', () => {
-    Auth.checkLogin().then(() => {
-      expect(Auth.userLogged).toEqual(true)
-    })
+describe('Auth Store', () => {
+  beforeEach(() => {
+    mock.reset()
+    mock.onGet('/api/user').reply(200, mockUser)
+    Auth.reset()
   })
-  it('Should have name and id', () => {
-    Auth.checkLogin().then(() => {
-      expect(Auth.user.name).toEqual('Testi Käyttäjä')
-    })
+
+  it('Should be logged in', async () => {
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(true)
   })
-  it('Should logout with logout()', () => {
-    mock.onDelete('/api/session').reply(200)
-    Auth.logout().then(() => {
-      expect(Auth.userLogged).toEqual(false)
-    })
-  })
-  it('Should not logout with logout() error', () => {
-    mock.onDelete('/api/session').reply(401)
-    Auth.checkLogin().then(() => {
-      Auth.logout().catch(() => {
-        expect(Auth.userLogged).toEqual(true)
+  it('Should have user data', async () => {
+    await Auth.checkLogin()
+    expect(Auth.user).toEqual(
+      expect.objectContaining({
+        name: 'Testi Käyttäjä',
+        loggedIn: true,
+        homeOrganizationName: 'organisaatio',
+        idaGroups: ['IDA:project_x', 'IDA:project_y'],
+        isUsingRems: true,
       })
-    })
+    )
   })
-  it('Login renewal error should clear login', () => {
-    mock.onGet('/api/session').reply(401)
-    const test = Auth.renewSession()
-    test.catch(() => {
-      expect(Auth.userLogged).toEqual(false)
-    })
+  it('Should fail to login without CSC user id', async () => {
+    const user = { ...mockUser, is_authenticated_CSC_user: false }
+    mock.onGet('/api/user').reply(200, user)
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(false)
   })
-  it('Login renewal error should clear user', () => {
+  it('Should logout with logout()', async () => {
+    mock.onDelete('/api/session').reply(200)
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(true)
+    await Auth.logout()
+    expect(Auth.userLogged).toBe(false)
+  })
+  it('Should not logout with logout() error', async () => {
+    mock.onDelete('/api/session').reply(401)
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(true)
+    // catch logged errors instead of printing
+    const spy = jest.spyOn(console, 'error').mockReturnValue()
+    try {
+      await Auth.logout()
+    } catch {}
+    expect(spy.mock.calls.length).toBe(1)
+    spy.mockRestore()
+    expect(Auth.userLogged).toBe(true)
+  })
+  it('Login renewal error should clear login', async () => {
     mock.onGet('/api/session').reply(401)
-    const test = Auth.renewSession()
-    test.catch(() => {
-      expect(Auth.user).toEqual({ id: undefined, name: undefined })
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(true)
+    try {
+      await Auth.renewSession()
+    } catch {}
+    expect(Auth.userLogged).toBe(false)
+  })
+  it('Login renewal error should clear user', async () => {
+    mock.onGet('/api/session').reply(401)
+    await Auth.checkLogin()
+    expect(Auth.userLogged).toBe(true)
+    try {
+      await Auth.renewSession()
+    } catch {}
+    expect(Auth.user).toEqual({
+      name: undefined,
+      loggedIn: false,
+      homeOrganizationName: undefined,
+      idaGroups: [],
+      isUsingRems: undefined,
     })
   })
 })

--- a/etsin_finder/frontend/__tests__/authStore.test.jsx
+++ b/etsin_finder/frontend/__tests__/authStore.test.jsx
@@ -17,10 +17,18 @@ const mockUser = {
 }
 
 describe('Auth Store', () => {
+  // catch logged errors instead of printing
+  let errorSpy
+
   beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockReturnValue()
     mock.reset()
     mock.onGet('/api/user').reply(200, mockUser)
     Auth.reset()
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
   })
 
   it('Should be logged in', async () => {
@@ -56,13 +64,10 @@ describe('Auth Store', () => {
     mock.onDelete('/api/session').reply(401)
     await Auth.checkLogin()
     expect(Auth.userLogged).toBe(true)
-    // catch logged errors instead of printing
-    const spy = jest.spyOn(console, 'error').mockReturnValue()
     try {
       await Auth.logout()
     } catch {}
-    expect(spy.mock.calls.length).toBe(1)
-    spy.mockRestore()
+    expect(errorSpy.mock.calls.length).toBe(1)
     expect(Auth.userLogged).toBe(true)
   })
   it('Login renewal error should clear login', async () => {

--- a/etsin_finder/frontend/__tests__/rems.test.jsx
+++ b/etsin_finder/frontend/__tests__/rems.test.jsx
@@ -46,7 +46,6 @@ describe('AskForAccess', () => {
 describe('REMSButton', () => {
   it('should render REMSButton as disabled', () => {
     const wrapper = shallow(<REMSButton applicationState="disabled" loading={false} />)
-    console.log(wrapper.debug())
     expect(wrapper.find('#rems-button-error').prop('disabled')).toEqual(true)
   })
   it('should render REMSButton for apply', () => {

--- a/etsin_finder/frontend/js/components/qvain/datasets/removeModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/removeModal.jsx
@@ -80,11 +80,7 @@ class RemoveModal extends Component {
         <TableButton id="cancel-remove-dataset" disabled={this.state.loading} onClick={onClose}>
           <Translate content="qvain.datasets.remove.confirm.cancel" />
         </TableButton>
-        <DangerButton
-          id="confirm-remove-dataset"
-          disabled={this.state.loading}
-          onClick={() => this.handleRemove()}
-        >
+        <DangerButton id="confirm-remove-dataset" disabled={this.state.loading} onClick={() => this.handleRemove()}>
           <Translate content={`qvain.datasets.remove.confirm.${removeKey}.ok`} />
         </DangerButton>
       </Modal>

--- a/etsin_finder/frontend/js/components/qvain/datasets/removeModal.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/removeModal.jsx
@@ -80,7 +80,11 @@ class RemoveModal extends Component {
         <TableButton id="cancel-remove-dataset" disabled={this.state.loading} onClick={onClose}>
           <Translate content="qvain.datasets.remove.confirm.cancel" />
         </TableButton>
-        <DangerButton id="confirm-remove-dataset" disabled={this.state.loading} onClick={() => this.handleRemove()}>
+        <DangerButton
+          id="confirm-remove-dataset"
+          disabled={this.state.loading}
+          onClick={() => this.handleRemove()}
+        >
           <Translate content={`qvain.datasets.remove.confirm.${removeKey}.ok`} />
         </DangerButton>
       </Modal>

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -9,7 +9,6 @@
  */
 
 import { observable, action, runInAction } from 'mobx'
-// import { observable, action, toJS } from 'mobx'
 import axios from 'axios'
 
 class Auth {

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -28,6 +28,25 @@ class Auth {
   }
 
   @action
+  resetUser = () => {
+    this.user = {
+      name: undefined,
+      loggedIn: false,
+      homeOrganizationName: undefined,
+      idaGroups: [],
+      isUsingRems: undefined,
+    }
+  }
+
+  @action
+  reset = () => {
+    this.resetUser()
+    this.userLogged = false
+    this.cscUserLogged = false
+    this.loading = false
+  }
+
+  @action
   checkLogin() {
     return new Promise((resolve, reject) => {
       runInAction(() => {
@@ -102,7 +121,7 @@ class Auth {
           resolve(res)
         })
         .catch((err) => {
-          console.log(err)
+          console.error(err)
           reject(err)
         })
     })
@@ -117,9 +136,7 @@ class Auth {
         .then(() => resolve())
         .catch((err) => {
           if (err.response.status === 401) {
-            this.userLogged = false
-            this.cscUserLogged = false
-            this.user = { name: undefined }
+            this.reset()
           }
           return reject(err)
         })


### PR DESCRIPTION
* Reset store state before each test
* Fix delayed test failures that were counted as passing
* Refactor tests to use async functions
* Add test to make sure user fields are filled in properly
* Hide console.error logging during tests