### PR TITLE
CSCFAIRMETA-665: Add focus indicator to filter items.

### DIFF
--- a/etsin_finder/frontend/js/components/search/filterResults/filterSection.jsx
+++ b/etsin_finder/frontend/js/components/search/filterResults/filterSection.jsx
@@ -319,7 +319,6 @@ export const FilterItems = styled.div`
     color: ${p => p.theme.color.dark};
     text-align: left;
     &:focus {
-      outline: none;
       color: ${p => p.theme.color.primary};
       text-decoration: underline;
     }


### PR DESCRIPTION
- Add a outline to elements in the filter when they are in focus.
- Remove the 'outline: none;' in css for the button.
- No side effects.