### PR TITLE
CSCFAIRMETA-1034: Disable hash names in development

### DIFF
--- a/etsin_finder/frontend/webpack.dev.js
+++ b/etsin_finder/frontend/webpack.dev.js
@@ -13,8 +13,8 @@ const config = env => ({
     // path of output
     path: path.join(__dirname, '/build'),
     publicPath: '/', // Needed in order to access frontend from nginx
-    filename: 'bundle.[contenthash].js',
-    chunkFilename: '[name].[chunkhash].js',
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
   },
   devtool: 'source-map',
   devServer: {


### PR DESCRIPTION
This should reduce webpack-dev-server memory usage by not creating a new file each time code changes.