### PR TITLE
CSCFAIRMETA-753: Use config from app context when available

### DIFF
--- a/etsin_finder/app_config.py
+++ b/etsin_finder/app_config.py
@@ -8,9 +8,9 @@
 """Get configurations for the app and external services."""
 
 import yaml
+from flask import has_app_context, current_app
 
 from etsin_finder.utils import executing_travis
-
 
 def _get_app_config_from_file():
     """Get app config from file
@@ -33,6 +33,10 @@ def get_app_config(is_testing):
         function: function to get app config.
 
     """
+    # use the existing config from app context when possible
+    if has_app_context():
+        return current_app.config
+
     if executing_travis():
         return _get_app_config_for_travis()
     if is_testing:


### PR DESCRIPTION
This changes the backend to use config from the app context instead of reading and parsing the app_config file every time some configuration value is needed. For some endpoints, such as /user (which read the config almost 30 times per request), this is a significant reduction in overhead.