### PR TITLE
CSCFAIRMETA-1138: Disable download buttons for drafts

### DIFF
--- a/etsin_finder/frontend/__tests__/combined/etsin/download.test.jsx
+++ b/etsin_finder/frontend/__tests__/combined/etsin/download.test.jsx
@@ -405,9 +405,7 @@ describe('getAllowDownload', () => {
       getAllowDownload(
         {
           isDraft: false,
-          results: {
-            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-ida' } },
-          },
+          isPas: false,
         },
         { allowDataIdaDownloadButton: true }
       )
@@ -419,9 +417,7 @@ describe('getAllowDownload', () => {
       getAllowDownload(
         {
           isDraft: false,
-          results: {
-            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-ida' } },
-          },
+          isPas: false,
         },
         { allowDataIdaDownloadButton: false }
       )
@@ -433,9 +429,7 @@ describe('getAllowDownload', () => {
       getAllowDownload(
         {
           isDraft: false,
-          results: {
-            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-pas' } },
-          },
+          isPas: true,
         },
         { allowDataIdaDownloadButton: true }
       )

--- a/etsin_finder/frontend/__tests__/combined/etsin/download.test.jsx
+++ b/etsin_finder/frontend/__tests__/combined/etsin/download.test.jsx
@@ -8,7 +8,10 @@ import EnvClass from '../../../js/stores/domain/env'
 import Packages from '../../../js/stores/view/packages'
 import { fakeDownload, applyMockAdapter } from '../../__testdata__/download.data'
 import { runInAction } from 'mobx'
-import getDownloadAction from '../../../js/components/dataset/data/idaResources/downloadActions'
+import getDownloadAction, {
+  getAllowDownload,
+  getDownloadAllText,
+} from '../../../js/components/dataset/data/idaResources/downloadActions'
 import {
   downloadFile,
   downloadPackage,
@@ -393,6 +396,64 @@ describe('Download functions', () => {
     await downloadPackage(500, 'package-id', mockPackages)
     expect(mockPackages.setError.mock.calls.length).toBe(1)
     expect(console.error.mock.calls.length).toBe(1)
+  })
+})
+
+describe('getAllowDownload', () => {
+  it('returns true for published IDA dataset', () => {
+    expect(
+      getAllowDownload(
+        {
+          isDraft: false,
+          results: {
+            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-ida' } },
+          },
+        },
+        { allowDataIdaDownloadButton: true }
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for restricted IDA dataset', () => {
+    expect(
+      getAllowDownload(
+        {
+          isDraft: false,
+          results: {
+            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-ida' } },
+          },
+        },
+        { allowDataIdaDownloadButton: false }
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for DPS dataset', () => {
+    expect(
+      getAllowDownload(
+        {
+          isDraft: false,
+          results: {
+            data_catalog: { catalog_json: { identifier: 'urn:nbn:fi:att:data-catalog-pas' } },
+          },
+        },
+        { allowDataIdaDownloadButton: true }
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for draft', () => {
+    expect(getAllowDownload({ isDraft: true }, { allowDataIdaDownloadButton: true })).toBe(false)
+  })
+})
+
+describe('getDownloadAllText', () => {
+  it('returns download text for non-draft', () => {
+    expect(getDownloadAllText({ isDraft: false })).toBe('dataset.dl.downloadAll')
+  })
+
+  it('returns download disabled text for draft', () => {
+    expect(getDownloadAllText({ isDraft: true })).toBe('dataset.dl.downloadDisabledForDraft')
   })
 })
 

--- a/etsin_finder/frontend/js/components/dataset/content.jsx
+++ b/etsin_finder/frontend/js/components/dataset/content.jsx
@@ -136,7 +136,6 @@ class Content extends Component {
                   id="tab-data"
                   aria-labelledby="tab-for-data"
                   role="tabpanel"
-                  dataset={this.props.dataset}
                   hasRemote={this.props.hasRemote}
                   hasFiles={this.props.hasFiles}
                   {...props}

--- a/etsin_finder/frontend/js/components/dataset/data/idaResources/downloadActions.js
+++ b/etsin_finder/frontend/js/components/dataset/data/idaResources/downloadActions.js
@@ -100,4 +100,20 @@ const getDownloadAction = (datasetIdentifier, item, Packages, Files) => {
   return action
 }
 
+export const getAllowDownload = (DatasetQuery, restrictions) => {
+  if (
+    DatasetQuery.results?.data_catalog?.catalog_json?.identifier ===
+    'urn:nbn:fi:att:data-catalog-pas'
+  ) {
+    return false
+  }
+  if (DatasetQuery.isDraft) {
+    return false
+  }
+  return restrictions.allowDataIdaDownloadButton
+}
+
+export const getDownloadAllText = DatasetQuery =>
+  DatasetQuery.isDraft ? 'dataset.dl.downloadDisabledForDraft' : 'dataset.dl.downloadAll'
+
 export default getDownloadAction

--- a/etsin_finder/frontend/js/components/dataset/data/idaResources/downloadActions.js
+++ b/etsin_finder/frontend/js/components/dataset/data/idaResources/downloadActions.js
@@ -101,10 +101,7 @@ const getDownloadAction = (datasetIdentifier, item, Packages, Files) => {
 }
 
 export const getAllowDownload = (DatasetQuery, restrictions) => {
-  if (
-    DatasetQuery.results?.data_catalog?.catalog_json?.identifier ===
-    'urn:nbn:fi:att:data-catalog-pas'
-  ) {
+  if (DatasetQuery.isPas) {
     return false
   }
   if (DatasetQuery.isDraft) {

--- a/etsin_finder/frontend/js/components/dataset/data/idaResources/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/data/idaResources/index.jsx
@@ -9,7 +9,7 @@ import Tree from './fileTree'
 import Info from './info'
 import sizeParse from '../../../../utils/sizeParse'
 import { withStores } from '../../../../stores/stores'
-import getDownloadAction from './downloadActions'
+import getDownloadAction, { getAllowDownload, getDownloadAllText } from './downloadActions'
 import ErrorMessage from './errorMessage'
 import PackageModal from './packageModal'
 import ManualDownloadModal from './manualDownloadModal'
@@ -20,16 +20,12 @@ import TooltipHover from '../../../general/tooltipHover'
 
 function IdaResources(props) {
   const { restrictions } = props.Stores.Access
-  const allowDownload =
-    props.dataset.data_catalog.catalog_json.identifier !== 'urn:nbn:fi:att:data-catalog-pas' &&
-    restrictions.allowDataIdaDownloadButton
-
   const { Files } = props.Stores.DatasetQuery
-
   const { inInfo, setInInfo, getUseCategoryLabel, getFileTypeLabel, root } = Files
-
   const { DatasetQuery } = props.Stores
   const { Packages } = DatasetQuery
+
+  const allowDownload = getAllowDownload(DatasetQuery, restrictions)
 
   const fileCount = (root && root.existingFileCount) || 0
   const totalSize = (root && root.existingByteSize) || 0
@@ -58,10 +54,10 @@ function IdaResources(props) {
   }
 
   const buttonProps = {}
-  const downloadAllText = 'dataset.dl.downloadAll'
+  const downloadAllText = getDownloadAllText(DatasetQuery)
 
   // Download full dataset package
-  const action = getDownloadAction(props.dataset.identifier, null, Packages, Files)
+  const action = getDownloadAction(DatasetQuery.results?.identifier, null, Packages, Files)
   const downloadFunc = action.func
   buttonProps.icon = action.icon
   buttonProps.spin = action.spin
@@ -92,11 +88,7 @@ function IdaResources(props) {
           {totalSize ? ` (${sizeParse(totalSize)})` : null}
         </HeaderStats>
 
-        <Translate
-          component={TooltipHover}
-          attributes={{ title: action.tooltip }}
-          showOnClick
-        >
+        <Translate component={TooltipHover} attributes={{ title: action.tooltip }} showOnClick>
           <FlaggedComponent flag="DOWNLOAD_API_V2.OPTIONS" whenDisabled={downloadButton}>
             <HeaderButtonSplit split={moreFunc}>
               {downloadButton}
@@ -132,7 +124,6 @@ const HeaderButtonSplit = styled(SplitButtonContainer)`
 `
 
 IdaResources.propTypes = {
-  dataset: PropTypes.object.isRequired,
   Stores: PropTypes.object.isRequired,
 }
 

--- a/etsin_finder/frontend/js/components/dataset/data/index.jsx
+++ b/etsin_finder/frontend/js/components/dataset/data/index.jsx
@@ -38,7 +38,7 @@ class Data extends Component {
   render() {
     return (
       <div id={this.props.id}>
-        {!this.props.hasRemote && <IdaResources dataset={this.props.dataset} />}
+        {!this.props.hasRemote && <IdaResources />}
         {this.props.hasRemote && <ExternalResources />}
       </div>
     )
@@ -47,7 +47,6 @@ class Data extends Component {
 
 Data.propTypes = {
   Stores: PropTypes.object.isRequired,
-  dataset: PropTypes.object.isRequired,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,

--- a/etsin_finder/frontend/js/stores/view/datasetquery.js
+++ b/etsin_finder/frontend/js/stores/view/datasetquery.js
@@ -61,6 +61,12 @@ class DatasetQuery {
     await this.Packages.fetch(this.results.identifier)
   }
 
+  @computed get isPas() {
+    return (
+      this.results?.data_catalog?.catalog_json?.identifier === 'urn:nbn:fi:att:data-catalog-pas'
+    )
+  }
+
   @computed get isDraft() {
     if (this.results) {
       if (this.results.draft_of || this.results.state === 'draft') {

--- a/etsin_finder/frontend/locale/english/index.js
+++ b/etsin_finder/frontend/locale/english/index.js
@@ -112,7 +112,7 @@ const english = {
       download: 'Download',
       downloadFailed: 'Download failed',
       downloadAll: 'Download all',
-      downloadDisabledForDraft: 'Download disabled for draft',
+      downloadDisabledForDraft: 'Download is disabled for drafts',
       downloading: 'Downloading...',
       source: 'Source',
       commonSource: 'Go to the original source',


### PR DESCRIPTION
* Fix download buttons not being disabled for drafts
* Move generation of allowDownload and downloadAllText to downloadActions
* Remove redundant data prop