### PR TITLE
CSCFAIRMETA-679: [FIX] DOI date settings, remove obsolete functions

### DIFF
--- a/etsin_finder/frontend/js/stores/view/qvain.js
+++ b/etsin_finder/frontend/js/stores/view/qvain.js
@@ -157,23 +157,6 @@ class Qvain {
   }
 
   @action
-  setTitle = (title, lang) => {
-    this.title[lang] = title
-    this.changed = true
-
-    // If this is a new dataset/draft and date is not yet defined, set date to today's date
-    if (this.issuedDate === undefined && this.original === undefined) {
-      this.issuedDate = moment().format('YYYY-MM-DD')
-    }
-  }
-
-  @action
-  setDescription = (description, lang) => {
-    this.description[lang] = description
-    this.changed = true
-  }
-
-  @action
   setIssuedDate = exp => {
     this.issuedDate = exp
     this.changed = true
@@ -399,6 +382,11 @@ class Qvain {
   setDataCatalog = selectedDataCatalog => {
     this.dataCatalog = selectedDataCatalog
     this.changed = true
+
+    // If this is a new dataset and date is not yet defined, set date to today's date
+    if (this.issuedDate === undefined && this.original === undefined) {
+      this.issuedDate = moment().format('YYYY-MM-DD')
+    }
 
     // Remove useDoi if dataCatalog is ATT
     if (selectedDataCatalog === DATA_CATALOG_IDENTIFIER.ATT) {


### PR DESCRIPTION
1) Setting DOI date to today's date as default was implemented here (defined in setTitle()):
https://github.com/CSCfi/etsin-finder/pull/530

2) ... but the direct call to setTitle(), from handleTitleChange(), was removed here:
https://github.com/CSCfi/etsin-finder/commit/85d3ecf885493948b9b0eb0b414e9d201d40922e#diff-c6721e58eaa8c05a170fb0e6a8ae449eL29

3) Thus, the DOI date setting functionality was never called anymore -> Moved it to setDataCatalog()

Bonus: Looks like setTitle() and setDescription() are not used anymore. Removed these functions.