### PR TITLE
CSCFAIRMETA-727: Prevent enter in input from causing form submission

### DIFF
--- a/etsin_finder/frontend/js/components/general/skipToContent.jsx
+++ b/etsin_finder/frontend/js/components/general/skipToContent.jsx
@@ -1,13 +1,13 @@
 {
-/**
- * This file is part of the Etsin service
- *
- * Copyright 2017-2018 Ministry of Education and Culture, Finland
- *
- *
- * @author    CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
- * @license   MIT
- */
+  /**
+   * This file is part of the Etsin service
+   *
+   * Copyright 2017-2018 Ministry of Education and Culture, Finland
+   *
+   *
+   * @author    CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+   * @license   MIT
+   */
 }
 
 import React, { Component } from 'react'
@@ -18,14 +18,16 @@ import PropTypes from 'prop-types'
 export default class SkipToContent extends Component {
   render() {
     return (
-      <STC onClick={this.props.callback}>
+      <SkipToContentButton onClick={this.props.callback}>
         <Translate content="stc" />
-      </STC>
+      </SkipToContentButton>
     )
   }
 }
 
-const STC = styled.button`
+const SkipToContentButton = styled.button.attrs({
+  type: 'button',
+})`
   background: ${p => p.theme.color.primary};
   color: white;
   max-height: 0;

--- a/etsin_finder/frontend/js/components/qvain/editor/dataset.jsx
+++ b/etsin_finder/frontend/js/components/qvain/editor/dataset.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Translate from 'react-translate-component'
 
-import { STSD, Form, SubmitContainer } from './editor.styled'
+import { SkipToSubmitDataset, Form, SubmitContainer, DisableImplicitSubmit } from './editor.styled'
 import { ErrorContainer, ErrorLabel, ErrorContent, ErrorButtons } from '../general/errors'
 import { Button } from '../../general/button'
 
@@ -40,6 +40,7 @@ const Dataset = ({
   }
   return (
     <Form className="container">
+      <DisableImplicitSubmit />
       <Description />
       <Actors />
       <RightsAndLicenses />
@@ -50,9 +51,9 @@ const Dataset = ({
       <SubmitContainer>
         <Translate component="p" content="qvain.consent" unsafe />
       </SubmitContainer>
-      <STSD onClick={setFocusOnSubmitButton}>
+      <SkipToSubmitDataset onClick={setFocusOnSubmitButton}>
         <Translate content="stsd" />
-      </STSD>
+      </SkipToSubmitDataset>
     </Form>
   )
 }

--- a/etsin_finder/frontend/js/components/qvain/editor/editor.styled.jsx
+++ b/etsin_finder/frontend/js/components/qvain/editor/editor.styled.jsx
@@ -5,7 +5,9 @@ import { Link } from 'react-router-dom'
 import { InvertedButton } from '../../general/button'
 import { Container, StickySubHeader } from '../general/card'
 
-export const STSD = styled.button`
+export const SkipToSubmitDataset = styled.button.attrs({
+  type: 'button',
+})`
   background: ${p => p.theme.color.primary};
   color: #fafafa;
   max-height: 0;
@@ -86,3 +88,14 @@ export const customStyles = {
     padding: '2vw',
   },
 }
+
+// According to the HTML spec, pressing enter in a text input causes implicit
+// form submission, i.e. the first submit button in the form is clicked.
+// Prevent this by adding a disabled submit button to the beginning of the form.
+export const DisableImplicitSubmit = styled.button.attrs({
+  disabled: true,
+  ariaHidden: true,
+  type: 'submit',
+})`
+  display: none;
+`

--- a/etsin_finder/frontend/js/components/qvain/main/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/main/index.jsx
@@ -40,7 +40,7 @@ class Qvain extends Component {
 
   constructor(props) {
     super(props)
-    this.setFocusOnSubmitOrUpdateButton = this.setFocusOnSubmitButton.bind(this)
+    this.setFocusOnSubmitButton = this.setFocusOnSubmitButton.bind(this)
     this.submitButtonsRef = React.createRef()
   }
 


### PR DESCRIPTION
* Add hidden disabled button to disable implicit submit for the dataset form
* Fix bound setFocusOnSubmitButton having wrong name
* Add type="button" to STSD (SkipToSubmitDataset) and STC (SkipToContent) components
* Unabbreviate STSD and STC component names to make their purpose clearer