### PR TITLE
[FIX] Update package-lock.json to reflect new version of Mobx

### DIFF
--- a/etsin_finder/frontend/package-lock.json
+++ b/etsin_finder/frontend/package-lock.json
@@ -10951,9 +10951,9 @@
       }
     },
     "mobx": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.0.1.tgz",
-      "integrity": "sha512-Pk6uJXZ34yqd661yRmS6z/9avm4FOGXpFpVjnEfiYYOsZXnAxv1fpYjxTCEZ9tuwk0Xe1qnUUlgm+rJtGe0YJA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.0.3.tgz",
+      "integrity": "sha512-DBMd0NXsMn25HJMUAWBndgJ2wRjOJPbpn6wdzUvZW0PVsyTnrw028XwQfzsjnxnKG+bAXGVNb38rvd+1o0G9uQ=="
     },
     "mobx-react": {
       "version": "7.0.0",


### PR DESCRIPTION
- MobX updated, but not reflected in package-lock.json
- ... causing Ansible deployments to fail
- This PR fixes the details in package-lock.json