### PR TITLE
CSCFAIRMETA-1122 pen icon does not update

### DIFF
--- a/etsin_finder/frontend/js/components/qvain/fields/files/ida/selectedItemsDropdown.jsx
+++ b/etsin_finder/frontend/js/components/qvain/fields/files/ida/selectedItemsDropdown.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Translate from 'react-translate-component'
 import { faPen, faEye } from '@fortawesome/free-solid-svg-icons'
+import { observer } from 'mobx-react'
 
 import { Dropdown, DropdownItem } from '../../../../general/dropdown'
 import { hasMetadata, hasPASMetadata } from '../../../../../stores/view/common.files.items'
@@ -155,4 +156,4 @@ EditDropdown.propTypes = {
   parentArgs: PropTypes.object.isRequired,
 }
 
-export default EditDropdown
+export default observer(EditDropdown)


### PR DESCRIPTION
fixed an error where pen icon's color did not update when adding or removing metadata