### PR TITLE
CSCFAIRADM-590: Add memcached (to Docker)

### DIFF
--- a/docker-compose-with-nginx.yml
+++ b/docker-compose-with-nginx.yml
@@ -21,6 +21,7 @@ services:
           target: /home/etsin-user/app_config
       volumes:
         - ./etsin_finder/:/etsin_finder/
+        - ./tests/:/tests/
       environment:
         - base_url=0.0.0.0:5000
         - FLASK_ENV=development
@@ -37,8 +38,14 @@ services:
         - "discovery.type=single-node"
       volumes:
         - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+    etsin-qvain-memcached:
+      image: memcached:latest
+      hostname: 'etsin-qvain-memcached'
+      ports:
+        - "11211:11211"
+      command: ["memcached"]
     fairdata-nginx:
-      image:  fairdata-docker.artifactory.ci.csc.fi/nginx
+      image: nginx:latest
       configs:
         - source: fairdata-nginx-config
           target: /etc/nginx/nginx.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
         - "discovery.type=single-node"
       volumes:
         - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+    etsin-qvain-memcached:
+      image: memcached:latest
+      hostname: 'etsin-qvain-memcached'
+      ports:
+        - "11211:11211"
+      command: ["memcached"]
 
 configs:
   etsin-qvain-app-config:


### PR DESCRIPTION
- Add in both docker-compose files

Additional fixes:
- Also add tests as a volume if running the standalone version (with nginx for etsin-qvain only)
- Use basic nginx image, no need for using a special nginx version/image