### PR TITLE
CSCFAIRMETA-906: Always use URL for DOI/URN citations

### DIFF
--- a/etsin_finder/frontend/__tests__/utils/cite.test.js
+++ b/etsin_finder/frontend/__tests__/utils/cite.test.js
@@ -128,7 +128,7 @@ describe('Citation styles', () => {
 
     it('should use URL also for capitalized URN:NBN:fi dataset', () => {
       c(capitalizedUrnDataset).should.eq(
-        'Top organization. (2021). Publication title. Publisher. http://urn.fi/URN:NBN:fi:att:d00d'
+        'Top organization. (2021). Publication title. Publisher. http://urn.fi/urn:nbn:fi:att:d00d'
       )
     })
 
@@ -188,7 +188,7 @@ describe('Citation styles', () => {
 
     it('should use URL also for capitalized URN:NBN:fi dataset', () => {
       c(capitalizedUrnDataset).should.eq(
-        'Top organization. 2021. ”Publication title”. Publisher. http://urn.fi/URN:NBN:fi:att:d00d'
+        'Top organization. 2021. ”Publication title”. Publisher. http://urn.fi/urn:nbn:fi:att:d00d'
       )
     })
 
@@ -245,7 +245,7 @@ describe('Citation styles', () => {
 
     it('should use URL also for capitalized URN:NBN:fi dataset', () => {
       c(capitalizedUrnDataset).should.eq(
-        'Top organization. ”Publication title”. Publisher, 2021. http://urn.fi/URN:NBN:fi:att:d00d'
+        'Top organization. ”Publication title”. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:d00d'
       )
     })
 

--- a/etsin_finder/frontend/__tests__/utils/cite.test.js
+++ b/etsin_finder/frontend/__tests__/utils/cite.test.js
@@ -8,7 +8,7 @@ import { should } from 'chai'
 const cite = new Cite(Locale.getValueTranslation)
 
 const emptyDataset = {
-  research_dataset: {}
+  research_dataset: {},
 }
 
 const personDataset = {
@@ -17,18 +17,23 @@ const personDataset = {
     publisher: { name: { en: 'Publisher' } },
     issued: '2021-02-23',
     title: { fi: 'Julkaisun nimi', en: 'Publication title' },
-    preferred_identifier: 'urn:nbn:fi:att:feedc0de'
+    preferred_identifier: 'urn:nbn:fi:att:feedc0de',
   },
   identifier: 'metax_identifier_for_this_dataset',
 }
 
 const organizationDataset = {
   research_dataset: {
-    creator: [{
-      name: { en: 'Some suborganization', fi: 'Joku aliorganisaatio' },
-      '@type': 'Organization',
-      'is_part_of': { name: { en: 'Top organization', fi: 'Pääorganisaatio' }, '@type': 'Organization' }
-    }],
+    creator: [
+      {
+        name: { en: 'Some suborganization', fi: 'Joku aliorganisaatio' },
+        '@type': 'Organization',
+        is_part_of: {
+          name: { en: 'Top organization', fi: 'Pääorganisaatio' },
+          '@type': 'Organization',
+        },
+      },
+    ],
     publisher: { name: { en: 'Publisher', fi: 'Julkaisija' } },
     issued: '2021-02-23',
     title: { fi: 'Julkaisun nimi', en: 'Publication title' },
@@ -40,8 +45,15 @@ const organizationDataset = {
 const doiDataset = {
   research_dataset: {
     ...organizationDataset.research_dataset,
-    preferred_identifier: 'doi:10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
-  }
+    preferred_identifier: 'doi:10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b',
+  },
+}
+
+const capitalizedUrnDataset = {
+  research_dataset: {
+    ...organizationDataset.research_dataset,
+    preferred_identifier: 'URN:NBN:fi:att:d00d',
+  },
 }
 
 const manyCreatorsDataset = {
@@ -71,17 +83,23 @@ const manyCreatorsDataset = {
       { name: 'Tyyppi Kahdeskymmenesensimmäinen' },
       { name: 'Tyyppi Kahdeskymmenestoinen' },
     ],
-  }
+  },
 }
 
 const firstVersionDataset = {
   ...organizationDataset,
-  dataset_version_set: [{ identifier: "metax_identifier_for_second" }, { identifier: organizationDataset.identifier }]
+  dataset_version_set: [
+    { identifier: 'metax_identifier_for_second' },
+    { identifier: organizationDataset.identifier },
+  ],
 }
 
 const secondVersionDataset = {
   ...organizationDataset,
-  dataset_version_set: [{ identifier: organizationDataset.identifier }, { identifier: "metax_identifier_for_first" }]
+  dataset_version_set: [
+    { identifier: organizationDataset.identifier },
+    { identifier: 'metax_identifier_for_first' },
+  ],
 }
 
 beforeEach(() => {
@@ -90,156 +108,179 @@ beforeEach(() => {
 
 describe('Citation styles', () => {
   describe('APA', () => {
+    const c = cite.apa
+
     it('should handle empty dataset', () => {
-      cite.apa(emptyDataset).should.eq('')
+      c(emptyDataset).should.eq('')
     })
 
     it('should render citation for dataset by a person', () => {
-      cite.apa(personDataset).should.eq(
-        'Von Sukunimi, E., & Henkilö, T. (2021). Publication title. Publisher. urn:nbn:fi:att:feedc0de'
+      c(personDataset).should.eq(
+        'Von Sukunimi, E., & Henkilö, T. (2021). Publication title. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for dataset by an organization', () => {
-      cite.apa(organizationDataset).should.eq(
-        'Top organization. (2021). Publication title. Publisher. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Top organization. (2021). Publication title. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
+      )
+    })
+
+    it('should use URL also for capitalized URN:NBN:fi dataset', () => {
+      c(capitalizedUrnDataset).should.eq(
+        'Top organization. (2021). Publication title. Publisher. http://urn.fi/URN:NBN:fi:att:d00d'
       )
     })
 
     it('should use URL for DOI dataset', () => {
-      cite.apa(doiDataset).should.eq(
+      c(doiDataset).should.eq(
         'Top organization. (2021). Publication title. Publisher. https://doi.org/10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
       )
     })
 
     it('should render citation for first version of dataset', () => {
-      cite.apa(firstVersionDataset).should.eq(
-        'Top organization. (2021). Publication title (Version 1). Publisher. urn:nbn:fi:att:feedc0de'
+      c(firstVersionDataset).should.eq(
+        'Top organization. (2021). Publication title (Version 1). Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for second version of dataset', () => {
-      cite.apa(secondVersionDataset).should.eq(
-        'Top organization. (2021). Publication title (Version 2). Publisher. urn:nbn:fi:att:feedc0de'
+      c(secondVersionDataset).should.eq(
+        'Top organization. (2021). Publication title (Version 2). Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use Finnish titles', () => {
       Locale.setLang('fi', true)
-      cite.apa(organizationDataset).should.eq(
-        'Pääorganisaatio. (2021). Julkaisun nimi. Julkaisija. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Pääorganisaatio. (2021). Julkaisun nimi. Julkaisija. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use ... for more than 20 creators', () => {
-      cite.apa(manyCreatorsDataset).should.eq(
+      c(manyCreatorsDataset).should.eq(
         'Eka, T., Toka, T., Kolmas, T., Neljäs, T., Viides, T., Kuudes, T., Seitsemäs, T., ' +
-        'Kahdeksas, T., Yhdeksäs, T., Kymmenes, T., Yhdestoista, T., Kahdestoista, T., Kolmastoista, T., ' +
-        'Neljästoista, T., Viidestoista, T., Kuudestoista, T., Seitsemästoista, T., Kahdeksastoista, T., Yhdeksästoista, T., . . . Kahdeskymmenestoinen, T. ' +
-        '(2021). Publication title. Publisher. urn:nbn:fi:att:feedc0de'
+          'Kahdeksas, T., Yhdeksäs, T., Kymmenes, T., Yhdestoista, T., Kahdestoista, T., Kolmastoista, T., ' +
+          'Neljästoista, T., Viidestoista, T., Kuudestoista, T., Seitsemästoista, T., Kahdeksastoista, T., Yhdeksästoista, T., . . . Kahdeskymmenestoinen, T. ' +
+          '(2021). Publication title. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
   })
 
   describe('Chicago', () => {
+    const c = cite.chicago
+
     it('should handle empty dataset', () => {
-      cite.chicago(emptyDataset).should.eq('')
+      c(emptyDataset).should.eq('')
     })
 
     it('should render citation for dataset by a person', () => {
-      cite.chicago(personDataset).should.eq(
-        'Von Sukunimi, Etunimi, and Toinen Henkilö. 2021. ”Publication title”. Publisher. urn:nbn:fi:att:feedc0de'
+      c(personDataset).should.eq(
+        'Von Sukunimi, Etunimi, and Toinen Henkilö. 2021. ”Publication title”. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for dataset by an organization', () => {
-      cite.chicago(organizationDataset).should.eq(
-        'Top organization. 2021. ”Publication title”. Publisher. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Top organization. 2021. ”Publication title”. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
+      )
+    })
+
+    it('should use URL also for capitalized URN:NBN:fi dataset', () => {
+      c(capitalizedUrnDataset).should.eq(
+        'Top organization. 2021. ”Publication title”. Publisher. http://urn.fi/URN:NBN:fi:att:d00d'
       )
     })
 
     it('should use URL for DOI dataset', () => {
-      cite.chicago(doiDataset).should.eq(
+      c(doiDataset).should.eq(
         'Top organization. 2021. ”Publication title”. Publisher. https://doi.org/10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
       )
     })
 
     it('should render citation for first version of dataset', () => {
-      cite.chicago(firstVersionDataset).should.eq(
-        'Top organization. 2021. ”Publication title”. Version 1. Publisher. urn:nbn:fi:att:feedc0de'
+      c(firstVersionDataset).should.eq(
+        'Top organization. 2021. ”Publication title”. Version 1. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for second version of dataset', () => {
-      cite.chicago(secondVersionDataset).should.eq(
-        'Top organization. 2021. ”Publication title”. Version 2. Publisher. urn:nbn:fi:att:feedc0de'
+      c(secondVersionDataset).should.eq(
+        'Top organization. 2021. ”Publication title”. Version 2. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use Finnish titles', () => {
       Locale.setLang('fi', true)
-      cite.chicago(organizationDataset).should.eq(
-        'Pääorganisaatio. 2021. ”Julkaisun nimi”. Julkaisija. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Pääorganisaatio. 2021. ”Julkaisun nimi”. Julkaisija. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use et al for more than 10 creators', () => {
-      cite.chicago(manyCreatorsDataset).should.eq(
-        'Eka, Tyyppi, Tyyppi Toka, Tyyppi Kolmas, Tyyppi Neljäs, Tyyppi Viides, Tyyppi Kuudes, Tyyppi Seitsemäs, et al. 2021. ”Publication title”. Publisher. urn:nbn:fi:att:feedc0de'
+      c(manyCreatorsDataset).should.eq(
+        'Eka, Tyyppi, Tyyppi Toka, Tyyppi Kolmas, Tyyppi Neljäs, Tyyppi Viides, Tyyppi Kuudes, Tyyppi Seitsemäs, et al. 2021. ”Publication title”. Publisher. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
   })
 
   describe('MLA', () => {
+    const c = cite.mla
+
     it('should handle empty dataset', () => {
-      cite.mla(emptyDataset).should.eq('')
+      c(emptyDataset).should.eq('')
     })
 
     it('should render citation for dataset by a person', () => {
-      cite.mla(personDataset).should.eq(
-        'Von Sukunimi, Etunimi, and Toinen Henkilö. ”Publication title”. Publisher, 2021. urn:nbn:fi:att:feedc0de'
+      c(personDataset).should.eq(
+        'Von Sukunimi, Etunimi, and Toinen Henkilö. ”Publication title”. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for dataset by an organization', () => {
-      cite.mla(organizationDataset).should.eq(
-        'Top organization. ”Publication title”. Publisher, 2021. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Top organization. ”Publication title”. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
-    it('should use DOI identifier for DOI dataset', () => {
-      cite.mla(doiDataset).should.eq(
-        'Top organization. ”Publication title”. Publisher, 2021. doi:10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
+    it('should use URL also for capitalized URN:NBN:fi dataset', () => {
+      c(capitalizedUrnDataset).should.eq(
+        'Top organization. ”Publication title”. Publisher, 2021. http://urn.fi/URN:NBN:fi:att:d00d'
+      )
+    })
+
+    it('should use URL for DOI dataset', () => {
+      c(doiDataset).should.eq(
+        'Top organization. ”Publication title”. Publisher, 2021. https://doi.org/10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
       )
     })
 
     it('should render citation for first version of dataset', () => {
-      cite.mla(firstVersionDataset).should.eq(
-        'Top organization. ”Publication title”. Version 1. Publisher, 2021. urn:nbn:fi:att:feedc0de'
+      c(firstVersionDataset).should.eq(
+        'Top organization. ”Publication title”. Version 1. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should render citation for second version of dataset', () => {
-      cite.mla(secondVersionDataset).should.eq(
-        'Top organization. ”Publication title”. Version 2. Publisher, 2021. urn:nbn:fi:att:feedc0de'
+      c(secondVersionDataset).should.eq(
+        'Top organization. ”Publication title”. Version 2. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use Finnish titles', () => {
       Locale.setLang('fi', true)
-      cite.mla(organizationDataset).should.eq(
-        'Pääorganisaatio. ”Julkaisun nimi”. Julkaisija, 2021. urn:nbn:fi:att:feedc0de'
+      c(organizationDataset).should.eq(
+        'Pääorganisaatio. ”Julkaisun nimi”. Julkaisija, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
 
     it('should use et al for more than 3 creators', () => {
-      cite.mla(manyCreatorsDataset).should.eq(
-        'Eka, Tyyppi, et al. ”Publication title”. Publisher, 2021. urn:nbn:fi:att:feedc0de'
+      c(manyCreatorsDataset).should.eq(
+        'Eka, Tyyppi, et al. ”Publication title”. Publisher, 2021. http://urn.fi/urn:nbn:fi:att:feedc0de'
       )
     })
   })
 })
-
 
 describe('Utils', () => {
   describe('getNameInitials', () => {
@@ -282,7 +323,9 @@ describe('Utils', () => {
     })
 
     it('should leave multi-part last name unchanged', () => {
-      getLastnameFirst('Johannes Diderik van der Waals').should.eq('van der Waals, Johannes Diderik')
+      getLastnameFirst('Johannes Diderik van der Waals').should.eq(
+        'van der Waals, Johannes Diderik'
+      )
     })
 
     it('should format hyphenated last name correctly', () => {

--- a/etsin_finder/frontend/__tests__/utils/idnToLink.test.jsx
+++ b/etsin_finder/frontend/__tests__/utils/idnToLink.test.jsx
@@ -1,0 +1,31 @@
+import 'chai/register-should'
+
+import idnToLink from '../../js/utils/idnToLink'
+
+describe('idnToLink', () => {
+  test('should create DOI url', () => {
+    idnToLink('doi:10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b').should.eql(
+      'https://doi.org/10.234567/c4fef00f-1234-5678-9abcde-133753c19b7b'
+    )
+  })
+
+  test('should create URN url', () => {
+    idnToLink('urn:nbn:fi:att:d00d').should.eql('http://urn.fi/urn:nbn:fi:att:d00d')
+  })
+
+  test('should create URN url fom capitalized characters', () => {
+    idnToLink('URN:NBN:fi:att:d00d').should.eql('http://urn.fi/urn:nbn:fi:att:d00d')
+  })
+
+  test('should return HTTP url', () => {
+    idnToLink('http://example.org/something').should.eql('http://example.org/something')
+  })
+
+  test('should return HTTPS url', () => {
+    idnToLink('https://example.org/something').should.eql('https://example.org/something')
+  })
+
+  test('should not return url for unknown identifier type', () => {
+    idnToLink('some-identifier').should.eql('')
+  })
+})

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/apa.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/apa.js
@@ -22,7 +22,7 @@ const getCitation = (dataset, getTranslation) => {
         }]
       },
       getPublisher(dataset, getTranslation),
-      getIdentifier(dataset, true),
+      getIdentifier(dataset),
     ]
   })
   return citation.get()

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/chicago.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/chicago.js
@@ -11,7 +11,7 @@ const getCitation = (dataset, getTranslation) => {
       addQuotes(getTitle(dataset, getTranslation)),
       capitalizeFirst(getVersion(dataset, getTranslation)),
       getPublisher(dataset, getTranslation),
-      getIdentifier(dataset, true),
+      getIdentifier(dataset),
     ]
   })
   return citation.get()

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/citationBuilder.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/citationBuilder.js
@@ -5,6 +5,10 @@ class CitationBuilder {
 
   constructor(parts) {
     this.parts = parts
+    this.addPart = this.addPart.bind(this)
+    this.joinStrings = this.joinStrings.bind(this)
+    this.renderPart = this.renderPart.bind(this)
+    this.get = this.get.bind(this)
   }
 
   addPart(part, format = val => val) {

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/index.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/index.js
@@ -5,6 +5,9 @@ import getMlaCitation from './mla'
 class Cite {
   constructor(getTranslation) {
     this.getTranslation = getTranslation
+    this.apa = this.apa.bind(this)
+    this.chicago = this.chicago.bind(this)
+    this.mla = this.mla.bind(this)
   }
 
   apa(dataset) {

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/mla.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/mla.js
@@ -18,7 +18,7 @@ const getCitation = (dataset, getTranslation) => {
         sep: ',',
         parts: [getPublisher(dataset, getTranslation), getYear(dataset)]
       },
-      getIdentifier(dataset, false),
+      getIdentifier(dataset),
     ]
   })
   return citation.get()

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/utils.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/utils.js
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import idnToLink from '../../../../utils/idnToLink'
 
 const topOrg = org => {
   if (org.is_part_of) {
@@ -163,16 +164,14 @@ export const getVersion = (dataset, getTranslation) => {
   return getTranslation({ en: `Version ${version}`, fi: `versio ${version}` })
 }
 
-export const getIdentifier = (dataset) => {
+export const getIdentifier = dataset => {
   const identifier = dataset.research_dataset.preferred_identifier
   if (!identifier) {
     return undefined
   }
-  if (identifier.startsWith('doi:')) {
-    return identifier.replace('doi:', 'https://doi.org/')
-  }
-  if (identifier.toLowerCase().startsWith('urn:nbn:fi:')) {
-    return `http://urn.fi/${identifier}`
+  const url = idnToLink(identifier)
+  if (url) {
+    return url
   }
   if (dataset.draft_of) {
     return dataset.draft_of.preferred_identifier

--- a/etsin_finder/frontend/js/components/dataset/citation/cite/utils.js
+++ b/etsin_finder/frontend/js/components/dataset/citation/cite/utils.js
@@ -1,6 +1,6 @@
 import moment from 'moment'
 
-const topOrg = (org) => {
+const topOrg = org => {
   if (org.is_part_of) {
     return topOrg(org.is_part_of)
   }
@@ -20,7 +20,7 @@ const romanNumeralMatch = /^(((IX|IV|V)I{0,3})|I{1,3})$/
 
 const toInitial = name => `${name[0]}.`
 
-export const getNameParts = (name) => {
+export const getNameParts = name => {
   const parts = name.split(' ')
   if (parts.length === 1) {
     return { first: [], last: [parts[0]], suffixes: [] }
@@ -38,7 +38,7 @@ export const getNameParts = (name) => {
 
   let isFirst = true
   parts.forEach((part, idx) => {
-    if ((idx === parts.length - 1) || startsWithLowerCase(part) || lastnameParts.includes(part)) {
+    if (idx === parts.length - 1 || startsWithLowerCase(part) || lastnameParts.includes(part)) {
       isFirst = false
     }
     if (isFirst) {
@@ -51,37 +51,23 @@ export const getNameParts = (name) => {
   return {
     first,
     last,
-    suffixes
+    suffixes,
   }
 }
 
-export const getNameInitials = (name) => {
-  const {
-    first,
-    last,
-    suffixes
-  } = getNameParts(name)
+export const getNameInitials = name => {
+  const { first, last, suffixes } = getNameParts(name)
 
-  const components = [
-    last.join(' '),
-    first.map(toInitial).join(' '),
-    suffixes.join(' '),
-  ].filter(v => v)
+  const components = [last.join(' '), first.map(toInitial).join(' '), suffixes.join(' ')].filter(
+    v => v
+  )
   return components.join(', ')
 }
 
-export const getLastnameFirst = (name) => {
-  const {
-    first,
-    last,
-    suffixes
-  } = getNameParts(name)
+export const getLastnameFirst = name => {
+  const { first, last, suffixes } = getNameParts(name)
 
-  const components = [
-    last.join(' '),
-    first.join(' '),
-    suffixes.join(' '),
-  ].filter(v => v)
+  const components = [last.join(' '), first.join(' '), suffixes.join(' ')].filter(v => v)
   return components.join(', ')
 }
 
@@ -120,35 +106,35 @@ export const getAuthorsFull = (dataset, getTranslation, etAlThreshold, etAlCount
   return authors
 }
 
-export const addParens = (string) => {
+export const addParens = string => {
   if (string === undefined) {
     return undefined
   }
   return `(${string})`
 }
 
-export const addQuotes = (string) => {
+export const addQuotes = string => {
   if (string === undefined) {
     return undefined
   }
   return `”${string}”`
 }
 
-export const capitalizeFirst = (string) => {
+export const capitalizeFirst = string => {
   if (string === undefined) {
     return undefined
   }
   return `${string.charAt(0).toUpperCase()}${string.slice(1)}`
 }
 
-export const getInitial = (string) => {
+export const getInitial = string => {
   if (string === undefined) {
     return undefined
   }
   return `${string.charAt(0).toUpperCase()}.`
 }
 
-export const getYear = (dataset) => {
+export const getYear = dataset => {
   const issued = dataset.research_dataset.issued
   if (!issued) {
     return undefined
@@ -177,13 +163,16 @@ export const getVersion = (dataset, getTranslation) => {
   return getTranslation({ en: `Version ${version}`, fi: `versio ${version}` })
 }
 
-export const getIdentifier = (dataset, useDoiUrls) => {
+export const getIdentifier = (dataset) => {
   const identifier = dataset.research_dataset.preferred_identifier
   if (!identifier) {
     return undefined
   }
-  if (useDoiUrls && identifier.startsWith('doi:')) {
+  if (identifier.startsWith('doi:')) {
     return identifier.replace('doi:', 'https://doi.org/')
+  }
+  if (identifier.toLowerCase().startsWith('urn:nbn:fi:')) {
+    return `http://urn.fi/${identifier}`
   }
   if (dataset.draft_of) {
     return dataset.draft_of.preferred_identifier
@@ -194,4 +183,5 @@ export const getIdentifier = (dataset, useDoiUrls) => {
   return identifier
 }
 
-export const getPublisher = (dataset, getTranslation) => getTranslation(dataset.research_dataset.publisher?.name)
+export const getPublisher = (dataset, getTranslation) =>
+  getTranslation(dataset.research_dataset.publisher?.name)

--- a/etsin_finder/frontend/js/utils/idnToLink.jsx
+++ b/etsin_finder/frontend/js/utils/idnToLink.jsx
@@ -1,23 +1,24 @@
 {
-/**
- * This file is part of the Etsin service
- *
- * Copyright 2017-2018 Ministry of Education and Culture, Finland
- *
- *
- * @author    CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
- * @license   MIT
- */
+  /**
+   * This file is part of the Etsin service
+   *
+   * Copyright 2017-2021 Ministry of Education and Culture, Finland
+   *
+   *
+   * @author    CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+   * @license   MIT
+   */
 }
 
-export default function idnToLink(idn) {
-  const sub3 = idn.substring(0, 3)
-  const sub4 = idn.substring(0, 4)
-  if (sub3 === 'urn' || sub3 === 'doi') {
-    const page = sub3 === 'doi' ? 'https://doi.org' : 'http://urn.fi'
-    return `${page}/${sub3 === 'doi' ? idn.substring(4) : idn}`
-  } if (sub4 === 'http') {
-    return idn
+export default function idnToLink(identifier) {
+  if (identifier.startsWith('doi:')) {
+    return identifier.replace('doi:', 'https://doi.org/')
   }
-  return false
+  if (identifier.toLowerCase().startsWith('urn:nbn:fi:')) {
+    return `http://urn.fi/urn:nbn:fi:${identifier.substring('urn:nbn:fi:'.length)}`
+  }
+  if (identifier.startsWith('http:') || identifier.startsWith('https:')) {
+    return identifier
+  }
+  return ''
 }


### PR DESCRIPTION
* Use URL for DOI in all citation styles
* Use URL for urn:nbn:fi citations in all citation styles
* Change e.g. `cite.apa(dataset)` to `c(dataset)` in tests to avoid prettier splitting it into multiple lines