### PR TITLE
CSCFAIRMETA-722-Long-filenames

### DIFF
--- a/etsin_finder/frontend/js/components/dataset/data/tableItem.jsx
+++ b/etsin_finder/frontend/js/components/dataset/data/tableItem.jsx
@@ -304,8 +304,9 @@ const TableRow = styled.tr`
 
 const FileType = styled.td``
 
-const FileName = styled.td``
-
+const FileName = styled.td`
+    word-break: break-all;
+`
 const FileSize = styled.td``
 
 const FileCategory = styled.td`


### PR DESCRIPTION
- Add 'word-break: break-all' to break the long filenames