### PR TITLE
CSCFAIRMETA-706: Front-end support for running Etsin and Qvain Light in separate domains

### DIFF
--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.jsx.snap
@@ -312,7 +312,10 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -322,6 +325,7 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": true,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -341,7 +345,10 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -351,6 +358,7 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": true,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {
@@ -576,7 +584,10 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -586,6 +597,7 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": true,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -605,7 +617,10 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -615,6 +630,7 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": true,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {
@@ -840,7 +856,10 @@ exports[`Qvain.Description should render <LanguageField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -850,6 +869,7 @@ exports[`Qvain.Description should render <LanguageField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": true,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -869,7 +889,10 @@ exports[`Qvain.Description should render <LanguageField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -879,6 +902,7 @@ exports[`Qvain.Description should render <LanguageField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": true,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {
@@ -1104,7 +1128,10 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -1114,6 +1141,7 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": true,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -1133,7 +1161,10 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -1143,6 +1174,7 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": true,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
@@ -269,7 +269,10 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -279,6 +282,7 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": false,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -298,7 +302,10 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -308,6 +315,7 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": false,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {
@@ -533,7 +541,10 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -543,6 +554,7 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": false,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -562,7 +574,10 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -572,6 +587,7 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": false,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {
@@ -797,7 +813,10 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
   Stores={
     Object {
       "Env": Env {
+        "app": undefined,
         "environment": "test",
+        "getEtsinUrl": [Function],
+        "getQvainUrl": [Function],
         "history": RouterStore {
           "go": [Function],
           "goBack": [Function],
@@ -807,6 +826,7 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "replace": [Function],
         },
         "metaxApiV2": false,
+        "separateQvain": false,
       },
       "Locale": Locale {},
       "Qvain": Qvain {
@@ -826,7 +846,10 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "toBackend": [Function],
         },
         "Env": Env {
+          "app": undefined,
           "environment": "test",
+          "getEtsinUrl": [Function],
+          "getQvainUrl": [Function],
           "history": RouterStore {
             "go": [Function],
             "goBack": [Function],
@@ -836,6 +859,7 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
             "replace": [Function],
           },
           "metaxApiV2": false,
+          "separateQvain": false,
         },
         "Files": Files {
           "AddItemsView": AddItemsView {

--- a/etsin_finder/frontend/js/components/general/navigation/maybeNavLink.jsx
+++ b/etsin_finder/frontend/js/components/general/navigation/maybeNavLink.jsx
@@ -1,0 +1,21 @@
+import { NavLink } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Link } from '../button'
+
+// return either a NavLink (moving within app) or Link (moving between sites) based on link target.
+
+const MaybeNavLink = ({ to, ...props }) => {
+  if (to.includes('://')) {
+    return <Link href={to} rel="noopener noreferrer" target="_blank" {...props} />
+  }
+  return <CustomNavLink to={to} {...props} />
+}
+
+MaybeNavLink.propTypes = {
+  to: PropTypes.string.isRequired,
+}
+
+const CustomNavLink = Link.withComponent(NavLink)
+
+export default MaybeNavLink

--- a/etsin_finder/frontend/js/components/general/navigation/mobileNavi.jsx
+++ b/etsin_finder/frontend/js/components/general/navigation/mobileNavi.jsx
@@ -12,6 +12,7 @@
 
 import PropTypes from 'prop-types'
 import React from 'react'
+import { inject, observer } from 'mobx-react'
 import { NavLink } from 'react-router-dom'
 import Translate from 'react-translate-component'
 import translate from 'counterpart'
@@ -25,9 +26,11 @@ import LangToggle from './langToggle'
 import Login from './loginButton'
 import { Link } from '../button'
 import { QVAIN_URL } from '../../../utils/constants'
+import MaybeNavLink from './maybeNavLink'
 
-export default class MobileNavi extends React.Component {
+class MobileNavi extends React.Component {
   render() {
+    const { Env } = this.props.Stores
     return (
       <MobileItems>
         <DropdownMenu transparent buttonContent={<FontAwesomeIcon title="Menu" icon={faBars} size="lg" />} transparentButton>
@@ -63,13 +66,13 @@ export default class MobileNavi extends React.Component {
                 >
                   Qvain
                 </Link>
-                <QvainNavLink
+                <MaybeNavLink
                   width="50%"
                   margin="0em 0em 0.6em 0em"
-                  to="/qvain"
+                  to={Env.getQvainUrl('')}
                 >
                   Qvain Light
-                </QvainNavLink>
+                </MaybeNavLink>
               </Row>
             </DatasetCont>
             <Row>
@@ -93,6 +96,12 @@ export default class MobileNavi extends React.Component {
     )
   }
 }
+
+MobileNavi.propTypes = {
+  Stores: PropTypes.object.isRequired,
+}
+
+export default inject('Stores')(observer(MobileNavi))
 
 MobileNavi.defaultProps = {
   helpUrl: undefined,
@@ -155,8 +164,6 @@ const NavItem = styled(NavLink)`
     color: ${p => p.theme.color.primary};
   }
 `
-
-const QvainNavLink = Link.withComponent(NavLink)
 
 const CustomContainer = styled.div`
   margin: 0 auto;

--- a/etsin_finder/frontend/js/components/general/navigation/settings.jsx
+++ b/etsin_finder/frontend/js/components/general/navigation/settings.jsx
@@ -14,16 +14,18 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Translate from 'react-translate-component'
 import styled from 'styled-components'
-import { NavLink } from 'react-router-dom'
+import { inject, observer } from 'mobx-react'
 
 import Login from './loginButton'
 import { Link } from '../button'
 import LangToggle from './langToggle'
 import DropdownMenu from './dropdownMenu'
 import { QVAIN_URL } from '../../../utils/constants'
+import MaybeNavLink from './maybeNavLink'
 
-export default class Settings extends Component {
+class Settings extends Component {
   render() {
+    const { Env } = this.props.Stores
     return (
       <React.Fragment>
         <Positioner>
@@ -45,16 +47,14 @@ export default class Settings extends Component {
                   href={QVAIN_URL}
                   rel="noopener noreferrer"
                   target="_blank"
-                >Qvain
+                >
+                  Qvain
                 </Link>
               </Row>
               <Row>
-                <QvainNavLink
-                  width="100%"
-                  margin="0.4em 0em 0.4em 0.4em"
-                  to="/qvain"
-                >Qvain Light
-                </QvainNavLink>
+                <MaybeNavLink width="100%" margin="0.4em 0em 0.4em 0.4em" to={Env.getQvainUrl('')}>
+                  Qvain Light
+                </MaybeNavLink>
               </Row>
             </CustomContainer>
           </DropdownMenu>
@@ -66,6 +66,11 @@ export default class Settings extends Component {
   }
 }
 
+Settings.propTypes = {
+  Stores: PropTypes.object.isRequired,
+}
+
+export default inject('Stores')(observer(Settings))
 
 Settings.defaultProps = {
   helpUrl: undefined,
@@ -89,8 +94,6 @@ const CustomContainer = styled.div`
   max-width: 400px;
   width: 100%;
 `
-
-const QvainNavLink = Link.withComponent(NavLink)
 
 const Row = styled.div`
   display: inline-flex;

--- a/etsin_finder/frontend/js/components/qvain/datasets/dataset.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/dataset.jsx
@@ -23,7 +23,7 @@ const datasetStateTranslation = dataset => {
   return 'qvain.datasets.state.draft'
 }
 
-const getGoToEtsinButton = dataset => {
+const getGoToEtsinButton = (dataset, getEtsinUrl) => {
   let identifier = dataset.identifier
   let goToEtsinKey = 'goToEtsin'
   if (dataset.next_draft) {
@@ -36,7 +36,7 @@ const getGoToEtsinButton = dataset => {
   return (
     <Translate
       component={TableButton}
-      onClick={() => window.open(`/dataset/${identifier}`, '_blank')}
+      onClick={() => window.open(getEtsinUrl(`/dataset/${identifier}`), '_blank')}
       content={`qvain.datasets.${goToEtsinKey}`}
     />
   )
@@ -83,7 +83,7 @@ function Dataset({
   indent,
   highlight,
 }) {
-  const { metaxApiV2 } = Stores.Env
+  const { metaxApiV2, getEtsinUrl } = Stores.Env
   const actions = []
   if (
     metaxApiV2 &&
@@ -144,7 +144,7 @@ function Dataset({
             dataset.next_draft ? 'qvain.datasets.editDraftButton' : 'qvain.datasets.editButton'
           }
         />
-        {getGoToEtsinButton(dataset)}
+        {getGoToEtsinButton(dataset, getEtsinUrl)}
         {actions.length === 1 ? (
           getActionButton(actions[0])
         ) : (

--- a/etsin_finder/frontend/js/components/qvain/datasets/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/index.jsx
@@ -33,6 +33,7 @@ class Datasets extends Component {
 
   render() {
     const { publishedDataset, setPublishedDataset } = this.props.Stores.QvainDatasets
+    const { getQvainUrl } = this.props.Stores.Env
 
     return (
       <QvainContainer>
@@ -54,7 +55,7 @@ class Datasets extends Component {
                 component={SaveButton}
                 onClick={() => {
                   this.props.Stores.Qvain.resetQvainStore()
-                  this.props.history.push('/qvain/dataset')
+                  this.props.history.push(getQvainUrl('/dataset'))
                 }}
                 content="qvain.datasets.createButton"
               />

--- a/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
+++ b/etsin_finder/frontend/js/components/qvain/datasets/table.jsx
@@ -145,7 +145,7 @@ class DatasetTable extends Component {
   }
 
   handleCreateNewVersion = async identifier => {
-    const { metaxApiV2 } = this.props.Stores.Env
+    const { metaxApiV2, getQvainUrl } = this.props.Stores.Env
     if (!metaxApiV2) {
       console.error('Metax API V2 is required for creating a new version')
       return
@@ -156,7 +156,7 @@ class DatasetTable extends Component {
     this.promises.push(promise)
     const res = await promise
     const newIdentifier = res.data.identifier
-    this.props.history.replace(`/qvain/dataset/${newIdentifier}`)
+    this.props.history.push(getQvainUrl(`/dataset/${newIdentifier}`))
   }
 
   postRemoveUpdate = (dataset, onlyChanges) => {
@@ -202,12 +202,13 @@ class DatasetTable extends Component {
   }
 
   handleEnterEdit = dataset => () => {
+    const { getQvainUrl } = this.props.Stores.Env
     if (dataset.next_draft) {
-      this.props.history.push(`/qvain/dataset/${dataset.next_draft.identifier}`)
+      this.props.history.push(getQvainUrl(`/dataset/${dataset.next_draft.identifier}`))
       return
     }
     this.props.Stores.Qvain.editDataset(dataset)
-    this.props.history.push(`/qvain/dataset/${dataset.identifier}`)
+    this.props.history.push(getQvainUrl(`/dataset/${dataset.identifier}`))
   }
 
   handleChangePage = pageNum => () => {

--- a/etsin_finder/frontend/js/components/qvain/editor/submitButtons.jsx
+++ b/etsin_finder/frontend/js/components/qvain/editor/submitButtons.jsx
@@ -314,7 +314,7 @@ class SubmitButtons extends Component {
     // Create new draft dataset
     const { history } = this.props
     const { original, setChanged, editDataset } = this.props.Stores.Qvain
-    const { metaxApiV2 } = this.props.Stores.Env
+    const { metaxApiV2, getQvainUrl } = this.props.Stores.Env
     if (original) {
       console.error('Use handleCreateNewVersion to create a draft from a published dataset')
       return null
@@ -347,7 +347,7 @@ class SubmitButtons extends Component {
         } else {
           await editDataset(res.data)
         }
-        history.replace(`/qvain/dataset/${identifier}`)
+        history.replace(getQvainUrl(`/dataset/${identifier}`))
       }
 
       if (showSuccess) {
@@ -374,6 +374,7 @@ class SubmitButtons extends Component {
     // If something goes wrong while updating files,
     // the incomplete dataset wont't get published.
     let identifier
+    const { getQvainUrl } = this.props.Stores.Env
     try {
       identifier = await this.handleCreateNewDraft(false, false)
       if (identifier) {
@@ -381,7 +382,7 @@ class SubmitButtons extends Component {
       }
     } catch (error) {
       if (identifier) {
-        this.props.history.replace(`/qvain/dataset/${identifier}`)
+        this.props.history.replace(getQvainUrl(`/dataset/${identifier}`))
       }
       this.failure(error)
     }
@@ -391,7 +392,7 @@ class SubmitButtons extends Component {
     // Create draft of a published dataset, save current changes to the draft
     const { Stores, history } = this.props
     const { original, editDataset } = Stores.Qvain
-    const { metaxApiV2 } = Stores.Env
+    const { metaxApiV2, getQvainUrl } = Stores.Env
     if (!original || original.state !== 'published') {
       console.error('Expected a published dataset')
       return null
@@ -418,7 +419,7 @@ class SubmitButtons extends Component {
       // Update created draft
       const dataset = await this.patchDataset(values)
       await editDataset(dataset)
-      history.replace(`/qvain/dataset/${dataset.identifier}`)
+      history.replace(getQvainUrl(`/dataset/${dataset.identifier}`))
       const data = { ...dataset, is_draft: true }
       this.success(data)
       return newIdentifier
@@ -471,7 +472,7 @@ class SubmitButtons extends Component {
   handlePublishDataset = async (saveChanges = true, overrideIdentifier = null) => {
     const { Stores, history } = this.props
     const { original, editDataset } = Stores.Qvain
-    const { metaxApiV2 } = Stores.Env
+    const { metaxApiV2, getQvainUrl } = Stores.Env
 
     if (!metaxApiV2) {
       console.error('Metax API V2 is required for publishing drafts')
@@ -506,7 +507,7 @@ class SubmitButtons extends Component {
       const resp = await axios.get(publishedUrl)
 
       await editDataset(resp.data)
-      history.replace(`/qvain/dataset/${resp.data.identifier}`)
+      history.replace(getQvainUrl(`/dataset/${resp.data.identifier}`))
 
       this.success(resp.data)
       this.goToDatasets(resp.data.identifier)

--- a/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/metadataModal/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
 import styled from 'styled-components'
 import axios from 'axios'
-
 import { observable, action } from 'mobx'
 
 import Modal from '../../../general/modal'

--- a/etsin_finder/frontend/js/components/qvain/files/response.jsx
+++ b/etsin_finder/frontend/js/components/qvain/files/response.jsx
@@ -2,18 +2,19 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Translate from 'react-translate-component'
-import { withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom'
+import { inject, observer } from 'mobx-react'
 
 import Loader from '../../general/loader'
 import { TableButton } from '../general/buttons'
 
-
 // Shows success/fail based on a RPC request response. If the response prop is null, shows a loader.
-const Response = (props) => {
+const Response = props => {
   const { response, history, requestClose } = props
+  const { getQvainUrl } = props.Stores.Env
 
-  const handleOpenNewVersion = (identifier) => {
-    history.push(`/qvain/dataset/${identifier}`)
+  const handleOpenNewVersion = identifier => {
+    history.push(getQvainUrl(`/dataset/${identifier}`))
     requestClose()
   }
 
@@ -25,7 +26,7 @@ const Response = (props) => {
           <ResponseLabel>
             <Translate content="qvain.files.responses.fail" />
           </ResponseLabel>
-          <p>{(response.error.toString().replace(/,/g, '\n'))}</p>
+          <p>{response.error.toString().replace(/,/g, '\n')}</p>
         </ResponseContainerContent>
       </ResponseContainerError>
     )
@@ -41,9 +42,13 @@ const Response = (props) => {
           <ResponseLabel success>
             <Translate content="qvain.files.responses.changeComplete" />
           </ResponseLabel>
-          { newIdentifier && (
+          {newIdentifier && (
             <>
-              <Translate component="p" content="qvain.files.responses.versionCreated" with={{ identifier: newIdentifier }} />
+              <Translate
+                component="p"
+                content="qvain.files.responses.versionCreated"
+                with={{ identifier: newIdentifier }}
+              />
               <NewVersionButton onClick={() => handleOpenNewVersion(newIdentifier)}>
                 <Translate content={'qvain.files.responses.openNewVersion'} />
               </NewVersionButton>
@@ -63,6 +68,7 @@ const Response = (props) => {
 }
 
 Response.propTypes = {
+  Stores: PropTypes.object.isRequired,
   response: PropTypes.object,
   history: PropTypes.object.isRequired,
   requestClose: PropTypes.func,
@@ -85,18 +91,18 @@ const ResponseContainerSuccess = styled.div`
   width: 100%;
   color: green;
   z-index: 2;
-  border-bottom: 1px solid rgba(0,0,0,0.3);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   position: relative;
   margin-bottom: 0.5em;
   min-width: 300px;
 `
 const ResponseContainerError = styled.div`
-  background-color: #FFEBE8;
+  background-color: #ffebe8;
   text-align: center;
   width: 100%;
-  color: ${(props) => props.theme.colo.redText};
+  color: ${props => props.theme.colo.redText};
   z-index: 2;
-  border-bottom: 1px solid rgba(0,0,0,0.3);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   position: relative;
   margin-bottom: 0.5em;
   min-width: 300px;
@@ -129,4 +135,4 @@ const NewVersionButton = styled(TableButton)`
   margin-bottom: 1em;
 `
 
-export default withRouter(Response)
+export default withRouter(inject('Stores')(observer(Response)))

--- a/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/submitResponse.jsx
@@ -37,7 +37,8 @@ class SubmitResponse extends Component {
   }
 
   handleOpenNewVersion = identifier => {
-    this.props.history.push(`/qvain/dataset/${identifier}`)
+    const { getQvainUrl } = this.props.Stores.Env
+    this.props.history.push(getQvainUrl(`/dataset/${identifier}`))
     this.closeSubmitResponse()
   }
 
@@ -50,6 +51,7 @@ class SubmitResponse extends Component {
   render() {
     const { response } = this.props
     const { original } = this.props.Stores.Qvain
+    const { getEtsinUrl } = this.props.Stores.Env
 
     // If the user wants to clear the submitResponse
     if (this.state.clearSubmitResponse) {
@@ -81,7 +83,9 @@ class SubmitResponse extends Component {
                 content={`qvain.submitStatus.${response.is_draft ? 'draftSuccess' : 'success'}`}
               />
             </ResponseLabel>
-            <LinkToEtsin onClick={() => window.open(`/dataset/${identifier}`, '_blank')}>
+            <LinkToEtsin
+              onClick={() => window.open(getEtsinUrl(`/dataset/${identifier}`), '_blank')}
+            >
               {goToEtsin}
             </LinkToEtsin>
             <p>Identifier: {this.getPreferredIdentifier()}</p>
@@ -119,7 +123,9 @@ class SubmitResponse extends Component {
                 }
               />
             </ResponseLabel>
-            <LinkToEtsin onClick={() => window.open(`/dataset/${identifier}`, '_blank')}>
+            <LinkToEtsin
+              onClick={() => window.open(getEtsinUrl(`/dataset/${identifier}`), '_blank')}
+            >
               {goToEtsin}
             </LinkToEtsin>
             <p>Identifier: {this.getPreferredIdentifier()}</p>
@@ -233,14 +239,14 @@ const FadeInAnimation = keyframes`
     color: #FFEBE8;
   }
   to {
-    color: ${(props) => props.theme.color.redText};
+    color: ${props => props.theme.color.redText};
   }
 `
 const ResponseContainerError = styled.div`
   background-color: #ffebe8;
   text-align: center;
   width: 100%;
-  color: ${(props) => props.theme.color.redText};
+  color: ${props => props.theme.color.redText};
   z-index: 2;
   border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   animation-name: ${FadeInAnimation};

--- a/etsin_finder/frontend/js/components/qvain/main/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/main/index.jsx
@@ -87,7 +87,7 @@ class Qvain extends Component {
   getDataset(identifier) {
     this.setState({ datasetLoading: true, datasetError: false, response: null, submitted: false })
     const { resetQvainStore, editDataset } = this.props.Stores.Qvain
-    const { metaxApiV2 } = this.props.Stores.Env
+    const { metaxApiV2, getQvainUrl } = this.props.Stores.Env
 
     let url = urls.v1.dataset(identifier)
     if (metaxApiV2) {
@@ -101,7 +101,7 @@ class Qvain extends Component {
         // Open draft instead if it exists
         const nextDraft = result.data.next_draft && result.data.next_draft.identifier
         if (nextDraft) {
-          this.props.history.replace(`/qvain/dataset/${nextDraft}`)
+          this.props.history.replace(getQvainUrl(`/dataset/${nextDraft}`))
         } else {
           editDataset(result.data)
           this.setState({ datasetLoading: false, datasetError: false, haveDataset: true })

--- a/etsin_finder/frontend/js/stores/domain/auth.js
+++ b/etsin_finder/frontend/js/stores/domain/auth.js
@@ -60,6 +60,7 @@ class Auth {
       axios
         .get('/api/user', {
           headers: { 'content-type': 'application/json', charset: 'utf-8' },
+          withCredentials: true
         })
         .then(
           action(res => {

--- a/etsin_finder/frontend/js/stores/domain/env.js
+++ b/etsin_finder/frontend/js/stores/domain/env.js
@@ -8,18 +8,65 @@
  * @license   MIT
  */
 
-import { action, observable } from 'mobx'
+import { action, computed, observable } from 'mobx'
 import { RouterStore } from 'mobx-react-router'
 
 const routingStore = new RouterStore()
+
+const getCookieValue = (key) => {
+  const entry = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(key))
+  if (entry) {
+    return entry.split('=')[1]
+  }
+  return undefined
+}
+
+const qvainHost = process.env.REACT_APP_QVAIN_HOST
+const etsinHost = process.env.REACT_APP_ETSIN_HOST
 
 class Env {
   @observable environment = process.env.NODE_ENV
 
   @observable metaxApiV2 = process.env.NODE_ENV !== 'production' && localStorage.getItem('metax_api_v2') === '1'
 
+  @observable app = getCookieValue('etsin_app')
+
+  @computed
+  get isQvain() {
+    return this.app === 'qvain'
+  }
+
+  @computed
+  get isEtsin() {
+    return this.app !== 'qvain'
+  }
+
+  @observable separateQvain = qvainHost !== etsinHost
+
   @action setMetaxApiV2 = (value) => {
     this.metaxApiV2 = value
+  }
+
+  getQvainUrl = (path) => {
+    if (this.isQvain) {
+      return path
+    }
+    if (qvainHost && this.separateQvain) {
+      return `https://${qvainHost}${path}`
+    }
+    return `/qvain${path}`
+  }
+
+  getEtsinUrl = (path) => {
+    if (this.isEtsin) {
+      return path
+    }
+    if (etsinHost && this.separateQvain) {
+      return `https://${etsinHost}${path}`
+    }
+    return path
   }
 
   history = routingStore

--- a/etsin_finder/frontend/js/stores/view/elasticquery.js
+++ b/etsin_finder/frontend/js/stores/view/elasticquery.js
@@ -363,11 +363,11 @@ class ElasticQuery {
             ],
             must_not: [
               {
-                  term: {
-                      'data_catalog.en': this.includePasDatasets ? '' : 'Fairdata PAS datasets'
-                  }
+                term: {
+                  'data_catalog.en': this.includePasDatasets ? '' : 'Fairdata PAS datasets'
+                }
               }
-          ]
+            ]
           },
         }
       } else {
@@ -380,11 +380,11 @@ class ElasticQuery {
             ],
             must_not: [
               {
-                  term: {
-                      'data_catalog.en': this.includePasDatasets ? '' : 'Fairdata PAS datasets'
-                  }
+                term: {
+                  'data_catalog.en': this.includePasDatasets ? '' : 'Fairdata PAS datasets'
+                }
               }
-          ]
+            ]
           },
         }
       }

--- a/etsin_finder/frontend/js/stores/view/qvain.actors.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.actors.js
@@ -72,10 +72,10 @@ const actorToBackend = actor => ({
   person:
     actor.type === ENTITY_TYPE.PERSON
       ? {
-          name: actor.person.name,
-          email: actor.person.email || undefined,
-          identifier: actor.person.identifier || undefined,
-        }
+        name: actor.person.name,
+        email: actor.person.email || undefined,
+        identifier: actor.person.identifier || undefined,
+      }
       : undefined,
   organizations: actor.organizations.map(org => ({
     name: org.name,
@@ -522,10 +522,10 @@ class Actors {
       person:
         actor.type === ENTITY_TYPE.PERSON
           ? {
-              name: actor.person.name,
-              email: actor.person.email || undefined,
-              identifier: actor.person.identifier || undefined,
-            }
+            name: actor.person.name,
+            email: actor.person.email || undefined,
+            identifier: actor.person.identifier || undefined,
+          }
           : undefined,
       organizations: actor.organizations.map(org => ({
         name: org.name,

--- a/etsin_finder/frontend/package.json
+++ b/etsin_finder/frontend/package.json
@@ -85,6 +85,7 @@
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
     "babel-plugin-styled-components": "^1.10.7",
+    "dotenv-webpack": "^2.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.4.4",

--- a/etsin_finder/frontend/webpack.config.js
+++ b/etsin_finder/frontend/webpack.config.js
@@ -1,6 +1,7 @@
 require('@babel/polyfill')
 const env = require('dotenv').config()
 const path = require('path')
+const DotenvPlugin = require('dotenv-webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 
@@ -49,6 +50,7 @@ const config = {
       MATOMO_URL: env.parsed ? env.parsed.MATOMO_URL : undefined,
       MATOMO_SITE_ID: env.parsed ? env.parsed.MATOMO_SITE_ID : undefined,
     }),
+    new DotenvPlugin(),
   ],
   watch: false,
   watchOptions: {

--- a/etsin_finder/frontend/webpack.prod.js
+++ b/etsin_finder/frontend/webpack.prod.js
@@ -1,5 +1,6 @@
 const env = require('dotenv').config()
 const path = require('path')
+const DotenvPlugin = require('dotenv-webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
@@ -45,6 +46,7 @@ const config = {
       MATOMO_URL: env.parsed ? env.parsed.MATOMO_URL : undefined,
       MATOMO_SITE_ID: env.parsed ? env.parsed.MATOMO_SITE_ID : undefined,
     }),
+    new DotenvPlugin(),
   ],
   optimization: {
     minimize: true,


### PR DESCRIPTION
* Read variables from `frontend/.env` if it exists using `dotenv-webpack` plugin
* Use REACT_APP_ETSIN_HOST, REACT_APP_QVAIN_HOST env variables for redirection between Etsin and Qvain
* When REACT_APP_QVAIN_HOST is defined and different from the Etsin host, `/qvain` is redirected there
* Add `Env.getQvainUrl()` that adds the `/qvain` prefix and/or the correct host when needed
* Add `Env.getEtsinUrl()` that adds Etsin host when needed
* Unless configured in `.env` to have separate hosts for Etsin and Qvain, Etsin should work as before
* Known issues:
  * Window title is the same for Etsin and Qvain
  * Navigation bar is the same for Etsin and Qvain
  * Qvain "Preview in Etsin" link for drafts does not work properly if user is not logged into Etsin