### PR TITLE
CSCFAIRMETA-909: Fix only first character of spatial being shown

### DIFF
--- a/etsin_finder/frontend/js/stores/view/locale.js
+++ b/etsin_finder/frontend/js/stores/view/locale.js
@@ -112,6 +112,9 @@ class Locale {
 
   getValueTranslation = (value, lang) => {
     // Get a translation from a multi-language string object, use supplied language by default
+    if (typeof value === 'string') {
+      return value
+    }
     if (value[lang]) {
       return value[lang]
     }


### PR DESCRIPTION
Fixes an issue where only the first character of the name was displayed for items in `Spatial coverage` list.