### PR TITLE
CSCFAIRMETA-944: Unify Qvain page title styles

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/general/card/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/card/index.jsx
@@ -47,9 +47,9 @@ export const QvainContainer = styled.div`
   background-color: #fafafa;
 `
 
-export const SubHeader = styled.h1`
+export const PageTitle = styled.h1`
   height: 100px;
-  background-color: #007fad;
+  background-color: ${p => p.theme.color.primary};
   color: white;
   display: flex;
   align-items: center;
@@ -62,6 +62,7 @@ export const SubHeader = styled.h1`
   letter-spacing: normal;
   padding: 0.5rem 1rem 0.5rem 2rem;
   white-space: nowrap;
+  margin-bottom: 0;
 `
 
 export const Paragraph = styled.p`
@@ -90,18 +91,6 @@ export const StickySubHeaderResponse = styled.div`
   display: flex;
   width: 100%;
   justify-content: center;
-`
-
-export const SubHeaderText = styled.div`
-  font-family: 'Lato', sans-serif;
-  font-size: 32px;
-  font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 0.81;
-  letter-spacing: normal;
-  color: #ffffff;
-  padding: 0.5rem 1rem 0.5rem 2rem;
 `
 
 export const FileContainer = styled(Container)`

--- a/etsin_finder/frontend/js/components/qvain/views/datasets/index.jsx
+++ b/etsin_finder/frontend/js/components/qvain/views/datasets/index.jsx
@@ -7,15 +7,8 @@ import styled from 'styled-components'
 import { useStores } from '../../utils/stores'
 
 import DatasetTable from './table'
-import {
-  ContainerLight,
-  ContainerSubsection,
-  QvainContainer,
-  SubHeader,
-  SubHeaderText,
-} from '../../general/card'
+import { ContainerLight, ContainerSubsection, QvainContainer, PageTitle } from '../../general/card'
 import { SaveButton } from '../../general/buttons'
-import Title from '../../general/card/title'
 import Tracking from '../../../../utils/tracking'
 import NoticeBar from '../../../general/noticeBar'
 
@@ -32,11 +25,7 @@ const Datasets = ({ history, location }) => {
 
   return (
     <QvainContainer>
-      <SubHeader>
-        <SubHeaderText>
-          <Translate component={Title} content="qvain.datasets.title" />
-        </SubHeaderText>
-      </SubHeader>
+      <Translate component={PageTitle} content="qvain.datasets.title" />
       {publishedDataset && (
         <PublishSuccess onClose={() => setPublishedDataset(null)}>
           <Translate content="qvain.submitStatus.success" />

--- a/etsin_finder/frontend/js/components/qvain/views/editor/header.jsx
+++ b/etsin_finder/frontend/js/components/qvain/views/editor/header.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Translate from 'react-translate-component'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import { SubHeader } from '../../general/card'
+import { PageTitle } from '../../general/card'
 import { useStores } from '../../utils/stores'
 
 const Header = ({ datasetLoading, datasetError }) => {
@@ -20,7 +20,7 @@ const Header = ({ datasetLoading, datasetError }) => {
     return 'qvain.titleCreate'
   }
 
-  return <Translate component={SubHeader} content={getTitleKey()} />
+  return <Translate component={PageTitle} content={getTitleKey()} />
 }
 
 Header.propTypes = {


### PR DESCRIPTION
* Rename SubHeader to PageTitle to make its purpose clearer
* Remove extra h1 from datasets page title
* Remove unintentional margin from below the page title block
