### PR TITLE
CSCFAIRMETA-990: Hide source buttons when there is a common source

### DIFF
--- a/etsin_finder/frontend/__tests__/combined/etsin/externalResources.test.jsx
+++ b/etsin_finder/frontend/__tests__/combined/etsin/externalResources.test.jsx
@@ -94,6 +94,7 @@ describe('ExternalResources', () => {
       noUrlResource,
     ])
     hasCommonSourceLink(wrapper).should.eql(true)
+    wrapper.find(ResourceItem).map(item => item.prop('hideAccess')).should.eql([true, true, true, true])
   })
 
   it('should not have common source link when there are different access urls', () => {
@@ -157,23 +158,32 @@ describe('ExternalResources', () => {
       const wrapper = renderResources([downloadUrlResource])
       wrapper.find(Grid).props().should.include({
         hasDownload: true,
-        hasAccess: false,
+        showAccess: false,
       })
     })
 
     it('has only access urls', () => {
-      const wrapper = renderResources([accessUrlResource])
+      const wrapper = renderResources([accessUrlResource, anotherAccessUrlResource])
       wrapper.find(Grid).props().should.include({
         hasDownload: false,
-        hasAccess: true,
+        showAccess: true,
+      })
+    })
+
+    it('has no urls', () => {
+      // access urls are not displayed if all resources have the same url
+      const wrapper = renderResources([accessUrlResource, accessUrlResource])
+      wrapper.find(Grid).props().should.include({
+        hasDownload: false,
+        showAccess: false,
       })
     })
 
     it('has both urls', () => {
-      const wrapper = renderResources([accessUrlResource, downloadUrlResource])
+      const wrapper = renderResources([accessUrlResource, anotherAccessUrlResource, downloadUrlResource])
       wrapper.find(Grid).props().should.include({
         hasDownload: true,
-        hasAccess: true,
+        showAccess: true,
       })
     })
   })

--- a/etsin_finder/frontend/js/components/dataset/data/externalResources/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/data/externalResources/index.jsx
@@ -38,6 +38,7 @@ const ExternalResources = () => {
   const accessUrls = new Set(remote.map(resource => resource.access_url?.identifier).filter(v => v))
   const hasAccess = accessUrls.size > 0
   const hasCommonAccess = accessUrls.size === 1
+  const showAccess = hasAccess && !hasCommonAccess
   const hasDownload = !!remote.find(resource => resource.download_url?.identifier)
 
   return (
@@ -63,11 +64,13 @@ const ExternalResources = () => {
         )}
       </Header>
 
-      <Grid hasAccess={hasAccess} hasDownload={hasDownload}>
+      <Grid showAccess={showAccess} hasDownload={hasDownload}>
         {remote.map(resource => (
           <ResourceItem
             key={`resource-${resource.identifier}-${resource.title}`}
             resource={resource}
+            hideAccess={!showAccess}
+            noButtons={!showAccess && !hasDownload}
           />
         ))}
       </Grid>
@@ -75,12 +78,12 @@ const ExternalResources = () => {
   )
 }
 
-const gridColumns = ({ hasAccess, hasDownload, mobile }) => {
+const gridColumns = ({ showAccess, hasDownload, mobile }) => {
   const columns = [['name', '1fr']]
   if (!mobile) {
     columns.push(['category', 'minmax(max-content, 0.75fr)'])
   }
-  if (hasAccess) {
+  if (showAccess) {
     columns.push(['access', '5.5rem'])
   }
   if (hasDownload) {

--- a/etsin_finder/frontend/js/components/dataset/data/externalResources/resourceItem.jsx
+++ b/etsin_finder/frontend/js/components/dataset/data/externalResources/resourceItem.jsx
@@ -9,7 +9,7 @@ import { observer } from 'mobx-react'
 import { useStores } from '../../../../stores/stores'
 import IconButton from '../common/iconButton'
 
-const ResourceItem = ({ resource }) => {
+const ResourceItem = ({ resource, hideAccess, noButtons }) => {
   const {
     Locale: { getValueTranslation },
   } = useStores()
@@ -20,9 +20,11 @@ const ResourceItem = ({ resource }) => {
         <ResourceIcon resource={resource} />
         {getValueTranslation(resource.title)}
       </Name>
-      <Category>{getValueTranslation(resource.use_category?.pref_label)}</Category>
+      <Category noButtons={noButtons}>
+        {getValueTranslation(resource.use_category?.pref_label)}
+      </Category>
 
-      {resource.access_url && (
+      {resource.access_url && !hideAccess && (
         <LinkButtonColumn>
           <Translate
             component={LinkButton}
@@ -47,6 +49,13 @@ const ResourceItem = ({ resource }) => {
 
 ResourceItem.propTypes = {
   resource: PropTypes.object.isRequired,
+  hideAccess: PropTypes.bool,
+  noButtons: PropTypes.bool,
+}
+
+ResourceItem.defaultProps = {
+  hideAccess: false,
+  noButtons: false,
 }
 
 export const Name = styled.span`
@@ -61,9 +70,14 @@ export const Category = styled.div`
   grid-column: 2/3;
   width: max-content;
 
-  @media (max-width: ${props => props.theme.breakpoints.sm}) {
+  ${p => p.noButtons && 'justify-self: end; '}
+
+  ${p =>
+    !p.noButtons &&
+    `
+  @media (max-width: ${p.theme.breakpoints.sm}) {
     display: none;
-  }
+  }`}
 `
 
 const ResourceIcon = styled(FontAwesomeIcon).attrs({


### PR DESCRIPTION
* Remote resources tab will show only the common source button when all access urls are same
* Justify category column right when there are no dl/source buttons