### PR TITLE
CSCFAIRMETA-720: Set title based on app

### DIFF
--- a/etsin_finder/frontend/static/index.template.ejs
+++ b/etsin_finder/frontend/static/index.template.ejs
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Kuvailutietojen perusteella käyttäjät voivat etsiä aineistoja ja arvioida löytämiensä aineistojen käyttökelpoisuutta tarpeisiinsa."
+      content="{{ app_description }}"
     />
     <meta name="theme-color" content="#007FAD" />
     <link rel="manifest" href="/static/manifest.json" />
-    <title>Etsin | Tutkimusaineistojen hakupalvelu</title>
+    <title>{{ app_title }}</title>
     <style>
       .loader:empty {
         position: absolute;

--- a/etsin_finder/views.py
+++ b/etsin_finder/views.py
@@ -95,7 +95,18 @@ def _render_index_template(saml_errors=[], slo_success=False):
             log.info(session.get('samlUserdata').items())
         if is_authenticated_through_fairdata_sso():
             log_sso_values()
-    return render_template('index.html')
+
+    if request.headers.get('X-Etsin-App', None) == 'qvain':
+        app_title = 'Qvain | Tutkimusaineiston metatietotyökalu'
+        app_description = 'Fairdata Qvain -työkalu tekee datasi ' \
+            'kuvailun ja julkaisemisen helpoksi.'
+    else:
+        app_title = 'Etsin | Tutkimusaineistojen hakupalvelu'
+        app_description = 'Kuvailutietojen perusteella käyttäjät ' \
+            'voivat etsiä aineistoja ja arvioida löytämiensä ' \
+            'aineistojen käyttökelpoisuutta tarpeisiinsa.'
+
+    return render_template('index.html', app_title=app_title, app_description=app_description)
 
 
 # SAML AUTHENTICATION RELATED


### PR DESCRIPTION
* Use Flask render_template to set title and meta description for Etsin/Qvain
* Because the etsin_app cookie is not available on the first request, X-Etsin-App header is used for identifying the app