### PR TITLE
CSCFAIRMETA-925: Qvain editor accessibility tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: xenial
 
 language: python
 python: 3.6
+node_js:
+  - 12
 
 git:
   depth: false
@@ -30,7 +32,7 @@ jobs:
       - sudo apt-get install npm libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     install:
       - cd $TRAVIS_BUILD_DIR/etsin_finder/frontend
-      - echo "Using node version $(node --version)"
+      - node --version
       - npm install
       - npm run build -- --define process.env.NODE_ENV=\"'travis'\"
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
       - sudo apt-get install npm libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     install:
       - cd $TRAVIS_BUILD_DIR/etsin_finder/frontend
+      - echo "Using node version $(node --version)"
       - npm install
       - npm run build -- --define process.env.NODE_ENV=\"'travis'\"
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 
 language: python
 python: 3.6
-node_js:
-  - 12
 
 git:
   depth: false
@@ -31,8 +29,9 @@ jobs:
     before_install:
       - sudo apt-get install npm libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     install:
-      - cd $TRAVIS_BUILD_DIR/etsin_finder/frontend
+      - nvm use 12
       - node --version
+      - cd $TRAVIS_BUILD_DIR/etsin_finder/frontend
       - npm install
       - npm run build -- --define process.env.NODE_ENV=\"'travis'\"
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
     before_install:
       - sudo apt-get install npm libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     install:
+      - nvm install 12
       - nvm use 12
       - node --version
       - cd $TRAVIS_BUILD_DIR/etsin_finder/frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
   include:
   - stage: tests
     before_install:
-      - sudo apt-get install npm libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+      - sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     install:
       - nvm install 12
       - nvm use 12

--- a/etsin_finder/frontend/__tests__/__testdata__/dataset.att.js
+++ b/etsin_finder/frontend/__tests__/__testdata__/dataset.att.js
@@ -1,0 +1,425 @@
+const dataset = {
+  "id": 1929,
+  "identifier": "162e04c5-857b-477c-a452-cd063ee3c44d",
+  "data_catalog": {
+    "id": 10,
+    "identifier": "urn:nbn:fi:att:data-catalog-att"
+  },
+  "deprecated": false,
+  "metadata_provider_org": "test.csc.fi",
+  "metadata_provider_user": "teppo",
+  "research_dataset": {
+    "theme": [
+      {
+        "in_scheme": "http://www.yso.fi/onto/koko/",
+        "identifier": "http://www.yso.fi/onto/koko/p40393",
+        "pref_label": {
+          "fi": "makkaranvalmistus",
+          "und": "makkaranvalmistus"
+        }
+      },
+      {
+        "in_scheme": "http://www.yso.fi/onto/koko/",
+        "identifier": "http://www.yso.fi/onto/koko/p55252",
+        "pref_label": {
+          "en": "concrete steel",
+          "fi": "betoniter\u00e4s",
+          "sv": "armeringsj\u00e4rn",
+          "und": "betoniter\u00e4s"
+        }
+      }
+    ],
+    "title": {
+      "en": "English Title",
+      "fi": "Finnish Title"
+    },
+    "issued": "2021-01-28",
+    "creator": [
+      {
+        "name": "Human Person",
+        "@type": "Person",
+        "email": "email@example.com",
+        "member_of": {
+          "name": {
+            "en": "Unseen University"
+          },
+          "@type": "Organization"
+        },
+        "identifier": "https://orcid.org/person"
+      }
+    ],
+    "curator": [
+      {
+        "name": "Human Person",
+        "@type": "Person",
+        "email": "email@example.com",
+        "member_of": {
+          "name": {
+            "en": "Unseen University"
+          },
+          "@type": "Organization"
+        },
+        "identifier": "https://orcid.org/person"
+      }
+    ],
+    "keyword": [
+      "first keyword",
+      "second",
+      "third"
+    ],
+    "spatial": [
+      {
+        "as_wkt": [
+          "POINT(24.14585 67.60502)"
+        ],
+        "place_uri": {
+          "in_scheme": "http://www.yso.fi/onto/yso/places",
+          "identifier": "http://www.yso.fi/onto/yso/p109778",
+          "pref_label": {
+            "en": "\u00c4k\u00e4slompolo",
+            "fi": "\u00c4k\u00e4slompolo (Kolari)",
+            "sv": "\u00c4k\u00e4slompolo (Kolari)",
+            "und": "\u00c4k\u00e4slompolo (Kolari)"
+          }
+        },
+        "geographic_name": "\u00c4k\u00e4slompolo"
+      },
+      {
+        "as_wkt": [
+          "POINT(30.53247 63.30216)"
+        ],
+        "place_uri": {
+          "in_scheme": "http://www.yso.fi/onto/yso/places",
+          "identifier": "http://www.yso.fi/onto/yso/p136721",
+          "pref_label": {
+            "en": "Hattuvaara",
+            "fi": "Hattuvaara (Lieksa)",
+            "sv": "Hattuvaara (Lieksa)",
+            "und": "Hattuvaara (Lieksa)"
+          }
+        },
+        "geographic_name": "Hat danger"
+      }
+    ],
+    "language": [
+      {
+        "title": {
+          "en": "Inuktitut",
+          "fi": "inuktitut",
+          "sv": "inuktitut",
+          "und": "inuktitut"
+        },
+        "identifier": "http://lexvo.org/id/iso639-3/iku"
+      },
+      {
+        "title": {
+          "en": "Finno-Ugric language",
+          "fi": "suomalais-ugrilainen kieli",
+          "sv": "finskugriskt spr\u00e5k",
+          "und": "suomalais-ugrilainen kieli"
+        },
+        "identifier": "http://lexvo.org/id/iso639-5/fiu"
+      }
+    ],
+    "relation": [
+      {
+        "entity": {
+          "type": {
+            "in_scheme": "http://uri.suomi.fi/codelist/fairdata/resource_type",
+            "identifier": "http://uri.suomi.fi/codelist/fairdata/resource_type/code/collection",
+            "pref_label": {
+              "en": "Collection",
+              "fi": "Kokoelma",
+              "und": "Kokoelma"
+            }
+          },
+          "title": {
+            "en": "Resource in English",
+            "fi": "Resurssi",
+            "und": "Resurssi"
+          },
+          "identifier": "1234-aaaaa-tunniste",
+          "description": {
+            "en": "Resource Description",
+            "fi": "Resurssin kuvaus",
+            "und": "Resurssin kuvaus"
+          }
+        },
+        "relation_type": {
+          "identifier": "http://purl.org/spar/cito/cites",
+          "pref_label": {
+            "en": "Cites",
+            "fi": "Viittaa",
+            "und": "Viittaa"
+          }
+        }
+      }
+    ],
+    "temporal": [
+      {
+        "end_date": "2021-01-13T00:00:00.000Z",
+        "start_date": "2020-12-29T00:00:00.000Z"
+      },
+      {
+        "end_date": "2021-02-01T00:00:00.000Z",
+        "start_date": "2019-05-26T00:00:00.000Z"
+      },
+      {
+        "end_date": "2050-03-02T00:00:00.000Z",
+        "start_date": "2030-01-01T00:00:00.000Z"
+      }
+    ],
+    "publisher": {
+      "name": "Human Person",
+      "@type": "Person",
+      "email": "email@example.com",
+      "member_of": {
+        "name": {
+          "en": "Unseen University"
+        },
+        "@type": "Organization"
+      },
+      "identifier": "https://orcid.org/person"
+    },
+    "contributor": [
+      {
+        "name": "Human Person",
+        "@type": "Person",
+        "email": "email@example.com",
+        "member_of": {
+          "name": {
+            "en": "Unseen University"
+          },
+          "@type": "Organization"
+        },
+        "identifier": "https://orcid.org/person"
+      },
+      {
+        "name": {
+          "en": "Aalto University",
+          "fi": "Aalto yliopisto",
+          "sv": "Aalto universitetet",
+          "und": "Aalto yliopisto"
+        },
+        "@type": "Organization",
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/organization/code/10076"
+      }
+    ],
+    "description": {
+      "en": "English Description",
+      "fi": "Finnish Description"
+    },
+    "is_output_of": [
+      {
+        "name": {
+          "en": "Project",
+          "fi": "Projekti"
+        },
+        "identifier": "project-identifier",
+        "funder_type": {
+          "in_scheme": "http://uri.suomi.fi/codelist/fairdata/funder_type",
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/funder_type/code/eu-esr",
+          "pref_label": {
+            "en": "EU European Social Fund ESR",
+            "fi": "EU Euroopan sosiaalirahasto ESR",
+            "und": "EU Euroopan sosiaalirahasto ESR"
+          }
+        },
+        "has_funding_agency": [
+          {
+            "name": {
+              "en": "Aalto University",
+              "fi": "Aalto yliopisto",
+              "sv": "Aalto universitetet",
+              "und": "Aalto yliopisto"
+            },
+            "@type": "Organization",
+            "identifier": "http://uri.suomi.fi/codelist/fairdata/organization/code/10076",
+            "contributor_type": [
+              {
+                "in_scheme": "http://uri.suomi.fi/codelist/fairdata/contributor_type",
+                "definition": {
+                  "en": "Definition of a concept",
+                  "fi": "Konseptin m\u00e4\u00e4ritelm\u00e4"
+                },
+                "identifier": "http://uri.suomi.fi/codelist/fairdata/contributor_type/code/Researcher",
+                "pref_label": {
+                  "en": "Researcher",
+                  "fi": "Tutkija",
+                  "sv": "Forskare",
+                  "und": "Tutkija"
+                }
+              }
+            ]
+          }
+        ],
+        "source_organization": [
+          {
+            "name": {
+              "en": "Aalto University",
+              "fi": "Aalto yliopisto",
+              "sv": "Aalto universitetet",
+              "und": "Aalto yliopisto"
+            },
+            "@type": "Organization",
+            "identifier": "http://uri.suomi.fi/codelist/fairdata/organization/code/10076"
+          }
+        ],
+        "has_funder_identifier": "project-funding-identifier"
+      }
+    ],
+    "access_rights": {
+      "license": [
+        {
+          "title": {
+            "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+            "fi": "Creative Commons Nime\u00e4 4.0 Kansainv\u00e4linen (CC BY 4.0)",
+            "und": "Creative Commons Nime\u00e4 4.0 Kansainv\u00e4linen (CC BY 4.0)"
+          },
+          "license": "https://creativecommons.org/licenses/by/4.0/",
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0"
+        },
+        {
+          "title": {
+            "en": "Creative Commons Attribution 1.0 Generic (CC BY 1.0)",
+            "fi": "Creative Commons Nime\u00e4 1.0 Yleinen (CC BY 1.0)",
+            "und": "Creative Commons Nime\u00e4 1.0 Yleinen (CC BY 1.0)"
+          },
+          "license": "https://creativecommons.org/licenses/by/1.0/",
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-1.0"
+        }
+      ],
+      "access_type": {
+        "in_scheme": "http://uri.suomi.fi/codelist/fairdata/access_type",
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/login",
+        "pref_label": {
+          "en": "Requires login in Fairdata service",
+          "fi": "Vaatii kirjautumisen Fairdata-palvelussa",
+          "und": "Vaatii kirjautumisen Fairdata-palvelussa"
+        }
+      },
+      "restriction_grounds": [
+        {
+          "in_scheme": "http://uri.suomi.fi/codelist/fairdata/restriction_grounds",
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/restriction_grounds/code/copyright",
+          "pref_label": {
+            "en": "Restricted access due to copyright",
+            "fi": "Saatavuutta rajoitettu tekij\u00e4oikeuden perusteella",
+            "sv": "Begr\u00e4nsad \u00e5tkomst p\u00e5 grund av upphovsr\u00e4tt",
+            "und": "Saatavuutta rajoitettu tekij\u00e4oikeuden perusteella"
+          }
+        }
+      ]
+    },
+    "rights_holder": [
+      {
+        "name": "Human Person",
+        "@type": "Person",
+        "email": "email@example.com",
+        "member_of": {
+          "name": {
+            "en": "Unseen University"
+          },
+          "@type": "Organization"
+        },
+        "identifier": "https://orcid.org/person"
+      }
+    ],
+    "infrastructure": [
+      {
+        "in_scheme": "https://avaa.tdata.fi/api/jsonws/tupa-portlet.Infrastructures/get-all-infrastructures",
+        "identifier": "http://urn.fi/urn:nbn:fi:research-infras-2016072527",
+        "pref_label": {
+          "en": "Bioeconomy Infrastructure",
+          "fi": "Huippuallianssi kest\u00e4v\u00e4\u00e4n biomassan jalostukseen",
+          "und": "Huippuallianssi kest\u00e4v\u00e4\u00e4n biomassan jalostukseen"
+        }
+      },
+      {
+        "in_scheme": "https://avaa.tdata.fi/api/jsonws/tupa-portlet.Infrastructures/get-all-infrastructures",
+        "identifier": "http://urn.fi/urn:nbn:fi:research-infras-2016072528",
+        "pref_label": {
+          "en": "Cherenkov Telescope Array",
+          "fi": "Cherenkov teleskooppij\u00e4rjestelm\u00e4",
+          "und": "Cherenkov teleskooppij\u00e4rjestelm\u00e4"
+        }
+      }
+    ],
+    "field_of_science": [
+      {
+        "in_scheme": "http://www.yso.fi/onto/okm-tieteenala/conceptscheme",
+        "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta111",
+        "pref_label": {
+          "en": "Mathematics",
+          "fi": "Matematiikka",
+          "sv": "Matematik",
+          "und": "Matematiikka"
+        }
+      },
+      {
+        "in_scheme": "http://www.yso.fi/onto/okm-tieteenala/conceptscheme",
+        "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta114",
+        "pref_label": {
+          "en": "Physical sciences",
+          "fi": "Fysiikka",
+          "sv": "Fysik",
+          "und": "Fysiikka"
+        }
+      },
+      {
+        "in_scheme": "http://www.yso.fi/onto/okm-tieteenala/conceptscheme",
+        "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta113",
+        "pref_label": {
+          "en": "Computer and information sciences",
+          "fi": "Tietojenk\u00e4sittely ja informaatiotieteet",
+          "sv": "Data- och informationsvetenskap",
+          "und": "Tietojenk\u00e4sittely ja informaatiotieteet"
+        }
+      }
+    ],
+    "other_identifier": [
+      {
+        "notation": "https://doi.org/identifier"
+      },
+      {
+        "notation": "https://doi.org/another_identifier"
+      }
+    ],
+    "remote_resources": [
+      {
+        "title": "Remote resource",
+        "access_url": {
+          "identifier": "https://access.url"
+        },
+        "download_url": {
+          "identifier": "https://download.url"
+        },
+        "use_category": {
+          "in_scheme": "http://uri.suomi.fi/codelist/fairdata/use_category",
+          "identifier": "http://uri.suomi.fi/codelist/fairdata/use_category/code/configuration",
+          "pref_label": {
+            "en": "Configuration files",
+            "fi": "Konfiguraatiotiedosto",
+            "und": "Konfiguraatiotiedosto"
+          }
+        }
+      }
+    ],
+    "preferred_identifier": "draft:162e04c5-857b-477c-a452-cd063ee3c44d",
+    "metadata_version_identifier": "2037942d-a9d1-44d8-bd6c-818a0278db83"
+  },
+  "preservation_state": 0,
+  "state": "draft",
+  "use_doi_for_published": false,
+  "cumulative_state": 0,
+  "api_meta": {
+    "version": 2
+  },
+  "date_modified": "2021-01-28T10:26:12+02:00",
+  "date_created": "2021-01-28T10:06:32+02:00",
+  "service_modified": "qvain-light",
+  "service_created": "qvain-light",
+  "removed": false
+}
+
+export default dataset

--- a/etsin_finder/frontend/__tests__/combined/qvain/a11y/qvain.editor.a11y.test.jsx
+++ b/etsin_finder/frontend/__tests__/combined/qvain/a11y/qvain.editor.a11y.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { ThemeProvider } from 'styled-components'
+import { BrowserRouter } from 'react-router-dom'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import ReactModal from 'react-modal'
+
+import etsinTheme from '../../../../js/styles/theme'
+import '../../../../locale/translations'
+import QvainContent from '../../../../js/components/qvain/views/main/index'
+import stores from '../../../../js/stores'
+import { StoresProvider } from '../../../../js/stores/stores'
+import dataset from '../../../__testdata__/dataset.att'
+import Section from '../../../../js/components/qvain/general/section/section'
+import Field from '../../../../js/components/qvain/general/section/field'
+import { ExpandCollapse } from '../../../../js/components/qvain/general/section/expand'
+
+expect.extend(toHaveNoViolations)
+
+describe('Qvain editor', () => {
+  let wrapper, helper
+
+  // open/close all visible sections
+  const setSectionsExpanded = (wrapper, value) => {
+    const sections = wrapper.find(Section)
+    sections.forEach(section => section.instance().setState({ isExpanded: value }))
+    wrapper.update()
+  }
+
+  // open/close all visible fields
+  const setFieldsExpanded = (wrapper, value) => {
+    const fields = wrapper.find(Field)
+    fields.forEach(field => {
+      const expander = field.find(ExpandCollapse).first()
+      const enabled = expander.prop('isExpanded')
+      if (enabled != value) {
+        // toggles field by clicking expand button
+        const button = expander.find('button').first()
+        button.simulate('click')
+      }
+    })
+    wrapper.update()
+  }
+
+  beforeEach(async () => {
+    await stores.Qvain.editDataset(dataset)
+
+    helper = document.createElement('div')
+    document.body.appendChild(helper)
+    ReactModal.setAppElement(helper)
+
+    wrapper = mount(
+      <StoresProvider store={stores}>
+        <BrowserRouter>
+          <ThemeProvider theme={etsinTheme}>
+            <main>
+              <QvainContent />
+            </main>
+          </ThemeProvider>
+        </BrowserRouter>
+      </StoresProvider>,
+      { attachTo: helper }
+    )
+  })
+
+  afterEach(() => {
+    wrapper?.unmount?.()
+    document.body.removeChild(helper)
+  })
+
+  it('is accessible with sections open', async () => {
+    setSectionsExpanded(wrapper, true)
+    setFieldsExpanded(wrapper, true)
+    const results = await axe(wrapper.getDOMNode())
+    expect(results).toHaveNoViolations()
+  })
+
+  it('is accessible with sections closed', async () => {
+    setSectionsExpanded(wrapper, false)
+    setFieldsExpanded(wrapper, false)
+    const results = await axe(wrapper.getDOMNode())
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/etsin_finder/frontend/__tests__/combined/qvain/metadataModal.test.jsx
+++ b/etsin_finder/frontend/__tests__/combined/qvain/metadataModal.test.jsx
@@ -181,6 +181,10 @@ describe('Qvain.MetadataModal', () => {
     stores.Qvain.Files.root.directories.push(dir)
   })
 
+  afterEach(() => {
+    wrapper?.unmount?.()
+  })
+
   it('opens file on click and validates the metadata', async () => {
     await setFile('/test/test.csv')
     expect(instance.state.fileIdentifier).toBe('test_file')

--- a/etsin_finder/frontend/js/components/qvain/fields/licenses/restrictionGrounds.jsx
+++ b/etsin_finder/frontend/js/components/qvain/fields/licenses/restrictionGrounds.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { observer } from 'mobx-react'
 import Translate from 'react-translate-component'
 
+import { LabelLarge } from '../../general/modal/form'
 import Select from '../../general/input/select'
 import ValidationError from '../../general/errors/validationError'
 import { useStores } from '../../utils/stores'
@@ -28,7 +29,11 @@ const RestrictionGrounds = () => {
 
   return (
     <RestrictionGroundsContainer>
-      <Translate component="h3" content="qvain.rightsAndLicenses.restrictionGrounds.title" />
+      <Translate
+        component={LabelLarge}
+        htmlFor="restrictionGrounds-select"
+        content="qvain.rightsAndLicenses.restrictionGrounds.title"
+      />
       <Translate
         name="restrictionGrounds"
         metaxIdentifier="restriction_grounds"

--- a/etsin_finder/frontend/package-lock.json
+++ b/etsin_finder/frontend/package-lock.json
@@ -10322,6 +10322,166 @@
         "jest-cli": "^24.9.0"
       }
     },
+    "jest-axe": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-4.1.0.tgz",
+      "integrity": "sha512-TPWRbwQYwdt1jtvM0DRi//0e51omWirMkyf99paeY7kYS5XsUZ9IcyP4omrqPKJ46xHDxs1AYqIwVz/minBoFw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.0.1",
+        "chalk": "^4.0.0",
+        "jest-matcher-utils": "^26.0.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
+          "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axe-core": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+          "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.6.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.6.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+          "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.6.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.6.2"
+          }
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-changed-files": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
@@ -11217,6 +11377,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.sortby": {

--- a/etsin_finder/frontend/package.json
+++ b/etsin_finder/frontend/package.json
@@ -63,7 +63,7 @@
     "react-interpolate-component": "^0.12.0",
     "react-leaflet": "2.1.2",
     "react-markdown": "^4.1.0",
-    "react-modal": "^3.9.1",
+    "react-modal": "^3.12.1",
     "react-router-dom": "^5.0.1",
     "react-select": "^3.1.0",
     "react-transition-group": "^2.9.0",
@@ -99,6 +99,7 @@
     "eslint-plugin-react-hooks": "^1.6.1",
     "history": "4.7.2",
     "jest": "^24.8.0",
+    "jest-axe": "^4.1.0",
     "jest-cli": "^24.8.0",
     "react-element-to-jsx-string": "^14.0.2"
   },


### PR DESCRIPTION
* Add jest-axe tests for Qvain editor
* Add missing label to restriction grounds
* Update react-modal
* Use node v12.x.x for travis (some jest-axe dependency didn't work with v8 that was used previously)