### PR TITLE
CSCFAIRMETA-834: Feature flags

### DIFF
--- a/etsin_finder/app.py
+++ b/etsin_finder/app.py
@@ -11,21 +11,24 @@ from etsin_finder.app_config import get_app_config
 from etsin_finder.cache import CatalogRecordCache, RemsCache
 from etsin_finder.utils import executing_travis, get_log_config
 from etsin_finder.converters import IdentifierConverter
+from etsin_finder.flags import validate_flags, initialize_supported_flags
 
 
 def create_app():
     """Create flask app
 
     Returns:
-        objetc: The flask.Flask app instance object.
+        object: The flask.Flask app instance object.
 
     """
     is_testing = bool(os.environ.get('TESTING', False))
     app = Flask(__name__, template_folder="./frontend/build")
 
     app.config.update(get_app_config(is_testing))
+    initialize_supported_flags(app)
     if not app.testing and not executing_travis():
         _setup_app_logging(app)
+    validate_flags(app)
     if not executing_travis():
         app.config.update({'SAML_PATH': '/home/etsin-user'})
         app.config.update({'SAML_PATH_ETSIN': '/home/etsin-user/etsin'})

--- a/etsin_finder/app_config.py
+++ b/etsin_finder/app_config.py
@@ -74,10 +74,12 @@ def _get_test_app_config():
             'PREFIX': 'fd_test_csc_fi',
         },
         'DOWNLOAD_API_V2': {
-            'ENABLED': True,
             'HOST': 'mock-download',
             'PORT': 1,
-        }
+        },
+        'FLAGS': {
+            'DOWNLOAD_API_V2': True,
+        },
     }
 
 
@@ -98,10 +100,12 @@ def _get_app_config_for_travis():
             'PREFIX': 'fd_test_csc_fi',
         },
         'DOWNLOAD_API_V2': {
-            'ENABLED': True,
             'HOST': 'mock-download',
             'PORT': 1,
-        }
+        },
+        'FLAGS': {
+            'DOWNLOAD_API_V2': True,
+        },
     }
 
 

--- a/etsin_finder/finder.py
+++ b/etsin_finder/finder.py
@@ -9,7 +9,7 @@
 
 from flask_restful import Api
 from etsin_finder.app import app
-from etsin_finder.app_config import get_download_api_v2_config
+from etsin_finder.flags import flag_enabled
 
 def add_download_v2_resources(api):
     """Set download API v2 endpoints"""
@@ -39,7 +39,8 @@ def add_restful_resources(app):
         Session,
         Files,
         Download,
-        AppConfig
+        AppConfig,
+        SupportedFlags
     )
     from etsin_finder.qvain_light_resources import (
         ProjectFiles,
@@ -77,31 +78,31 @@ def add_restful_resources(app):
     )
 
     # Download API v2 endpoints
-    dl_api_config = get_download_api_v2_config(app.testing) or {}
-    if dl_api_config.get('ENABLED'):
+    if flag_enabled('DOWNLOAD_API_V2.BACKEND', app):
         add_download_v2_resources(api)
 
-    # Common Qvain and Etsin endpoints for Metax v2
-    api.add_resource(V2DatasetUserMetadata, '/api/v2/common/datasets/<id:cr_id>/user_metadata', endpoint='v2_dataset_user_metadata')
-    api.add_resource(V2DatasetProjects, '/api/v2/common/datasets/<id:cr_id>/projects', endpoint='v2_dataset_projects')
-    api.add_resource(V2ProjectFiles, '/api/v2/common/projects/<string:pid>/files', endpoint='v2_project_files')
-    api.add_resource(V2DirectoryFiles, '/api/v2/common/directories/<string:dir_id>/files', endpoint='v2_directory_files')
+    if flag_enabled('METAX_API_V2.BACKEND', app):
+        # Common Qvain and Etsin endpoints for Metax v2
+        api.add_resource(V2DatasetUserMetadata, '/api/v2/common/datasets/<id:cr_id>/user_metadata', endpoint='v2_dataset_user_metadata')
+        api.add_resource(V2DatasetProjects, '/api/v2/common/datasets/<id:cr_id>/projects', endpoint='v2_dataset_projects')
+        api.add_resource(V2ProjectFiles, '/api/v2/common/projects/<string:pid>/files', endpoint='v2_project_files')
+        api.add_resource(V2DirectoryFiles, '/api/v2/common/directories/<string:dir_id>/files', endpoint='v2_directory_files')
 
-    # Qvain API endpoints for Metax v2
-    api.add_resource(V2FileCharacteristics, '/api/v2/qvain/files/<string:file_id>/file_characteristics', endpoint='v2_file_characteristics')
-    api.add_resource(V2QvainDatasets, '/api/v2/qvain/datasets', endpoint='v2_datasets')
-    api.add_resource(V2QvainDataset, '/api/v2/qvain/datasets/<id:cr_id>', endpoint='v2_dataset_edit')
-    api.add_resource(V2QvainDatasetFiles, '/api/v2/qvain/datasets/<id:cr_id>/files', endpoint='v2_dataset_files')
+        # Qvain API endpoints for Metax v2
+        api.add_resource(V2FileCharacteristics, '/api/v2/qvain/files/<string:file_id>/file_characteristics', endpoint='v2_file_characteristics')
+        api.add_resource(V2QvainDatasets, '/api/v2/qvain/datasets', endpoint='v2_datasets')
+        api.add_resource(V2QvainDataset, '/api/v2/qvain/datasets/<id:cr_id>', endpoint='v2_dataset_edit')
+        api.add_resource(V2QvainDatasetFiles, '/api/v2/qvain/datasets/<id:cr_id>/files', endpoint='v2_dataset_files')
 
-    # Qvain API RPC endpoints for Metax v2
-    api.add_resource(V2QvainDatasetChangeCumulativeState, '/api/v2/rpc/datasets/change_cumulative_state', endpoint='v2_change_cumulative_state')
-    api.add_resource(V2QvainDatasetCreateNewVersion, '/api/v2/rpc/datasets/create_new_version', endpoint='v2_create_new_version')
-    api.add_resource(V2QvainDatasetCreateDraft, '/api/v2/rpc/datasets/create_draft', endpoint='v2_create_draft')
-    api.add_resource(V2QvainDatasetPublishDataset, '/api/v2/rpc/datasets/publish_dataset', endpoint='v2_publish_dataset')
-    api.add_resource(V2QvainDatasetMergeDraft, '/api/v2/rpc/datasets/merge_draft', endpoint='v2_merge_draft')
+        # Qvain API RPC endpoints for Metax v2
+        api.add_resource(V2QvainDatasetChangeCumulativeState, '/api/v2/rpc/datasets/change_cumulative_state', endpoint='v2_change_cumulative_state')
+        api.add_resource(V2QvainDatasetCreateNewVersion, '/api/v2/rpc/datasets/create_new_version', endpoint='v2_create_new_version')
+        api.add_resource(V2QvainDatasetCreateDraft, '/api/v2/rpc/datasets/create_draft', endpoint='v2_create_draft')
+        api.add_resource(V2QvainDatasetPublishDataset, '/api/v2/rpc/datasets/publish_dataset', endpoint='v2_publish_dataset')
+        api.add_resource(V2QvainDatasetMergeDraft, '/api/v2/rpc/datasets/merge_draft', endpoint='v2_merge_draft')
 
-    # Etsin API endpoint for Metax v2 dataset, needed for draft_of
-    api.add_resource(V2Dataset, '/api/v2/dataset/<id:cr_id>', endpoint='v2_etsin_dataset')
+        # Etsin API endpoint for Metax v2 dataset, needed for draft_of
+        api.add_resource(V2Dataset, '/api/v2/dataset/<id:cr_id>', endpoint='v2_etsin_dataset')
 
     # Etsin API endpoints
     api.add_resource(Dataset, '/api/dataset/<id:cr_id>')
@@ -112,6 +113,7 @@ def add_restful_resources(app):
     api.add_resource(Session, '/api/session')
     api.add_resource(Download, '/api/dl')
     api.add_resource(AppConfig, '/api/app_config')
+    api.add_resource(SupportedFlags, '/api/supported_flags')
 
     # Qvain API endpoints
     api.add_resource(ProjectFiles, '/api/qvain/projects/<string:pid>/files')

--- a/etsin_finder/flags.py
+++ b/etsin_finder/flags.py
@@ -1,0 +1,106 @@
+# This file is part of the Etsin service
+#
+# Copyright 2017-2020 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+"""Feature flag utilities"""
+
+import re
+from flask import has_app_context, current_app
+
+default_supported_flags = {
+    'DOWNLOAD_API_V2.BACKEND',
+    'DOWNLOAD_API_V2.FRONTEND',
+    'METAX_API_V2.BACKEND',
+    'METAX_API_V2.FRONTEND',
+}
+
+# Match last part of dot-separated path (including the period), e.g. '.last' in 'first.second.last'
+re_last_part = re.compile(r'\.?[^\.]*$')
+
+def _get_partial_paths(paths, include_full=False):
+    """Split flag paths into groups."""
+    partials = set()
+    for path in paths:
+        parts = path.split('.')
+        limit = len(parts)
+        if not include_full:
+            limit -= 1
+        for i in range(limit):
+            partials.add('.'.join(parts[0:i + 1]))
+    return partials
+
+def _ensure_app(app):
+    """Use app context if no app parameter is supplied"""
+    if app:
+        return app
+    if has_app_context():
+        return current_app
+    raise ValueError('Missing app parameter and no app context available')
+
+def set_flags(value, app):
+    """Set flags for app (useful for testing)"""
+    app.config['FLAGS'] = value
+
+def set_supported_flags(app, flags):
+    """Set supported flags for app (useful for testing)"""
+    app.config['SUPPORTED_FLAGS'] = set(flags)
+
+def initialize_supported_flags(app):
+    """Assign default supported flags for app"""
+    app.config['SUPPORTED_FLAGS'] = set(default_supported_flags)
+
+def validate_flags(app=None):
+    """Validate flags
+
+    Logs warning if a flag in config is not in supported flags or
+    is not a group containing supported flags.
+    """
+    app = _ensure_app(app)
+    supported = _get_partial_paths(get_supported_flags(app), True)
+    flags = app.config.get('FLAGS', {})
+    for path, value in flags.items():
+        if type(value) is not bool and value is not None:
+            app.logger.warning(f'validate_flags: invalid flag value {path}={value}')
+
+    flag_paths = set(flags.keys())
+    unknown_flags = list(flag_paths.difference(supported))
+    if len(unknown_flags) > 0:
+        app.logger.warning(f'validate_flags: unsupported flags {sorted(unknown_flags)}')
+
+def get_flags(app):
+    """Get feature flag dictionary"""
+    return app.config.get('FLAGS', {})
+
+def get_supported_flags(app):
+    """Get set of supported feature flags"""
+    return app.config.get('SUPPORTED_FLAGS', set())
+
+def flag_enabled(flag_path, app=None):
+    """Get state of flag for feature
+
+    Example:
+      flag_path='FEATURE_GROUP.FEATURE.SUBFEATURE'
+    will search
+    - flags['FEATURE_GROUP.FEATURE.SUBFEATURE']
+    - flags['FEATURE_GROUP.FEATURE']
+    - flags['FEATURE_GROUP']
+    and return the first matching not-None value, or False if no matches are found.
+
+    Requesting a flag not in supported flags will cause a warning.
+    """
+    app = _ensure_app(app)
+
+    if flag_path not in get_supported_flags(app):
+        app.logger.warning(f'flag_enabled: requesting value for unsupported flag {flag_path}')
+
+    flags = get_flags(app)
+    while flag_path:
+        value = flags.get(flag_path)
+        if value is not None:
+            return value
+        flag_path = re_last_part.sub('', flag_path)
+
+    return False

--- a/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
+++ b/etsin_finder/frontend/__tests__/__snapshots__/qvain.test.legacy.jsx.snap
@@ -5,8 +5,16 @@ exports[`Qvain should render correctly 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -19,7 +27,6 @@ exports[`Qvain should render correctly 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -309,8 +316,16 @@ exports[`Qvain should render correctly 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -323,7 +338,6 @@ exports[`Qvain should render correctly 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {
@@ -1431,8 +1445,16 @@ exports[`Qvain.Description should render <Description /> 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -1445,7 +1467,6 @@ exports[`Qvain.Description should render <Description /> 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -1735,8 +1756,16 @@ exports[`Qvain.Description should render <Description /> 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -1749,7 +1778,6 @@ exports[`Qvain.Description should render <Description /> 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {
@@ -2857,8 +2885,16 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -2871,7 +2907,6 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -3161,8 +3196,16 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -3175,7 +3218,6 @@ exports[`Qvain.Description should render <DescriptionField /> 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {
@@ -4283,8 +4325,16 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -4297,7 +4347,6 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -4587,8 +4636,16 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -4601,7 +4658,6 @@ exports[`Qvain.Description should render <FieldOfScienceField /> 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {
@@ -5709,8 +5765,16 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -5723,7 +5787,6 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -6013,8 +6076,16 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -6027,7 +6098,6 @@ exports[`Qvain.Description should render <KeywordsField /> 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {
@@ -7135,8 +7205,16 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
   value={
     Object {
       "Env": Env {
+        "Flags": Flags {
+          "fetchingSupportedFlags": false,
+          "flagEnabled": [Function],
+          "flags": Object {
+            "METAX_API_V2": false,
+          },
+          "overrides": Object {},
+          "supportedFlags": null,
+        },
         "app": undefined,
-        "downloadApiV2": false,
         "etsinHost": "",
         "getEtsinUrl": [Function],
         "getQvainUrl": [Function],
@@ -7149,7 +7227,6 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "push": [Function],
           "replace": [Function],
         },
-        "metaxApiV2": false,
         "qvainHost": "",
       },
       "Locale": Locale {
@@ -7439,8 +7516,16 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
           "value": undefined,
         },
         "Env": Env {
+          "Flags": Flags {
+            "fetchingSupportedFlags": false,
+            "flagEnabled": [Function],
+            "flags": Object {
+              "METAX_API_V2": false,
+            },
+            "overrides": Object {},
+            "supportedFlags": null,
+          },
           "app": undefined,
-          "downloadApiV2": false,
           "etsinHost": "",
           "getEtsinUrl": [Function],
           "getQvainUrl": [Function],
@@ -7453,7 +7538,6 @@ exports[`Qvain.Description should render <OtherIdentifierField /> 1`] = `
             "push": [Function],
             "replace": [Function],
           },
-          "metaxApiV2": false,
           "qvainHost": "",
         },
         "FieldOfSciences": FieldOfSciences {

--- a/etsin_finder/frontend/__tests__/cumulativeState.test.jsx
+++ b/etsin_finder/frontend/__tests__/cumulativeState.test.jsx
@@ -36,7 +36,7 @@ jest.mock('../js/stores/stores', () => {
 
 const Qvain = new QvainStoreClass(Env)
 
-Env.setMetaxApiV2(true)
+Env.Flags.setFlag('METAX_API_V2', true)
 const stores = {
   Env,
   Qvain,

--- a/etsin_finder/frontend/__tests__/download.test.jsx
+++ b/etsin_finder/frontend/__tests__/download.test.jsx
@@ -33,7 +33,7 @@ const { PENDING, SUCCESS } = DOWNLOAD_API_REQUEST_STATUS
 // require some changes.
 jest.useFakeTimers('legacy')
 
-Env.setDownloadApiV2(true)
+Env.Flags.setFlag('DOWNLOAD_API_V2', true)
 const mockAdapter = new MockAdapter(axios)
 applyMockAdapter(mockAdapter)
 

--- a/etsin_finder/frontend/__tests__/general.flaggedComponent.test.jsx
+++ b/etsin_finder/frontend/__tests__/general.flaggedComponent.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import FlaggedComponent from '../js/components/general/flaggedComponent'
+import { useStores } from '../js/stores/stores'
+import FlagsClass from '../js/stores/domain/env.flags.js'
+const Flags = new FlagsClass()
+Flags.setFlags({
+  ENABLED_FEATURE: true,
+  DISABLED_FEATURE: false,
+  ENABLED_GROUP: true,
+  'ENABLED_GROUP.DISABLED_SUBFEATURE': false,
+  'ENABLED_GROUP.NULL_SUBFEATURE': null,
+  DISABLED_GROUP: false,
+  'DISABLED_GROUP.ENABLED_SUBFEATURE': true,
+  UNSUPPORTED_FEATURE: true,
+})
+
+Flags.setSupportedFlags([
+  'ENABLED_FEATURE',
+  'DISABLED_FEATURE',
+  'ENABLED_GROUP.DISABLED_SUBFEATURE',
+  'ENABLED_GROUP.SUBFEATURE',
+  'ENABLED_GROUP.NULL_SUBFEATURE',
+  'DISABLED_GROUP.ENABLED_SUBFEATURE',
+  'DISABLED_GROUP.SUBFEATURE',
+])
+
+jest.mock('../js/stores/stores', () => ({
+  useStores: jest.fn(),
+}))
+
+useStores.mockReturnValue({ Env: { Flags } })
+
+describe('FlaggedComponent', () => {
+  let wrapper
+  const { flagEnabled } = Flags
+  const TestComponent = () => <div>test component</div>
+  const WhenDisabledComponent = () => <div>test component 2</div>
+
+  describe('when flag is true', () => {
+    test('should render TestComponent', () => {
+      wrapper = shallow(
+        <FlaggedComponent flag="ENABLED_FEATURE" whenDisabled={<WhenDisabledComponent />}>
+          <TestComponent />
+        </FlaggedComponent>
+      )
+      expect(wrapper.find(TestComponent).exists()).toBe(true)
+    })
+  })
+
+  describe('when flag is false', () => {
+    test('should render WhenDisabledComponent', () => {
+      wrapper = shallow(
+        <FlaggedComponent flag="DISABLED_FEATURE" whenDisabled={<WhenDisabledComponent />}>
+          <TestComponent />
+        </FlaggedComponent>
+      )
+      expect(wrapper.find(WhenDisabledComponent).exists()).toBe(true)
+    })
+
+    test('should render nothing', () => {
+      wrapper = shallow(
+        <FlaggedComponent flag="DISABLED_FEATURE">
+          <TestComponent />
+        </FlaggedComponent>
+      )
+      expect(wrapper.isEmptyRender()).toBe(true)
+    })
+  })
+
+  describe('when group flag is true', () => {
+    test('should enable subfeature by default', () => {
+      expect(flagEnabled('ENABLED_GROUP.SUBFEATURE')).toBe(true)
+    })
+
+    test('should enable null-valued subfeature', () => {
+      expect(flagEnabled('ENABLED_GROUP.NULL_SUBFEATURE')).toBe(true)
+    })
+
+    test('should respect disabled subfeature flag', () => {
+      expect(flagEnabled('ENABLED_GROUP.DISABLED_SUBFEATURE')).toBe(false)
+    })
+  })
+
+  describe('when group flag is false', () => {
+    test('should disable subfeature by default', () => {
+      expect(flagEnabled('DISABLED_GROUP.SUBFEATURE')).toBe(false)
+    })
+
+    test('should respect enabled subfeature flag', () => {
+      expect(flagEnabled('DISABLED_GROUP.ENABLED_SUBFEATURE')).toBe(true)
+    })
+  })
+
+  describe('when flag is unsupported', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+    })
+
+    afterEach(() => {
+      console.warn.mockRestore()
+    })
+
+    test('should warn when state is requested', () => {
+      wrapper = shallow(
+        <FlaggedComponent
+          flag="THIS_FEATURE_DOES_NOT_EXIST"
+          whenDisabled={<WhenDisabledComponent />}
+        >
+          <TestComponent />
+        </FlaggedComponent>
+      )
+      expect(console.warn.mock.calls).toEqual([
+        [expect.stringContaining('THIS_FEATURE_DOES_NOT_EXIST')],
+      ])
+    })
+
+    test('should warn when flag is set', () => {
+      Flags.validateFlags()
+      expect(console.warn.mock.calls).toEqual([[expect.stringContaining('UNSUPPORTED_FEATURE')]])
+    })
+  })
+})

--- a/etsin_finder/frontend/__tests__/metadataModal.legacy.test.jsx
+++ b/etsin_finder/frontend/__tests__/metadataModal.legacy.test.jsx
@@ -20,7 +20,7 @@ jest.mock('axios')
 
 const QvainStore = new QvainStoreClass(Env)
 const getStores = () => {
-  Env.setMetaxApiV2(false)
+  Env.Flags.setFlag('METAX_API_V2', false)
   return {
     Env,
     Qvain: QvainStore,

--- a/etsin_finder/frontend/__tests__/metadataModal.test.jsx
+++ b/etsin_finder/frontend/__tests__/metadataModal.test.jsx
@@ -17,7 +17,7 @@ import { Project, File, Directory } from '../js/stores/view/common.files.items'
 import LocaleStore from '../js/stores/view/locale'
 
 const getStores = () => {
-  Env.setMetaxApiV2(true)
+  Env.Flags.setFlag('METAX_API_V2', true)
   const QvainStore = new QvainStoreClass(Env)
   QvainStore.resetQvainStore()
   return {

--- a/etsin_finder/frontend/__tests__/qvain.accessType.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.accessType.test.jsx
@@ -16,7 +16,7 @@ jest.mock('axios')
 const QvainStore = new QvainStoreClass(Env)
 
 const getStores = () => {
-  Env.setMetaxApiV2(true)
+  Env.Flags.setFlag('METAX_API_V2', true)
   return {
     Auth,
     Env,

--- a/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.actors.test.jsx
@@ -49,7 +49,7 @@ jest.mock('../js/stores/stores', () => {
 })
 
 const QvainStore = new QvainStoreClass(Env)
-Env.setMetaxApiV2(true)
+Env.Flags.setFlag('METAX_API_V2', true)
 const stores = {
   Env,
   Qvain: QvainStore,

--- a/etsin_finder/frontend/__tests__/qvain.files.legacy.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.files.legacy.jsx
@@ -25,7 +25,7 @@ global.Promise = require('bluebird')
 const QvainStore = new QvainStoreClass(Env)
 
 const getStores = () => {
-  Env.setMetaxApiV2(false)
+  Env.Flags.setFlag('METAX_API_V2', false)
   return {
     Env,
     Qvain: QvainStore,
@@ -42,7 +42,7 @@ jest.mock('../js/stores/stores', () => {
       dataCatalog: DATA_CATALOG_IDENTIFIER.IDA,
     },
     Env: {
-      metaxAPIv2: false,
+      metaxApiV2: false,
     },
   })
   return { ...jest.requireActual('../js/stores/stores'), useStores }

--- a/etsin_finder/frontend/__tests__/qvain.files.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.files.test.jsx
@@ -159,7 +159,7 @@ const loadDataset = async () => {
 
 beforeEach(async () => {
   Qvain.resetQvainStore()
-  Env.setMetaxApiV2(true)
+  Env.Flags.setFlag('METAX_API_V2', true)
   await loadDataset()
 })
 

--- a/etsin_finder/frontend/__tests__/qvain.metadata.store.test.js
+++ b/etsin_finder/frontend/__tests__/qvain.metadata.store.test.js
@@ -98,7 +98,7 @@ const testFile4 = {
 
 const getStores = () => {
   const QvainStore = new QvainStoreClass(Env)
-  Env.setMetaxApiV2(true)
+  Env.Flags.setFlag('METAX_API_V2', true)
   QvainStore.resetQvainStore()
 
   QvainStore.hierarchy = Directory(

--- a/etsin_finder/frontend/__tests__/qvain.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.test.jsx
@@ -67,7 +67,7 @@ jest.mock('../js/stores/stores', () => {
 })
 
 const getStores = () => {
-  Env.setMetaxApiV2(true)
+  Env.Flags.setFlag('METAX_API_V2', true)
   return {
     Env,
     Qvain: new QvainStoreClass(Env),

--- a/etsin_finder/frontend/__tests__/qvain.test.legacy.jsx
+++ b/etsin_finder/frontend/__tests__/qvain.test.legacy.jsx
@@ -61,7 +61,7 @@ jest.mock('../js/stores/stores', () => {
 
 const QvainStore = new QvainStoreClass(Env)
 const getStores = () => {
-  Env.setMetaxApiV2(false)
+  Env.Flags.setFlag('METAX_API_V2', false)
   return {
     Env,
     Qvain: QvainStore,

--- a/etsin_finder/frontend/__tests__/qvainPas.legacy.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvainPas.legacy.test.jsx
@@ -34,7 +34,7 @@ const QvainStore = new QvainStoreClass(EnvStore)
 
 const getStores = () => {
   QvainStore.resetQvainStore()
-  EnvStore.setMetaxApiV2(false)
+  EnvStore.Flags.setFlag('METAX_API_V2', false)
   return {
     Qvain: QvainStore,
     Locale: LocaleStore,

--- a/etsin_finder/frontend/__tests__/qvainPas.test.jsx
+++ b/etsin_finder/frontend/__tests__/qvainPas.test.jsx
@@ -34,7 +34,7 @@ const QvainStore = new QvainStoreClass(EnvStore)
 
 const getStores = () => {
   QvainStore.resetQvainStore()
-  EnvStore.setMetaxApiV2(true)
+  EnvStore.Flags.setFlag('METAX_API_V2', true)
   return {
     Qvain: QvainStore,
     Locale: LocaleStore,

--- a/etsin_finder/frontend/__tests__/removeModal.test.jsx
+++ b/etsin_finder/frontend/__tests__/removeModal.test.jsx
@@ -17,7 +17,7 @@ const mockLocale = LocaleStore
 jest.mock('../js/stores/stores', () => {
   const getStores = () => {
     mockStores.resetQvainStore()
-    mockEnv.setMetaxApiV2(true)
+    mockEnv.Flags.setFlag('METAX_API_V2', true)
     return {
       Qvain: mockStores,
       Env: mockEnv,

--- a/etsin_finder/frontend/__tests__/submitButtons.test.jsx
+++ b/etsin_finder/frontend/__tests__/submitButtons.test.jsx
@@ -51,7 +51,7 @@ const getMockProps = () => ({
   handleSubmitError: jest.fn(),
 })
 
-Env.setMetaxApiV2(true)
+Env.Flags.setFlag('METAX_API_V2', true)
 const stores = {
   Env,
   Qvain,

--- a/etsin_finder/frontend/js/components/general/flaggedComponent.jsx
+++ b/etsin_finder/frontend/js/components/general/flaggedComponent.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import { observer } from 'mobx-react'
+
+import { useStores } from '../../stores/stores'
+
+const FlaggedComponent = ({ flag, children, whenDisabled }) => {
+  const {
+    Env: {
+      Flags: { flagEnabled },
+    },
+  } = useStores()
+  if (flagEnabled(flag)) {
+    return children
+  }
+  return whenDisabled
+}
+
+FlaggedComponent.propTypes = {
+  flag: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  whenDisabled: PropTypes.element,
+}
+
+FlaggedComponent.defaultProps = {
+  whenDisabled: null,
+}
+
+export default observer(FlaggedComponent)

--- a/etsin_finder/frontend/js/stores/domain/env.flags.js
+++ b/etsin_finder/frontend/js/stores/domain/env.flags.js
@@ -1,0 +1,196 @@
+/**
+ * This file is part of the Etsin service
+ *
+ * Copyright 2017-2020 Ministry of Education and Culture, Finland
+ *
+ *
+ * @author    CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+ * @license   MIT
+ */
+
+import axios from 'axios'
+import { action, makeObservable, observable, extendObservable, computed, toJS, runInAction, when } from 'mobx'
+
+
+//  Match last part of dot-separated path (including the period), e.g. '.last' in 'first.second.last'
+const lastPartRegex = /\.?[^.]*$/
+
+// supportedFlags has the following possible states for a flag:
+// - 'full': flag is supported
+// - 'partial': flag is a group and can be set, but is not a valid flag by itself (flagEnabled will warn)
+// - undefined: flag is unsupported (flagEnabled/validateFlags will warn)
+const FLAG_SUPPORT = {
+  FULL: 'full',
+  PARTIAL: 'partial',
+  NO: undefined
+}
+
+class Flags {
+  constructor() {
+    makeObservable(this)
+    if (process.env.NODE_ENV !== 'production') {
+      // Global flag helpers for front-end development. The functions do not modify
+      // flags directly but instead the values are kept in the overrides object.
+      // The values are stored in localStorage.
+      //   setFlag: set a flag value
+      //   getFlags: get all flag values in effect (flags + overrides)
+      //   flagEnabled: is a flag enabled
+      //   resetFlags: reset flags to original values (clears overrides)
+      //   cleanupFlags: reset flags that aren't supported
+      extendObservable(this, {
+        overrides: {}
+      })
+
+      // Apply existing overrides starting from shortest paths
+      const overridesList = Object.entries(JSON.parse(localStorage.getItem('flagOverrides')) || {})
+      overridesList.sort(([pathA], [pathB]) => pathA.split('.').length - pathB.split('.').length)
+      overridesList.forEach(([path, value]) => this.setOverride(path, value))
+
+      window.flagEnabled = this.flagEnabled
+
+      window.getFlags = () => toJS(this.activeFlags)
+
+      window.setFlag = action((flagPath, value) => {
+        if (this.supportedFlags && !this.validateFlagPath(flagPath)) {
+          console.warn(`unsupported flag: ${flagPath}`)
+        }
+
+        if (typeof flagPath !== 'string') {
+          console.error('expected string flag path')
+          return
+        }
+        this.setOverride(flagPath, value)
+        localStorage.setItem('flagOverrides', JSON.stringify(this.overrides))
+      })
+
+      window.cleanupFlags = action(() => {
+        for (const path of Object.keys(this.overrides)) {
+          if (this.supportedFlags && !this.validateFlagPath(path)) {
+            delete this.overrides[path]
+          }
+        }
+        localStorage.setItem('flagOverrides', JSON.stringify(this.overrides))
+      })
+
+      window.resetFlags = action(() => {
+        this.overrides = {}
+        localStorage.removeItem('flagOverrides')
+      })
+    }
+  }
+
+  @observable flags = {}
+
+  @observable supportedFlags = null
+
+  @observable fetchingSupportedFlags = false
+
+  @action setSupportedFlags(paths) {
+    this.supportedFlags = {}
+    paths.forEach(flagPath => {
+      let partialPath = flagPath
+      this.supportedFlags[partialPath] = FLAG_SUPPORT.FULL
+      partialPath = partialPath.replace(lastPartRegex, '')
+      while (partialPath) {
+        this.supportedFlags[partialPath] = this.supportedFlags[partialPath] || FLAG_SUPPORT.PARTIAL
+        partialPath = partialPath.replace(lastPartRegex, '')
+      }
+    })
+  }
+
+  @action async fetchSupportedFlags() {
+    if (this.fetchingSupportedFlags) {
+      await when(() => !this.fetchingSupportedFlags)
+      return
+    }
+
+    this.fetchingSupportedFlags = true
+    try {
+      const { data } = await axios.get('/api/supported_flags')
+      this.setSupportedFlags(data)
+    } finally {
+      runInAction(() => {
+        this.fetchingSupportedFlags = false
+      })
+    }
+  }
+
+  @action validateFlagPath(path) {
+    return this.supportedFlags[path] || FLAG_SUPPORT.undefined
+  }
+
+  @action async validateFlags() {
+    if (!this.supportedFlags) {
+      await this.fetchSupportedFlags()
+    }
+
+    let ok = true
+    for (const path of Object.keys(this.flags)) {
+      if (!this.validateFlagPath(path)) {
+        console.warn(`unsupported flag: ${path}`)
+        ok = false
+      }
+    }
+
+    for (const path of Object.keys(this.overrides)) {
+      if (!this.validateFlagPath(path)) {
+        console.warn(`unsupported flag override: ${path}, call cleanupFlags() to remove`)
+        ok = false
+      }
+    }
+    return ok
+  }
+
+  @action setFlags(flags) {
+    this.flags = flags
+  }
+
+  @action setOverride(path, value) {
+    this.overrides[path] = value
+
+    // child items will use value from parent
+    const pathPrefix = `${path}.`
+    for (const flagPath of Object.keys(this.flags)) {
+      if (flagPath.startsWith(pathPrefix)) {
+        this.overrides[flagPath] = undefined
+      }
+    }
+  }
+
+  @action setFlag(path, value) {
+    this.flags[path] = value
+
+    // child items will use value from parent
+    const pathPrefix = `${path}.`
+    for (const flagPath of Object.keys(this.flags)) {
+      if (flagPath.startsWith(pathPrefix)) {
+        this.flags[flagPath] = undefined
+      }
+    }
+  }
+
+  @computed get activeFlags() {
+    if (process.env.NODE_ENV !== 'production' && this.overrides) {
+      return { ...this.flags, ...this.overrides }
+    }
+    return this.flags
+  }
+
+  flagEnabled = (flagPath) => {
+    if (this.supportedFlags && this.validateFlagPath(flagPath) !== FLAG_SUPPORT.FULL) {
+      console.warn(`flagEnabled called with unsupported flag: ${flagPath}`)
+    }
+
+    let path = flagPath
+    while (path) {
+      const value = this.activeFlags[path]
+      if (value != null) {
+        return value
+      }
+      path = path.replace(lastPartRegex, '')
+    }
+    return false
+  }
+}
+
+export default Flags

--- a/etsin_finder/frontend/js/stores/domain/env.js
+++ b/etsin_finder/frontend/js/stores/domain/env.js
@@ -11,6 +11,7 @@
 import axios from 'axios'
 import { action, computed, makeObservable, observable } from 'mobx'
 import { RouterStore } from 'mobx-react-router'
+import Flags from './env.flags'
 
 import { getCookieValue } from '../../utils/cookies'
 
@@ -24,6 +25,7 @@ async function importValuesAsync() {
 class Env {
   constructor() {
     makeObservable(this)
+    this.Flags = new Flags()
   }
 
   @observable etsinHost = ''
@@ -34,7 +36,10 @@ class Env {
     const values = await importValuesAsync()
     this.setEtsinHost(values.SERVER_ETSIN_DOMAIN_NAME)
     this.setQvainHost(values.SERVER_QVAIN_DOMAIN_NAME)
-    this.setDownloadApiV2(!!values.DOWNLOAD_API_V2_ENABLED)
+    this.Flags.setFlags(values.FLAGS)
+    if (process.env.NODE_ENV !== 'production') {
+      await this.Flags.validateFlags()
+    }
   }
 
   @action setEtsinHost(host) {
@@ -45,14 +50,13 @@ class Env {
     this.qvainHost = host
   }
 
-  @action setDownloadApiV2(enabled) {
-    this.downloadApiV2 = enabled
+  @computed get metaxApiV2() {
+    return this.Flags.flagEnabled('METAX_API_V2.FRONTEND')
   }
 
-  @observable metaxApiV2 =
-    process.env.NODE_ENV !== 'production' && localStorage.getItem('metax_api_v2') === '1'
-
-  @observable downloadApiV2 = false
+  @computed get downloadApiV2() {
+    return this.Flags.flagEnabled('DOWNLOAD_API_V2')
+  }
 
   @observable app = getCookieValue('etsin_app')
 
@@ -69,10 +73,6 @@ class Env {
   @computed
   get separateQvain() {
     return this.qvainHost !== this.etsinHost
-  }
-
-  @action setMetaxApiV2 = value => {
-    this.metaxApiV2 = value
   }
 
   getEtsinUrl = path => {

--- a/etsin_finder/resources.py
+++ b/etsin_finder/resources.py
@@ -7,7 +7,7 @@
 
 """RESTful API endpoints, meant to be used by the frontend"""
 
-from flask import session
+from flask import session, current_app
 from flask_mail import Message
 from flask_restful import abort, reqparse, Resource
 
@@ -28,6 +28,7 @@ from etsin_finder.email_utils import \
     validate_send_message_request
 from etsin_finder.app import app
 from etsin_finder.log import log
+from etsin_finder.flags import get_supported_flags
 
 from etsin_finder.utils import \
     sort_array_of_obj_by_key, \
@@ -496,5 +497,21 @@ class AppConfig(Resource):
         return {
             'SERVER_ETSIN_DOMAIN_NAME': app_config.get('SERVER_ETSIN_DOMAIN_NAME', ''),
             'SERVER_QVAIN_DOMAIN_NAME': app_config.get('SERVER_QVAIN_DOMAIN_NAME', ''),
-            'DOWNLOAD_API_V2_ENABLED': app_config.get('DOWNLOAD_API_V2', {}).get('ENABLED', False)
+            'FLAGS': app_config.get('FLAGS', {})
         }
+
+
+class SupportedFlags(Resource):
+    """Supported flags endpoint"""
+
+    @log_request
+    def get(self):
+        """Return list of supported flags
+
+        Used for flag validation in the frontend.
+
+        Returns:
+            list of supported flags
+
+        """
+        return sorted(list(get_supported_flags(current_app)))

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,101 @@
+# This file is part of the Etsin service
+#
+# Copyright 2017-2020 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+"""Test feature flags"""
+
+import json
+import pytest
+import requests
+
+from etsin_finder.flags import set_flags, set_supported_flags, validate_flags, flag_enabled
+from .basetest import BaseTest
+
+supported_flags = {
+    'SUPPORTED_FLAG',
+    'SUPPORTED_FLAG_TRUE',
+    'SUPPORTED_FLAG_FALSE',
+    'SUPPORTED_GROUP',
+    'SUPPORTED_GROUP.FLAG1',
+    'SUPPORTED_GROUP.FLAG2',
+    'ANOTHER_GROUP.FLAG1',
+}
+
+class TestFlags(BaseTest):
+    """Test feature flags"""
+
+    @pytest.fixture
+    def flags_app(self, app):
+        """Helper fixture that overrides default supported flags"""
+        set_supported_flags(app, supported_flags)
+        return app
+
+    def test_unsupported_flag_set_warning(self, flags_app, expect_log):
+        """Setting an unsupported flag should log a warning"""
+        set_flags({
+            'SUPPORTED_FLAG': True,
+            'UNSUPPORTED_FLAG': True,
+            'ANOTHER_GROUP': True,
+        }, flags_app)
+        validate_flags(flags_app)
+        expect_log(warnings=['UNSUPPORTED_FLAG'])
+
+    def test_flag_enabled(self, flags_app, expect_log):
+        """Test enabling flag"""
+        set_flags({
+            'SUPPORTED_FLAG_TRUE': True,
+            'UNSUPPORTED_FLAG_FALSE': False,
+        }, flags_app)
+        assert flag_enabled('SUPPORTED_FLAG_TRUE', flags_app) is True
+        assert flag_enabled('SUPPORTED_FLAG_FALSE', flags_app) is False
+        expect_log()
+
+    def test_flag_enabled_default_false(self, flags_app, expect_log):
+        """Test that flags are disabled by default"""
+        set_flags({
+            'SUPPORTED_FLAG_TRUE': True,
+            'UNSUPPORTED_FLAG_FALSE': False,
+        }, flags_app)
+        assert flag_enabled('SUPPORTED_FLAG', flags_app) is False
+        expect_log()
+
+    def test_flag_enabled_group(self, flags_app, expect_log):
+        """Test that flags in enabled group are enabled unless they are explicitly False"""
+        set_flags({
+            'SUPPORTED_GROUP': True,
+            'SUPPORTED_GROUP.FLAG2': False,
+        }, flags_app)
+        assert flag_enabled('SUPPORTED_GROUP', flags_app) is True
+        assert flag_enabled('SUPPORTED_GROUP.FLAG1', flags_app) is True
+        assert flag_enabled('SUPPORTED_GROUP.FLAG2', flags_app) is False
+        expect_log()
+
+    def test_flag_disabled_group(self, flags_app, expect_log):
+        """Test that flags in disabled group are disabled unless they are explicitly True"""
+        set_flags({
+            'SUPPORTED_GROUP': False,
+            'SUPPORTED_GROUP.FLAG2': True,
+        }, flags_app)
+        assert flag_enabled('SUPPORTED_GROUP.FLAG1', flags_app) is False
+        assert flag_enabled('SUPPORTED_GROUP.FLAG2', flags_app) is True
+        expect_log()
+
+    def test_flag_enabled_unsupported(self, flags_app, expect_log):
+        """Test that flag_enabled for unsupported flag logs warning"""
+        set_flags({
+            'SUPPORTED_GROUP': True,
+            'SUPPORTED_GROUP.FLAG2': False,
+        }, flags_app)
+        assert flag_enabled('SUPPORTED_GROUP.UNSUPPORTED_FLAG', flags_app) is True
+        expect_log(warnings=['SUPPORTED_GROUP.UNSUPPORTED_FLAG'])
+
+    def test_flag_enabled_unsupported_group(self, flags_app, expect_log):
+        """Test that flag_enabled for group not explicitly in supported flags gives warning"""
+        set_flags({
+            'ANOTHER_GROUP': True
+        }, flags_app)
+        assert flag_enabled('ANOTHER_GROUP', flags_app) is True
+        expect_log(warnings=['ANOTHER_GROUP'])

--- a/tests/test_request_utils.py
+++ b/tests/test_request_utils.py
@@ -7,7 +7,6 @@
 
 """Basic app tests"""
 
-import logging
 import pytest
 import requests
 from requests_mock import ANY
@@ -17,41 +16,6 @@ from etsin_finder.request_utils import get_request_url, make_request
 
 class TestMakeRequest(BaseTest):
     """Tests for request_utils functions"""
-
-    @pytest.fixture
-    def expect_log(self, caplog):
-        """
-        Expect specific warnings and errors to be logged
-
-        The number logged warnings and errors of must match
-        the length of the supplied warnings/errors lists, and
-        each log must contain the matching substring.
-
-        E.g. with warnings=['something happened'], there must be exactly
-        one warning and it must contain the substring 'something happened'.
-
-        Args:
-            warnings (list of str): Substrings expected in warnings
-            errors (list of str): Substrings expected in errors
-
-        """
-        def check(warnings=None, errors=None):
-            warnings = warnings or []
-            errors = errors or []
-
-            records = caplog.get_records('call')
-
-            log_warnings = [x.message for x in records if x.levelno == logging.WARNING]
-            assert len(warnings) == len(log_warnings)
-            for (expected, logged) in zip(warnings, log_warnings):
-                assert expected in logged
-
-            log_errors = [x.message for x in records if x.levelno == logging.ERROR]
-            for (expected, logged) in zip(errors, log_errors):
-                assert expected in logged
-            assert len(errors) == len(log_errors)
-
-        return check
 
     def test_ok_text(self, app, expect_log, requests_mock):
         """GET request with text response"""


### PR DESCRIPTION
* Add list of supported flags in `flags.py`
* Add FLAGS dict to app_config, used by both backend and frontend
* Support enabling flags by group, e.g. `GROUP: True` enables `GROUP.FLAG1`, `GROUP.FLAG2`
* Add FlaggedComponent helper for creating flagged frontend components
* Convert DOWNLOAD_API_V2.ENABLED and metaxApiV2 to new flag implementation
* Add global development helpers for overriding frontend flags: setFlag, cleanupFlags, flagEnabled, getFlags, resetFlags