### PR TITLE
CSCFAIRMETA-1119 fix for provenance not loading spatials and usedEntities

### DIFF
--- a/etsin_finder/frontend/__tests__/stores/view/qvain.spatial.test.js
+++ b/etsin_finder/frontend/__tests__/stores/view/qvain.spatial.test.js
@@ -27,9 +27,10 @@ jest.mock('mobx')
 describe('Spatials store', () => {
   let spatials
   const parent = {}
+  const existingSpatials = ["here lies spatials"]
 
   beforeEach(() => {
-    spatials = new Spatials(parent)
+    spatials = new Spatials(parent, existingSpatials)
   })
 
   afterEach(() => {
@@ -46,6 +47,11 @@ describe('Spatials store', () => {
     test('should call makeObservable', () => {
       expect(makeObservable).to.have.beenCalledTimes(1)
     })
+
+    test('should call fromBackendBase with existing spatials', () => {
+      expect(spatials.fromBackendBase).to.have.beenCalledWith(existingSpatials, parent)
+    })
+
 
     describe('when calling clone', () => {
       let returnValue

--- a/etsin_finder/frontend/__tests__/stores/view/usedEntities.test.js
+++ b/etsin_finder/frontend/__tests__/stores/view/usedEntities.test.js
@@ -23,11 +23,12 @@ jest.mock('mobx')
 
 describe('UsedEntities', () => {
   let usedEntities
+  const existingEntities = ["some serious entities here"]
 
   const Qvain = {}
 
   beforeEach(() => {
-    usedEntities = new UsedEntities(Qvain)
+    usedEntities = new UsedEntities(Qvain, existingEntities)
   })
 
   describe('when calling constructor', () => {
@@ -43,6 +44,11 @@ describe('UsedEntities', () => {
     test('should call makeObservable', () => {
       expect(makeObservable).to.have.beenCalledWith(usedEntities)
     })
+
+    test('should call fromBackendBase with existingEntities', () => {
+      expect(usedEntities.fromBackendBase).to.have.beenCalledWith(existingEntities, Qvain)
+    })
+
   })
 
   describe('when calling fromBackend with dataset and Qvain', () => {

--- a/etsin_finder/frontend/js/stores/view/qvain/qvain.spatials.js
+++ b/etsin_finder/frontend/js/stores/view/qvain/qvain.spatials.js
@@ -45,9 +45,11 @@ export const Spatial = (
 })
 
 class Spatials extends Field {
-  constructor(Parent) {
+  constructor(Parent, spatials = []) {
     super(Parent, Spatial, SpatialModel, 'spatials')
     makeObservable(this)
+
+    this.fromBackendBase(spatials, Parent)
   }
 
   clone = () => this

--- a/etsin_finder/frontend/js/stores/view/qvain/qvain.usedEntities.js
+++ b/etsin_finder/frontend/js/stores/view/qvain/qvain.usedEntities.js
@@ -12,9 +12,11 @@ export const UsedEntityTemplate = (
 ) => ({ uiid, name, description, identifier, entityType })
 
 class UsedEntities extends Field {
-  constructor(Qvain) {
+  constructor(Qvain, entities = []) {
     super(Qvain, UsedEntityTemplate, UsedEntityModel, 'usedEntities')
     makeObservable(this)
+
+    this.fromBackendBase(entities, Qvain)
   }
 
   clone = () => this


### PR DESCRIPTION
 fix for provenance not loading spatials and usedEntities when editing a existing dataset.