### PR TITLE
CSCFAIRADM-407: [FIX] Support old login

### DIFF
--- a/etsin_finder/authentication_direct_proxy.py
+++ b/etsin_finder/authentication_direct_proxy.py
@@ -64,15 +64,9 @@ def prepare_flask_request_for_saml(request, service):
     # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
     url_data = urlparse(request.url)
 
-    # If in local development environment this will redirect the legacy SAML login right.
-    if request.host == 'localhost':
-        http_host = '30.30.30.30'
-    else:
-        http_host = get_app_config(app.testing).get('SERVER_ETSIN_DOMAIN_NAME')
-
     return {
         'https': 'on' if request.scheme == 'https' else 'off',
-        'http_host': http_host,
+        'http_host': get_app_config(app.testing).get('SERVER_ETSIN_DOMAIN_NAME'),
         'server_port': url_data.port,
         'script_name': request.path,
         'get_data': request.args.copy(),

--- a/etsin_finder/authentication_direct_proxy.py
+++ b/etsin_finder/authentication_direct_proxy.py
@@ -67,12 +67,8 @@ def prepare_flask_request_for_saml(request, service):
     # If in local development environment this will redirect the legacy SAML login right.
     if request.host == 'localhost':
         http_host = '30.30.30.30'
-    # Non-local login through Etsin SSO
-    elif service == 'ETSIN':
+    else:
         http_host = get_app_config(app.testing).get('SERVER_ETSIN_DOMAIN_NAME')
-    # Non-local login through Qvain SSO
-    elif service == 'QVAIN':
-        http_host = get_app_config(app.testing).get('SERVER_QVAIN_DOMAIN_NAME')
 
     return {
         'https': 'on' if request.scheme == 'https' else 'off',

--- a/etsin_finder/views.py
+++ b/etsin_finder/views.py
@@ -165,7 +165,7 @@ def saml_metadata_legacy():
 
 @app.route('/acs/', methods=['GET', 'POST'])
 def saml_attribute_consumer_service_legacy():
-    """The endpoint which is used by the saml library on auth.login call for Etsin"""
+    """The endpoint which is used by the saml library on auth.login call for both Etsin & Qvain"""
     reset_flask_session_on_login()
     req = prepare_flask_request_for_saml(request, '')
     auth = init_saml_auth(req, '')
@@ -182,78 +182,10 @@ def saml_attribute_consumer_service_legacy():
 
     return _render_index_template(saml_errors=errors)
 
-@app.route('/acs/etsin', methods=['GET', 'POST'])
-def saml_attribute_consumer_service_etsin():
-    """The endpoint which is used by the saml library on auth.login call for Etsin"""
-    reset_flask_session_on_login()
-    req = prepare_flask_request_for_saml(request, '_ETSIN')
-    auth = init_saml_auth(req, '_ETSIN')
-    auth.process_response()
-    errors = auth.get_errors()
-    if len(errors) == 0 and auth.is_authenticated():
-        session['samlUserdata'] = auth.get_attributes()
-        session['samlNameId'] = auth.get_nameid()
-        session['samlSessionIndex'] = auth.get_session_index()
-        self_url = OneLogin_Saml2_Utils.get_self_url(req)
-        log.debug("SESSION: {0}".format(session))
-        if 'RelayState' in request.form and self_url != request.form.get('RelayState'):
-            return redirect(auth.redirect_to(unquote(request.form.get('RelayState'))))
-
-    return _render_index_template(saml_errors=errors)
-
-@app.route('/acs/qvain', methods=['GET', 'POST'])
-def saml_attribute_consumer_service_qvain():
-    """The endpoint which is used by the saml library on auth.login call for Qvain"""
-    reset_flask_session_on_login()
-    req = prepare_flask_request_for_saml(request, '_QVAIN')
-    auth = init_saml_auth(req, '_QVAIN')
-    auth.process_response()
-    errors = auth.get_errors()
-    if len(errors) == 0 and auth.is_authenticated():
-        session['samlUserdata'] = auth.get_attributes()
-        session['samlNameId'] = auth.get_nameid()
-        session['samlSessionIndex'] = auth.get_session_index()
-        self_url = OneLogin_Saml2_Utils.get_self_url(req)
-        log.debug("SESSION: {0}".format(session))
-        if 'RelayState' in request.form and self_url != request.form.get('RelayState'):
-            return redirect(auth.redirect_to(unquote(request.form.get('RelayState'))))
-
-    return _render_index_template(saml_errors=errors)
-
 @app.route('/sls/', methods=['GET', 'POST'])
 def saml_single_logout_service_legacy():
-    """The endpoint which is used by the saml library on auth.logout call"""
+    """The endpoint which is used by the saml library on auth.logout call for both Etsin & Qvain"""
     auth = get_saml_auth(request, '')
-    slo_success = False
-    url = auth.process_slo(delete_session_cb=lambda: session.clear())
-    errors = auth.get_errors()
-    if len(errors) == 0:
-        if url is not None:
-            return redirect(url)
-        else:
-            slo_success = True
-
-    return _render_index_template(saml_errors=errors, slo_success=slo_success)
-
-@app.route('/sls/etsin', methods=['GET', 'POST'])
-def saml_single_logout_service_etsin():
-    """The endpoint which is used by the saml library on auth.logout call"""
-    auth = get_saml_auth(request, '_ETSIN')
-    slo_success = False
-    url = auth.process_slo(delete_session_cb=lambda: session.clear())
-    errors = auth.get_errors()
-    if len(errors) == 0:
-        if url is not None:
-            return redirect(url)
-        else:
-            slo_success = True
-
-    return _render_index_template(saml_errors=errors, slo_success=slo_success)
-
-@app.route('/sls/qvain', methods=['GET', 'POST'])
-def saml_single_logout_service_qvain():
-    """The endpoint which is used by the saml library on auth.logout call"""
-    auth = get_saml_auth(request, '_QVAIN')
     slo_success = False
     url = auth.process_slo(delete_session_cb=lambda: session.clear())
     errors = auth.get_errors()


### PR DESCRIPTION
- This is mostly cleanup, the actual support is handled elsewhere, through correct settings in app_config
- Removal of functions that are neither used by the old proxy login nor the new SSO login
- The changes in etsin_finder/authentication_direct_proxy.py will ensure that proxy login works