### PR TITLE
CSCFAIRMETA-721: Fix missing organization email on dataset load

### DIFF
--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.actors.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.actors.test.jsx.snap
@@ -123,7 +123,7 @@ Array [
         },
       },
       Object {
-        "email": undefined,
+        "email": "manual@notreference.com",
         "identifier": undefined,
         "name": Object {
           "en": "Manual Org",

--- a/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
@@ -294,6 +294,12 @@ describe('Qvain.Actors modal', () => {
     )
   })
 
+  it('loads email address for manually added organization', () => {
+    const { allOrganizationsFlat } = stores.Qvain.Actors
+    const org = allOrganizationsFlat.find(org => org.name.en === 'Manual Org')
+    expect(org.email).toBe('manual@notreference.com')
+  })
+
   it('shows reference organizations in menu', () => {
     const { actors, editActor, setActorOrganizations } = stores.Qvain.Actors
     editActor(actors.find(actor => actor.organizations.length === 2))

--- a/etsin_finder/frontend/js/stores/view/qvain.actors.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.actors.js
@@ -16,6 +16,7 @@ const createActor = (actorJson, roles) => {
       orgs.unshift(
         Organization({
           name: currentOrg.name,
+          email: currentOrg.email,
           identifier: currentOrg.identifier,
           isReference: null, // null here means we aren't sure yet
         })


### PR DESCRIPTION
Fixes issue where Qvain Light doesn't load email addresses for manually added organizations.