### PR TITLE
CSCFAIRMETA-821: Refactor SSO & SAML

### DIFF
--- a/etsin_finder/app_config.py
+++ b/etsin_finder/app_config.py
@@ -70,6 +70,9 @@ def _get_test_app_config():
         'MAIL_USERNAME': '',
         'MAIL_PASSWORD': '',
         'MAIL_DEFAULT_SENDER': 'test@fairdata.fi',
+        'SSO': {
+            'PREFIX': 'fd_test_csc_fi',
+        },
         'DOWNLOAD_API_V2': {
             'ENABLED': True,
             'HOST': 'mock-download',
@@ -91,6 +94,9 @@ def _get_app_config_for_travis():
         'APP_LOG_PATH': '/var/log/etsin_finder/etsin_finder.log',
         'DEBUG': True,
         'SECRET_KEY': 'cb3c5d29f16eda4e46fb77c14d6a75f9ab23e6df95c84e32',
+        'SSO': {
+            'PREFIX': 'fd_test_csc_fi',
+        },
         'DOWNLOAD_API_V2': {
             'ENABLED': True,
             'HOST': 'mock-download',

--- a/etsin_finder/app_config.py
+++ b/etsin_finder/app_config.py
@@ -70,7 +70,6 @@ def _get_test_app_config():
         'MAIL_USERNAME': '',
         'MAIL_PASSWORD': '',
         'MAIL_DEFAULT_SENDER': 'test@fairdata.fi',
-        'SSO_PREFIX': 'fd_test_csc_fi',
         'DOWNLOAD_API_V2': {
             'ENABLED': True,
             'HOST': 'mock-download',
@@ -92,8 +91,6 @@ def _get_app_config_for_travis():
         'APP_LOG_PATH': '/var/log/etsin_finder/etsin_finder.log',
         'DEBUG': True,
         'SECRET_KEY': 'cb3c5d29f16eda4e46fb77c14d6a75f9ab23e6df95c84e32',
-        'SSO_PREFIX': 'fd_test_csc_fi',
-        'SSO_AUTHORIZATION': False,
         'DOWNLOAD_API_V2': {
             'ENABLED': True,
             'HOST': 'mock-download',

--- a/etsin_finder/app_config.py
+++ b/etsin_finder/app_config.py
@@ -93,6 +93,7 @@ def _get_app_config_for_travis():
         'DEBUG': True,
         'SECRET_KEY': 'cb3c5d29f16eda4e46fb77c14d6a75f9ab23e6df95c84e32',
         'SSO_PREFIX': 'fd_test_csc_fi',
+        'SSO_AUTHORIZATION': False,
         'DOWNLOAD_API_V2': {
             'ENABLED': True,
             'HOST': 'mock-download',

--- a/etsin_finder/authentication_fairdata_sso.py
+++ b/etsin_finder/authentication_fairdata_sso.py
@@ -17,7 +17,6 @@ from urllib.parse import urlparse, urlunparse, parse_qs, urlencode, urljoin
 from etsin_finder.app import app
 from etsin_finder.log import log
 from etsin_finder.app_config import get_app_config
-from etsin_finder.saml_config import get_sso_key
 from etsin_finder.utils import executing_travis
 
 def get_sso_environment_prefix():
@@ -37,7 +36,7 @@ def get_decrypted_sso_session_details():
         decrypted_fd_sso_session(list): List of decrypted cookies
 
     """
-    key = get_sso_key()
+    key = get_app_config(app.testing).get('SSO_KEY')
     sso_environment_and_session = get_sso_environment_prefix() + '_fd_sso_session'
     if request.cookies.getlist(sso_environment_and_session):
         fd_sso_session = request.cookies.getlist(sso_environment_and_session)

--- a/etsin_finder/authentication_fairdata_sso.py
+++ b/etsin_finder/authentication_fairdata_sso.py
@@ -26,7 +26,7 @@ def get_sso_environment_prefix():
         session_data (string): String that defines what the SSO environment is
 
     """
-    environment_string = get_app_config(app.testing).get('SSO_PREFIX')
+    environment_string = get_app_config(app.testing).get('SSO').get('PREFIX')
     return environment_string
 
 def get_decrypted_sso_session_details():
@@ -36,7 +36,7 @@ def get_decrypted_sso_session_details():
         decrypted_fd_sso_session(list): List of decrypted cookies
 
     """
-    key = get_app_config(app.testing).get('SSO_KEY')
+    key = get_app_config(app.testing).get('SSO').get('KEY')
     sso_environment_and_session = get_sso_environment_prefix() + '_fd_sso_session'
     if request.cookies.getlist(sso_environment_and_session):
         fd_sso_session = request.cookies.getlist(sso_environment_and_session)

--- a/etsin_finder/frontend/js/components/general/keepAlive/index.jsx
+++ b/etsin_finder/frontend/js/components/general/keepAlive/index.jsx
@@ -51,7 +51,7 @@ export default class KeepAlive extends Component {
     if (idle && Auth.userLogged) {
       this.timeout = setTimeout(() => {
         // Auth.logout()
-        window.location = `/slo/${this.state.loggedInThroughService}`
+        window.location = `/logout/${this.state.loggedInThroughService}`
         this.setState({
           showNotice: true,
         })

--- a/etsin_finder/frontend/js/components/general/navigation/loginButton.jsx
+++ b/etsin_finder/frontend/js/components/general/navigation/loginButton.jsx
@@ -64,7 +64,7 @@ class Login extends Component {
         loading: true,
       },
       () => {
-        window.location = `/sso/${loginThroughService}?relay=${
+        window.location = `/login/${loginThroughService}?relay=${
           location.pathname
         }${encodeURIComponent(query)}`
       }
@@ -77,7 +77,7 @@ class Login extends Component {
         showNotice: true,
       },
       () => {
-        window.location = `/slo/${this.state.loggedInThroughService}`
+        window.location = `/logout/${this.state.loggedInThroughService}`
       }
     )
   }

--- a/etsin_finder/saml_config.py
+++ b/etsin_finder/saml_config.py
@@ -19,13 +19,3 @@ def get_etsin_saml_config_from_file():
     """
     with open('/home/etsin-user/etsin/settings.json') as saml_json_file:
         return json.load(saml_json_file)
-
-def get_sso_key():
-    """Get SSO key from saml config.
-
-    Returns:
-        saml_config
-
-    """
-    data = get_etsin_saml_config_from_file()
-    return data.get('sp').get('privateKey')

--- a/etsin_finder/views.py
+++ b/etsin_finder/views.py
@@ -164,7 +164,7 @@ def frontend_app(path):
 
     """
     # Check if URL endpoint force enabling SSO has been visited
-    sso_enabled_through_url = request.args.get('sso_authentication', default = 'false', type = str)
+    sso_enabled_through_url = request.args.get('sso_authentication', default='false', type=str)
     resp = make_response(_render_index_template())
 
     if sso_enabled_through_url == 'true':

--- a/etsin_finder/views.py
+++ b/etsin_finder/views.py
@@ -168,9 +168,10 @@ def frontend_app(path):
     resp = make_response(_render_index_template())
 
     if sso_enabled_through_url == 'true':
-        # Force enable SSO cookie for entire domain (Etsin + Qvain)
-        cookie_domain = get_app_config(app.testing).get('SHARED_DOMAIN_NAME')
-        resp.set_cookie('sso_authentication', 'true', domain=cookie_domain)
+        # Force enable SSO cookie for entire domain (Etsin + Qvain)...
+        shared_domain = get_app_config(app.testing).get('SHARED_DOMAIN_NAME')
+        formatted_shared_domain = '.' + shared_domain
+        resp.set_cookie('sso_authentication', 'true', domain=formatted_shared_domain)
 
     return resp
 


### PR DESCRIPTION
- Enable both SSO or SAML login, depending on app config
- SSO can be force enabled by visiting the hidden URL endpoint `?sso_authentication=true`
- Requires https://github.com/CSCfi/etsin-ops/pull/46
- SSO checks for active sessions even if not enabled