### PR TITLE
CSCFAIRMETA-706: Update werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz==2018.9
 pyyaml==5.1
 requests==2.21.0
 tox==3.7.0
+Werkzeug==1.0.1


### PR DESCRIPTION
Needed by https://github.com/CSCfi/etsin-ops/pull/28 to support `SameSite=None`