### PR TITLE
CSCFAIRMETA-675: Improve margins

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/actors/field/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/field/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
 import Translate from 'react-translate-component'
@@ -7,7 +6,7 @@ import AddedActors from './addedActors'
 import ActorTitle from './actorTitle'
 import { Container } from '../../general/card'
 import { Actor } from '../../../../stores/view/qvain.actors'
-import Button from '../../../general/button'
+import { ButtonContainer, AddNewButton } from '../../general/addButton'
 
 const ActorsField = ({ Stores }) => {
   const { editActor } = Stores.Qvain.Actors
@@ -33,13 +32,5 @@ const ActorsField = ({ Stores }) => {
 ActorsField.propTypes = {
   Stores: PropTypes.object.isRequired,
 }
-
-const ButtonContainer = styled.div`
-  text-align: right;
-`
-const AddNewButton = styled(Button)`
-  margin: 0;
-  margin-top: 11px;
-`
 
 export default inject('Stores')(observer(ActorsField))

--- a/etsin_finder/frontend/js/components/qvain/actors/modal/roleCheckbox.jsx
+++ b/etsin_finder/frontend/js/components/qvain/actors/modal/roleCheckbox.jsx
@@ -17,7 +17,7 @@ const RoleCheckbox = ({ Stores, role, help, disabled }) => {
   }
 
   const id = `role-${role}`
-  const helpField = help && <HelpField>{help}</HelpField>
+  const helpField = help && <RoleHelpField>{help}</RoleHelpField>
   const label = `qvain.actors.add.checkbox.${role}`
   return (
     <ListItem disabled={readonly || disabled}>
@@ -50,6 +50,10 @@ RoleCheckbox.defaultProps = {
   help: null,
   disabled: null,
 }
+
+const RoleHelpField = styled(HelpField)`
+  margin-left: 0.5em;
+`
 
 export const ListItem = styled.li`
   height: 40px;

--- a/etsin_finder/frontend/js/components/qvain/description/keywordsField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/keywordsField.jsx
@@ -10,10 +10,10 @@ import counterpart from 'counterpart'
 import Tooltip from '../../general/tooltipHover'
 import Card from '../general/card'
 import Label from '../general/label'
-import Button from '../../general/button'
 import { keywordsSchema } from '../utils/formValidation'
 import ValidationError from '../general/validationError'
-import { LabelLarge } from '../general/form'
+import { LabelLarge, Input } from '../general/form'
+import { ButtonContainer, AddNewButton } from '../general/addButton'
 
 class KeywordsField extends Component {
   static propTypes = {
@@ -111,24 +111,8 @@ class KeywordsField extends Component {
   }
 }
 
-const Input = styled.input`
-  width: 100%;
-  border-radius: 3px;
-  border: 1px solid #cccccc;
-  padding: 8px;
-  color: #808080;
-  margin-bottom: 20px;
-`
 const PaddedWord = styled.span`
   padding-right: 10px;
-`
-
-const ButtonContainer = styled.div`
-  text-align: right;
-`
-const AddNewButton = styled(Button)`
-  margin: 0;
-  margin-top: 11px;
 `
 
 export default inject('Stores')(observer(KeywordsField))

--- a/etsin_finder/frontend/js/components/qvain/description/otherIdentifierField.jsx
+++ b/etsin_finder/frontend/js/components/qvain/description/otherIdentifierField.jsx
@@ -6,12 +6,12 @@ import Translate from 'react-translate-component'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import translate from 'counterpart'
-import Button from '../../general/button'
 import Card from '../general/card'
 import Label from '../general/label'
 import { otherIdentifiersArraySchema, otherIdentifierSchema } from '../utils/formValidation'
 import ValidationError from '../general/validationError'
 import { Input, LabelLarge } from '../general/form'
+import { ButtonContainer, AddNewButton } from '../general/addButton'
 
 const OtherIdentifierField = ({ Stores }) => {
   const {
@@ -111,13 +111,6 @@ OtherIdentifierField.propTypes = {
   Stores: PropTypes.object.isRequired,
 }
 
-const ButtonContainer = styled.div`
-  text-align: right;
-`
-const AddNewButton = styled(Button)`
-  margin: 0;
-  margin-top: 11px;
-`
 const PaddedWord = styled.span`
   padding-right: 10px;
 `

--- a/etsin_finder/frontend/js/components/qvain/general/addButton.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/addButton.jsx
@@ -48,9 +48,9 @@ AddButton.defaultProps = {
 export default inject('Stores')(observer(AddButton))
 
 export const ButtonContainer = styled.div`
+  margin-top: 1.25rem;
   text-align: right;
 `
 export const AddNewButton = styled(Button)`
   margin: 0;
-  margin-top: 11px;
 `

--- a/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/buttons.jsx
@@ -106,7 +106,7 @@ export const DangerCancelButton = styled.button`
   border: solid 1px #4f4f4f;
   font-size: 16px;
   line-height: 1.31;
-  padding: 0.75rem 0.25rem;
+  padding: 0.75rem 1.25rem;
   color: #4f4f4f;
   &:hover {
     background-color: #ccc;

--- a/etsin_finder/frontend/js/components/qvain/general/card.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/card.jsx
@@ -68,7 +68,6 @@ export const StickySubHeaderWrapper = styled.div`
 `
 
 export const StickySubHeader = styled.div`
-  height: 50px;
   background-color: rgb(231, 233, 237);
   color: #4f4f4f;
   display: flex;

--- a/etsin_finder/frontend/js/components/qvain/general/durationpicker.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/durationpicker.jsx
@@ -24,11 +24,11 @@ const DurationPicker = ({ Stores, Field, translationsRoot, datum }) => {
     date && handleDatePickerChange(date.toISOString(), d => changeAttribute(propName, d))
 
   return (
-    <DatePickerContainer>
+    <>
       <Label htmlFor="period-of-time-input" style={{ width: '100%', marginBottom: 5 }}>
         <Translate content={translations.label} />
       </Label>
-      <DatePickerStartWrapper>
+      <DatePickerContainer>
         <Translate
           id="startTimeInput"
           component={DatePicker}
@@ -48,27 +48,27 @@ const DurationPicker = ({ Stores, Field, translationsRoot, datum }) => {
           dateFormat={getDateFormatLocale(lang)}
           disabled={readonly}
         />
-      </DatePickerStartWrapper>
-      <Translate
-        id="endTimeInput"
-        component={DatePicker}
-        selectsEnd
-        minDate={startDate && new Date(startDate)}
-        startDate={startDate && new Date(startDate)}
-        endDate={endDate && new Date(endDate)}
-        strictParsing
-        selected={endDate ? new Date(endDate) : ''}
-        onChangeRaw={e => handleDateChangeRaw(e, 'endDate')}
-        onChange={date => handleDateChange(date, 'endDate')}
-        locale={lang}
-        attributes={{
-          placeholderText: translations.endPlaceholder,
-          ariaLabel: translations.endPlaceholder,
-        }}
-        dateFormat={getDateFormatLocale(lang)}
-        disabled={readonly}
-      />
-    </DatePickerContainer>
+        <Translate
+          id="endTimeInput"
+          component={DatePicker}
+          selectsEnd
+          minDate={startDate && new Date(startDate)}
+          startDate={startDate && new Date(startDate)}
+          endDate={endDate && new Date(endDate)}
+          strictParsing
+          selected={endDate ? new Date(endDate) : ''}
+          onChangeRaw={e => handleDateChangeRaw(e, 'endDate')}
+          onChange={date => handleDateChange(date, 'endDate')}
+          locale={lang}
+          attributes={{
+            placeholderText: translations.endPlaceholder,
+            ariaLabel: translations.endPlaceholder,
+          }}
+          dateFormat={getDateFormatLocale(lang)}
+          disabled={readonly}
+        />
+      </DatePickerContainer>
+    </>
   )
 }
 
@@ -83,10 +83,15 @@ const DatePickerContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
-`
+  margin: -0.25em -0.25em calc(-0.25em + 1.25em) -0.25em;
 
-const DatePickerStartWrapper = styled.span`
-  margin-right: 0.5em;
+  & > * {
+    margin: 0.25em;
+  }
+
+  input[type='text'] {
+    margin: 0;
+  }
 `
 
 export default inject('Stores')(observer(DurationPicker))

--- a/etsin_finder/frontend/js/components/qvain/general/fieldListAdd.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/fieldListAdd.jsx
@@ -107,6 +107,8 @@ FieldListAdd.defaultProps = {
 
 const ButtonContainer = styled.div`
   text-align: ${props => props.position};
+  margin-top: 1.25rem;
+  margin-bottom: 0;
 `
 const AddNewButton = styled(Button)`
   margin: 0;

--- a/etsin_finder/frontend/js/components/qvain/general/form.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/form.jsx
@@ -16,7 +16,8 @@ export const Input = styled.input`
   border: solid 1px #cccccc;
   padding: 8px;
   color: #000;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
+  display: block;
 `
 
 export const Textarea = styled.textarea`
@@ -25,11 +26,12 @@ export const Textarea = styled.textarea`
   border: solid 1px #cccccc;
   padding: 8px;
   color: #000;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
+  display: block;
 `
 
 export const CustomSelect = styled(Select)`
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 `
 
 export const Label = styled.label`
@@ -70,6 +72,8 @@ export const RadioInput = styled.input`
   height: 16px;
   margin: 5px;
   padding: 0;
+  flex-shrink: 0;
+  flex-grow: 0;
 `
 
 export const Checkbox = props => <CheckboxStyles {...props} type="checkbox" />

--- a/etsin_finder/frontend/js/components/qvain/general/modalReferenceInput.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/modalReferenceInput.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Translate from 'react-translate-component'
 import { Observer } from 'mobx-react'
+import styled from 'styled-components'
+
 import SearchSelect from './searchSelect'
 import Select from './select'
 import { Label } from './form'
@@ -52,12 +54,12 @@ const ModalReferenceInput = ({
   const select = search ? getSearchSelect() : getStaticSelect()
 
   return (
-    <>
+    <ModalReferenceInputContainer>
       <Label htmlFor={`${datum}-input`}>
         <Translate content={translations.label} />
       </Label>
       <Observer>{() => select}</Observer>
-    </>
+    </ModalReferenceInputContainer>
   )
 }
 
@@ -73,5 +75,9 @@ ModalReferenceInput.propTypes = {
 ModalReferenceInput.defaultProps = {
   search: false,
 }
+
+const ModalReferenceInputContainer = styled.div`
+  margin-bottom: 0.75em;
+`
 
 export default ModalReferenceInput

--- a/etsin_finder/frontend/js/components/qvain/temporalAndSpatial/spatial/form/SpatialArrayInput.jsx
+++ b/etsin_finder/frontend/js/components/qvain/temporalAndSpatial/spatial/form/SpatialArrayInput.jsx
@@ -68,7 +68,7 @@ const ModalArrayInput = ({
         <Translate content={translations.label} /> {isRequired ? '*' : ''}
       </Label>
       {renderInputs()}
-      <Button
+      <AddButton
         onClick={() => {
           const arr = [...Field.inEdit[datum]]
           arr.push({ key: uuidv4(), value: '' })
@@ -76,7 +76,7 @@ const ModalArrayInput = ({
         }}
       >
         <Translate content={`${translationsRoot}.modal.buttons.addGeometry`} />
-      </Button>
+      </AddButton>
       {error && <ArrayInputError>{error}</ArrayInputError>}
     </ModalArrayInputWrapper>
   )
@@ -100,6 +100,10 @@ ModalArrayInput.defaultProps = {
 
 const ModalArrayInputWrapper = styled.div`
   margin-bottom: 8px;
+`
+
+const AddButton = styled(Button)`
+  margin-left: 0;
 `
 
 const RemoveButton = styled(Button)`


### PR DESCRIPTION
- Make margins more consistent in the UI
- Use `display: block` for inputs to allow margins to collapse
- Allow sticky header to grow vertically when needed