### PR TITLE
CSCFAIRMETA-679: [FIX] Use today's date for publishing by default

### DIFF
--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -1,5 +1,6 @@
 import { observable, action, computed, runInAction } from 'mobx'
 import axios from 'axios'
+import moment from 'moment'
 import { getDirectories, getFiles, deepCopy } from '../../components/qvain/utils/fileHierarchy'
 import urls from '../../components/qvain/utils/urls'
 import {
@@ -194,6 +195,11 @@ class Qvain {
       this.title.fi = title
     }
     this.changed = true
+
+    // If this is a new dataset/draft and date is not yet defined, set date to today's date
+    if (this.issuedDate === undefined && this.original === undefined) {
+      this.issuedDate = moment().format('YYYY-MM-DD')
+    }
   }
 
   @action


### PR DESCRIPTION
- This should not require separate definition (i.e. should not require user manually selecting the date)
- Now: if undefined, then today's date will be used (using the moment() library)
- Do not set the date by default using moment(), since that would cause snapshot issues
- Default must be undefined, and then later defined. Defined when title is set.