### PR TITLE
Travis: Update package-lock.json

### DIFF
--- a/etsin_finder/frontend/package-lock.json
+++ b/etsin_finder/frontend/package-lock.json
@@ -5439,6 +5439,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
       "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "dev": true,
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -12442,20 +12443,6 @@
         "@babel/runtime": "^7.0.0"
       }
     },
-    "react-clipboard-icon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-clipboard-icon/-/react-clipboard-icon-1.1.0.tgz",
-      "integrity": "sha512-j55e/QkL3bQtoIO2T/RyJPmMnlvYUvzLleeL1vUQ/L2DLneDr3o6KAmoPdpzfeMzGJY/8NB+LRDetDieblrSfg=="
-    },
-    "react-copy-to-clipboard": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz",
-      "integrity": "sha512-ELKq31/E3zjFs5rDWNCfFL4NvNFQvGRoJdAKReD/rUPA+xxiLPQmZBZBvy2vgH7V0GE9isIQpT9WXbwIVErYdA==",
-      "requires": {
-        "copy-to-clipboard": "^3",
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-datepicker": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-2.16.0.tgz",
@@ -15218,7 +15205,8 @@
     "toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
+      "dev": true
     },
     "toidentifier": {
       "version": "1.0.0",


### PR DESCRIPTION
This PR is similar to the previous https://github.com/CSCfi/etsin-finder/pull/586

Travis deployment fails ( https://travis-ci.com/github/CSCfi/etsin-finder/jobs/462225761 ) ... due to differences in package-lock.json, related to recent updates to package.json:
- CSCFAIRMETA-28: https://github.com/CSCfi/etsin-finder/pull/654
- CSCFAIRMETA-805: https://github.com/CSCfi/etsin-finder/commit/833e39bad0ef9da250c44dcb318f6e1efc1855f2
- CSCFAIRMETA-831: https://github.com/CSCfi/etsin-finder/pull/653/

What was done:
- In local env, `git checkout test && git pull`
- In local env, `npm prune && npm install --only=production`
- Result: this PR