### PR TITLE
CSCFAIRMETA-1160: Refactor saving access rights

### DIFF
--- a/etsin_finder/frontend/__tests__/combined/qvain/__snapshots__/qvain.files.test.jsx.snap
+++ b/etsin_finder/frontend/__tests__/combined/qvain/__snapshots__/qvain.files.test.jsx.snap
@@ -2,13 +2,17 @@
 
 exports[`Qvain.Files handleSubmit submits data correctly 1`] = `
 Object {
-  "accessType": Object {
-    "name": Object {
-      "en": "Open",
-      "fi": "Avoin",
-      "und": "Avoin",
+  "access_rights": Object {
+    "access_type": Object {
+      "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
     },
-    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+    "available": undefined,
+    "license": Array [
+      Object {
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+      },
+    ],
+    "restriction_grounds": undefined,
   },
   "contributor": undefined,
   "creator": Array [
@@ -30,7 +34,6 @@ Object {
     "en": "",
     "fi": "Description",
   },
-  "embargoDate": undefined,
   "field_of_science": Array [],
   "identifiers": Array [],
   "infrastructure": Array [],
@@ -39,14 +42,6 @@ Object {
     "keyword",
   ],
   "language": Array [],
-  "license": Array [
-    Object {
-      "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
-      "name": Object {
-        "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-      },
-    },
-  ],
   "original": Object {
     "cumulative_state": 0,
     "data_catalog": Object {
@@ -141,7 +136,6 @@ Object {
   "publisher": undefined,
   "relation": Array [],
   "remote_resources": Array [],
-  "restrictionGrounds": undefined,
   "rights_holder": undefined,
   "spatial": Array [],
   "temporal": Array [],
@@ -156,13 +150,17 @@ Object {
 
 exports[`Qvain.Files handleSubmit submits data correctly after adding directory 1`] = `
 Object {
-  "accessType": Object {
-    "name": Object {
-      "en": "Open",
-      "fi": "Avoin",
-      "und": "Avoin",
+  "access_rights": Object {
+    "access_type": Object {
+      "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
     },
-    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+    "available": undefined,
+    "license": Array [
+      Object {
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+      },
+    ],
+    "restriction_grounds": undefined,
   },
   "contributor": undefined,
   "creator": Array [
@@ -184,7 +182,6 @@ Object {
     "en": "",
     "fi": "Description",
   },
-  "embargoDate": undefined,
   "field_of_science": Array [],
   "identifiers": Array [],
   "infrastructure": Array [],
@@ -193,14 +190,6 @@ Object {
     "keyword",
   ],
   "language": Array [],
-  "license": Array [
-    Object {
-      "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
-      "name": Object {
-        "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-      },
-    },
-  ],
   "original": Object {
     "cumulative_state": 0,
     "data_catalog": Object {
@@ -295,7 +284,6 @@ Object {
   "publisher": undefined,
   "relation": Array [],
   "remote_resources": Array [],
-  "restrictionGrounds": undefined,
   "rights_holder": undefined,
   "spatial": Array [],
   "temporal": Array [],
@@ -310,13 +298,17 @@ Object {
 
 exports[`Qvain.Files handleSubmit submits data correctly after adding file 1`] = `
 Object {
-  "accessType": Object {
-    "name": Object {
-      "en": "Open",
-      "fi": "Avoin",
-      "und": "Avoin",
+  "access_rights": Object {
+    "access_type": Object {
+      "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
     },
-    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+    "available": undefined,
+    "license": Array [
+      Object {
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+      },
+    ],
+    "restriction_grounds": undefined,
   },
   "contributor": undefined,
   "creator": Array [
@@ -338,7 +330,6 @@ Object {
     "en": "",
     "fi": "Description",
   },
-  "embargoDate": undefined,
   "field_of_science": Array [],
   "identifiers": Array [],
   "infrastructure": Array [],
@@ -347,14 +338,6 @@ Object {
     "keyword",
   ],
   "language": Array [],
-  "license": Array [
-    Object {
-      "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
-      "name": Object {
-        "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-      },
-    },
-  ],
   "original": Object {
     "cumulative_state": 0,
     "data_catalog": Object {
@@ -449,7 +432,6 @@ Object {
   "publisher": undefined,
   "relation": Array [],
   "remote_resources": Array [],
-  "restrictionGrounds": undefined,
   "rights_holder": undefined,
   "spatial": Array [],
   "temporal": Array [],
@@ -464,13 +446,17 @@ Object {
 
 exports[`Qvain.Files handleSubmit submits data correctly after removing directory 1`] = `
 Object {
-  "accessType": Object {
-    "name": Object {
-      "en": "Open",
-      "fi": "Avoin",
-      "und": "Avoin",
+  "access_rights": Object {
+    "access_type": Object {
+      "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
     },
-    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+    "available": undefined,
+    "license": Array [
+      Object {
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+      },
+    ],
+    "restriction_grounds": undefined,
   },
   "contributor": undefined,
   "creator": Array [
@@ -492,7 +478,6 @@ Object {
     "en": "",
     "fi": "Description",
   },
-  "embargoDate": undefined,
   "field_of_science": Array [],
   "identifiers": Array [],
   "infrastructure": Array [],
@@ -501,14 +486,6 @@ Object {
     "keyword",
   ],
   "language": Array [],
-  "license": Array [
-    Object {
-      "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
-      "name": Object {
-        "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-      },
-    },
-  ],
   "original": Object {
     "cumulative_state": 0,
     "data_catalog": Object {
@@ -603,7 +580,6 @@ Object {
   "publisher": undefined,
   "relation": Array [],
   "remote_resources": Array [],
-  "restrictionGrounds": undefined,
   "rights_holder": undefined,
   "spatial": Array [],
   "temporal": Array [],
@@ -618,13 +594,17 @@ Object {
 
 exports[`Qvain.Files handleSubmit submits data correctly after removing file 1`] = `
 Object {
-  "accessType": Object {
-    "name": Object {
-      "en": "Open",
-      "fi": "Avoin",
-      "und": "Avoin",
+  "access_rights": Object {
+    "access_type": Object {
+      "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
     },
-    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+    "available": undefined,
+    "license": Array [
+      Object {
+        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
+      },
+    ],
+    "restriction_grounds": undefined,
   },
   "contributor": undefined,
   "creator": Array [
@@ -646,7 +626,6 @@ Object {
     "en": "",
     "fi": "Description",
   },
-  "embargoDate": undefined,
   "field_of_science": Array [],
   "identifiers": Array [],
   "infrastructure": Array [],
@@ -655,14 +634,6 @@ Object {
     "keyword",
   ],
   "language": Array [],
-  "license": Array [
-    Object {
-      "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
-      "name": Object {
-        "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-      },
-    },
-  ],
   "original": Object {
     "cumulative_state": 0,
     "data_catalog": Object {
@@ -757,7 +728,6 @@ Object {
   "publisher": undefined,
   "relation": Array [],
   "remote_resources": Array [],
-  "restrictionGrounds": undefined,
   "rights_holder": undefined,
   "spatial": Array [],
   "temporal": Array [],

--- a/etsin_finder/frontend/__tests__/stores/view/qvain.restrictionGrounds.test.js
+++ b/etsin_finder/frontend/__tests__/stores/view/qvain.restrictionGrounds.test.js
@@ -1,7 +1,7 @@
 import 'chai/register-expect'
 import { makeObservable, override } from 'mobx'
 import RestrictionGrounds, {
-  restrictionGroundsSchema,
+  restrictionGroundsIdentifierSchema,
 } from '../../../js/stores/view/qvain/qvain.restrictionGrounds'
 
 jest.mock('../../../js/stores/view/qvain/qvain.singleValueField', () => {
@@ -41,7 +41,7 @@ describe('RestrictionGrounds', () => {
     test('should call super.constructor', () => {
       expect(restrictionGrounds.constructorFunc).to.have.beenCalledWith(
         Parent,
-        restrictionGroundsSchema
+        restrictionGroundsIdentifierSchema
       )
     })
 
@@ -82,8 +82,8 @@ describe('RestrictionGrounds', () => {
         returnValue = restrictionGrounds.toBackend()
       })
 
-      test('should return value.identifier', () => {
-        returnValue.should.eql('identifier')
+      test('should return identifier object in array', () => {
+        returnValue.should.eql([{ identifier: 'identifier' }])
       })
     })
 

--- a/etsin_finder/frontend/__tests__/utils/utils.handleSubmit.test.js
+++ b/etsin_finder/frontend/__tests__/utils/utils.handleSubmit.test.js
@@ -95,9 +95,12 @@ describe('when calling handleSubmit with mockStores', () => {
       curator: 'curator',
       contributor: 'contributor',
       infrastructure: 'infrastructures',
-      restrictionGrounds: 'restrictionGrounds',
-      embargoDate: 'embargoDate',
-      license: 'license',
+      access_rights: {
+        license: 'license',
+        access_type: 'accessType',
+        available: 'embargoDate',
+        restriction_grounds: 'restrictionGrounds',
+      },
       remote_resources: 'externalResources',
       dataCatalog: 'dataCatalog',
       cumulativeState: 'cumulativeState',
@@ -110,7 +113,6 @@ describe('when calling handleSubmit with mockStores', () => {
       field_of_science: 'field_of_science',
       language: 'language',
       issuedDate: 'issuedDate',
-      accessType: 'accessType',
     }
 
     returnValue.should.deep.eql(expectedReturn)

--- a/etsin_finder/frontend/js/components/qvain/general/errors/validationError.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/errors/validationError.jsx
@@ -3,15 +3,20 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import Translate from 'react-translate-component'
 
+export const isAlreadyTranslated = children => {
+  if (Array.isArray(children)) {
+    return children[0]?.includes(' ')
+  }
+  if (typeof children === 'string') {
+    return children.includes(' ')
+  }
+  return false
+}
+
 export const ValidationError = ({ children }) => {
   if (!children) return null
-  let isAlreadyTranslated = false
-  if (Array.isArray(children)) {
-    isAlreadyTranslated = children[0]?.includes(' ')
-  } else if (typeof children === 'string') {
-    isAlreadyTranslated = children.includes(' ')
-  }
-  if (isAlreadyTranslated) {
+
+  if (isAlreadyTranslated(children)) {
     return <ValidationErrorText>{children}</ValidationErrorText>
   }
   return <Translate content={children} component={ValidationErrorText} />

--- a/etsin_finder/frontend/js/components/qvain/general/header/tooltipHoverOnSave.jsx
+++ b/etsin_finder/frontend/js/components/qvain/general/header/tooltipHoverOnSave.jsx
@@ -14,6 +14,7 @@ import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Translate from 'react-translate-component'
+import { isAlreadyTranslated } from '../errors/validationError'
 
 const TooltipHoverOnSave = ({ isOpen, children, errors, description }) => {
   const wrapperTooltipButtonRef = useRef(null)
@@ -23,9 +24,13 @@ const TooltipHoverOnSave = ({ isOpen, children, errors, description }) => {
     return children
   }
 
-  const TranslatedErrors = errors.map(error => (
-    <Translate key={error} content={error} component={TooltipText} />
-  ))
+  const TranslatedErrors = errors.map(error =>
+    isAlreadyTranslated(error) ? (
+      <TooltipText key={error}>{error}</TooltipText>
+    ) : (
+      <Translate key={error} content={error} component={TooltipText} />
+    )
+  )
 
   return (
     <>

--- a/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
+++ b/etsin_finder/frontend/js/components/qvain/utils/handleSubmit.js
@@ -46,9 +46,12 @@ const handleSubmitToBackend = values => {
     curator,
     contributor,
     infrastructure: values.Infrastructures.toBackend(),
-    restrictionGrounds,
-    embargoDate,
-    license,
+    access_rights: {
+      license,
+      access_type: accessType,
+      restriction_grounds: restrictionGrounds,
+      available: embargoDate
+    },
     remote_resources: values.ExternalResources.toBackend(),
     dataCatalog: values.dataCatalog,
     cumulativeState: values.cumulativeState,
@@ -61,7 +64,6 @@ const handleSubmitToBackend = values => {
     field_of_science,
     language,
     issuedDate,
-    accessType,
   }
 
   if (values.original) {

--- a/etsin_finder/frontend/js/stores/view/qvain/qvain.accessType.js
+++ b/etsin_finder/frontend/js/stores/view/qvain/qvain.accessType.js
@@ -5,14 +5,26 @@ import SingleValueField from './qvain.singleValueField'
 import { ACCESS_TYPE_URL } from '../../../utils/constants'
 import { touch } from './track'
 
-export const accessTypeSchema = yup.object().shape({
-  name: yup.object().nullable(),
-  url: yup
-    .string()
-    .typeError('qvain.validationMessages.accessType.string')
-    .url('qvain.validationMessages.accessType.url')
-    .required('qvain.validationMessages.accessType.required'),
-})
+export const accessTypeIdentifierSchema = yup
+  .string()
+  .typeError('qvain.validationMessages.accessType.string')
+  .url('qvain.validationMessages.accessType.url')
+  .required('qvain.validationMessages.accessType.required')
+
+export const accessTypeQvainSchema = yup
+  .object()
+  .shape({
+    name: yup.object().nullable(),
+    url: accessTypeIdentifierSchema,
+  })
+  .noUnknown()
+
+export const accessTypeMetaxSchema = yup
+  .object()
+  .shape({
+    identifier: accessTypeIdentifierSchema,
+  })
+  .noUnknown()
 
 const Model = (name, url) => ({
   name,
@@ -23,15 +35,17 @@ const defaultValue = Model(undefined, ACCESS_TYPE_URL.OPEN)
 
 class AccessType extends SingleValueField {
   constructor(Parent) {
-    super(Parent, accessTypeSchema, defaultValue)
+    super(Parent, accessTypeQvainSchema, defaultValue)
     makeObservable(this)
   }
 
-  @action fromBackend = (dataset) => {
-    const at = dataset.access_rights.access_type ? dataset.access_rights.access_type : undefined
-    touch(dataset.access_rights.access_type)
+  @action fromBackend = dataset => {
+    const at = dataset.access_rights?.access_type ? dataset.access_rights?.access_type : undefined
+    touch(dataset.access_rights?.access_type)
     this.value = at ? this.Model({ ...at.pref_label }, at.identifier) : this.defaultValue
   }
+
+  toBackend = () => this.value?.url && { identifier: this.value.url }
 
   Model = Model
 }

--- a/etsin_finder/frontend/js/stores/view/qvain/qvain.embargoExpDate.js
+++ b/etsin_finder/frontend/js/stores/view/qvain/qvain.embargoExpDate.js
@@ -11,7 +11,7 @@ class EmbargoExpDate extends SingleValueField {
   }
 
   @action fromBackend = dataset => {
-    this.value = dataset.access_rights.available || undefined
+    this.value = dataset.access_rights?.available || undefined
   }
 
   schema = embargoExpDateSchema

--- a/etsin_finder/frontend/js/stores/view/qvain/qvain.restrictionGrounds.js
+++ b/etsin_finder/frontend/js/stores/view/qvain/qvain.restrictionGrounds.js
@@ -1,27 +1,43 @@
 import { makeObservable, override } from 'mobx'
 import * as yup from 'yup'
 import SingleValueField from './qvain.singleValueField'
+import { touch } from './track'
 
-export const restrictionGroundsSchema = yup
+export const restrictionGroundsIdentifierSchema = yup
   .string()
   .typeError('qvain.validationMessages.restrictionGrounds.string')
   .url('qvain.validationMessages.restrictionGrounds.url')
   .required('qvain.validationMessages.restrictionGrounds.required')
 
+export const restrictionGroundsMetaxSchema = yup
+  .array()
+  .of(
+    yup
+      .object()
+      .shape({
+        identifier: restrictionGroundsIdentifierSchema,
+      })
+      .required('qvain.validationMessages.restrictionGrounds.required')
+      .noUnknown()
+  )
+  .min(1)
+  .required('qvain.validationMessages.restrictionGrounds.required')
+
 class RestrictionGrounds extends SingleValueField {
   constructor(Parent) {
-    super(Parent, restrictionGroundsSchema)
+    super(Parent, restrictionGroundsIdentifierSchema)
     makeObservable(this)
   }
 
   fromBackend = dataset => {
-    const rg = dataset.access_rights.restriction_grounds
+    const rg = dataset.access_rights?.restriction_grounds
       ? dataset.access_rights.restriction_grounds[0]
       : undefined
+    touch(dataset.access_rights?.restriction_grounds)
     this.value = rg ? this.Model(rg.pref_label, rg.identifier) : undefined
   }
 
-  toBackend = () => (this.value ? this.value.identifier : undefined)
+  toBackend = () => (this.value ? [{ identifier: this.value.identifier }] : undefined)
 
   @override validate() {
     if (!this.Schema) return undefined
@@ -39,7 +55,7 @@ class RestrictionGrounds extends SingleValueField {
     identifier,
   })
 
-  schema = restrictionGroundsSchema
+  schema = restrictionGroundsIdentifierSchema
 }
 
 export default RestrictionGrounds

--- a/etsin_finder/schemas/qvain_dataset_schema.py
+++ b/etsin_finder/schemas/qvain_dataset_schema.py
@@ -114,6 +114,13 @@ class ProjectValidationSchema(Schema):
         fields.Nested(OrganizationValidationSchema), required=False
     )
 
+class AccessRightsValidationSchema(Schema):
+    """Access rights validation schema"""
+
+    license = fields.List(fields.Nested(LicenseValidationSchema))
+    available = fields.Str() # Embargo date
+    restriction_grounds = fields.List(fields.Nested(ReferenceObjectValidationSchema))
+    access_type = fields.Dict(required=True)
 
 class DatasetValidationSchema(Schema):
     """
@@ -151,13 +158,10 @@ class DatasetValidationSchema(Schema):
     curator = fields.List(fields.Nested(ActorValidationSchema))
     rights_holder = fields.List(fields.Nested(ActorValidationSchema))
     contributor = fields.List(fields.Nested(ActorValidationSchema))
-    accessType = fields.Dict(required=True)
     infrastructure = fields.List(fields.Dict())
     spatial = fields.List(fields.Dict())
     temporal = fields.List(fields.Dict())
-    embargoDate = fields.Str()
-    restrictionGrounds = fields.Str()
-    license = fields.List(fields.Nested(LicenseValidationSchema))
+    access_rights = fields.Nested(AccessRightsValidationSchema)
     dataCatalog = fields.Str(validate=validate.Regexp(data_catalog_matcher))
     cumulativeState = fields.Int(validate=OneOf([0, 1, 2]))
     files = fields.List(fields.Dict())

--- a/etsin_finder/schemas/qvain_dataset_schema_v2.py
+++ b/etsin_finder/schemas/qvain_dataset_schema_v2.py
@@ -4,9 +4,9 @@ from marshmallow.validate import Length, OneOf
 
 from etsin_finder.schemas.qvain_dataset_schema import (
     ActorValidationSchema,
+    AccessRightsValidationSchema,
     DatasetValidationSchema as DatasetValidationSchemaV1,
     ProjectValidationSchema,
-    LicenseValidationSchema,
     ReferenceObjectValidationSchema,
     RemoteResourceValidationSchema,
     data_catalog_matcher as data_catalog_matcher_v1,
@@ -57,7 +57,7 @@ class DraftDatasetValidationSchema(Schema):
     rights_holder = fields.List(fields.Nested(ActorValidationSchema))
     contributor = fields.List(fields.Nested(ActorValidationSchema))
 
-    accessType = fields.Dict()
+    access_rights = fields.Nested(AccessRightsValidationSchema)
 
     infrastructure = fields.List(fields.Dict())
 
@@ -67,9 +67,6 @@ class DraftDatasetValidationSchema(Schema):
 
     theme = fields.List(fields.Nested(ReferenceObjectValidationSchema))
 
-    embargoDate = fields.Str()
-    restrictionGrounds = fields.Str()
-    license = fields.List(fields.Nested(LicenseValidationSchema))
     dataCatalog = fields.Str()
     cumulativeState = fields.Int(validate=OneOf([0, 1, 2]))
     files = fields.List(fields.Dict())

--- a/etsin_finder/utils/qvain_utils.py
+++ b/etsin_finder/utils/qvain_utils.py
@@ -81,48 +81,6 @@ def other_identifiers_to_metax(identifiers_list):
     return other_identifiers
 
 
-def access_rights_to_metax(data):
-    """Cherry pick access right data from the frontend form data and make it comply with Metax schema.
-
-    Arguments:
-        data (dict): The whole object sent from the frontend.
-
-    Returns:
-        dict: Dictionary containing access right object that comply to Metax schema.
-
-    """
-    access_rights = {}
-    access_rights["license"] = []
-    license = data.get("license", [])
-    for lic in license:
-        license_id = lic.get("identifier")
-        license_name_en = lic.get("name", {}).get("en") or ""
-        if license_id and not license_name_en.startswith("Other (URL)"):
-            license_object = {}
-            license_object["identifier"] = license_id
-            access_rights["license"].append(license_object)
-        elif license_id and license_name_en.startswith("Other (URL)"):
-            license_object = {}
-            license_object["license"] = license_id
-            access_rights["license"].append(license_object)
-
-    access_type = data.get("accessType", {})
-    access_type_url = access_type.get("url")
-    if access_type:
-        access_rights["access_type"] = {}
-        access_rights["access_type"]["identifier"] = access_type_url
-        if data["accessType"]["url"] != ACCESS_TYPES.get("open"):
-            access_rights["restriction_grounds"] = []
-            access_rights["restriction_grounds"].append(
-                {"identifier": data.get("restrictionGrounds")}
-            )
-        if (
-            data["accessType"]["url"] == ACCESS_TYPES.get("embargo") and "embargoDate" in data
-        ):
-            access_rights["available"] = data.get("embargoDate")
-    return access_rights
-
-
 def data_to_metax(data, metadata_provider_org, metadata_provider_user):
     """Convert all the data from the frontend to conform to Metax schema.
 
@@ -154,7 +112,7 @@ def data_to_metax(data, metadata_provider_org, metadata_provider_user):
             "language": data.get("language"),
             "keyword": data.get("keywords"),
             "theme": data.get("theme"),
-            "access_rights": access_rights_to_metax(data),
+            "access_rights": data.get("access_rights"),
             "remote_resources": data.get("remote_resources"),
             "is_output_of": alter_projects_to_metax(data.get("projects")),
             "relation": data.get("relation"),
@@ -310,7 +268,7 @@ def edited_data_to_metax(data, original):
             "language": data.get("language"),
             "keyword": data.get("keywords"),
             "theme": data.get("theme"),
-            "access_rights": access_rights_to_metax(data),
+            "access_rights": data.get("access_rights"),
             "remote_resources": data.get("remote_resources"),
             "infrastructure": data.get("infrastructure"),
             "spatial": data.get("spatial"),

--- a/tests/frontend_test_data.py
+++ b/tests/frontend_test_data.py
@@ -218,6 +218,22 @@ original_complete_dataset = {
     "identifiers": ["https://doin.com/some_identifier"],
     "keywords": ["qwe"],
     "theme": [{"identifier": "http://www.yso.fi/onto/koko/p46606"}],
+    "access_rights": {
+        "license": [
+            {
+                "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0"
+            }
+        ],
+        "access_type": {
+            "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/embargo"
+        },
+        "restriction_grounds": [
+            {
+                "identifier": "http://uri.suomi.fi/codelist/fairdata/restriction_grounds/code/copyright"
+            }
+        ],
+        "available": "2021-07-14",
+    },
     "creator": [
         {
             "@type": "Person",
@@ -311,18 +327,6 @@ original_complete_dataset = {
     "infrastructure": [
         {
             "identifier": "http://urn.fi/urn:nbn:fi:research-infras-2016072515",
-        }
-    ],
-    "restrictionGrounds": "http://uri.suomi.fi/codelist/fairdata/restriction_grounds/code/copyright",
-    "embargoDate": "2021-07-14",
-    "license": [
-        {
-            "name": {
-                "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-                "fi": "Creative Commons Nimeä 4.0 Kansainvälinen (CC BY 4.0)",
-                "und": "Creative Commons Nimeä 4.0 Kansainvälinen (CC BY 4.0)",
-            },
-            "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0",
         }
     ],
     "remote_resources": [
@@ -441,10 +445,6 @@ original_complete_dataset = {
     "field_of_science": [{"identifier": "http://www.yso.fi/onto/okm-tieteenala/ta112"}],
     "language": [{"identifier": "http://lexvo.org/id/iso639-3/udm"}],
     "issuedDate": "2021-06-23",
-    "accessType": {
-        "name": {"en": "Embargo", "fi": "Embargo", "und": "Embargo"},
-        "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/embargo",
-    },
     "original": {
         "id": 2182,
         "identifier": "d986fc86-adfc-4227-8944-df1460d61e7a",

--- a/tests/test_qvain_utils.py
+++ b/tests/test_qvain_utils.py
@@ -5,7 +5,6 @@ from etsin_finder.services import cr_service
 from etsin_finder.utils.flags import set_flags
 from copy import deepcopy
 from etsin_finder.utils.qvain_utils import (
-    access_rights_to_metax,
     alter_projects_to_metax,
     check_authentication,
     check_dataset_edit_permission,
@@ -61,15 +60,6 @@ class TestQvainUtils(BaseTest):
         """Test that function alters other identifiers suitable for Metax."""
         modified_identifiers = other_identifiers_to_metax(original_other_identifiers)
         assert modified_identifiers == expected_other_identifiers
-
-    def test_access_rights_to_metax(app):
-        """Test that function alters access rights suitable for Metax."""
-        modified_open_rights = access_rights_to_metax(original_open_rights)
-        modified_embargo_rights = access_rights_to_metax(original_embargo_rights)
-        modified_custom_rights = access_rights_to_metax(original_custom_rights)
-        assert modified_open_rights == expected_open_rights
-        assert modified_embargo_rights == expected_embargo_rights
-        assert modified_custom_rights == expected_custom_rights
 
     def test_data_to_metax(self):
         """Test that function alters dataset for metax."""


### PR DESCRIPTION
CSCFAIRMETA-1160: Refactor saving access rights
* Save access rights (license, access type, restriction grounds, embargo) in Metax JSON format
* Use separate frontend schemas for Qvain and Metax data models
* Fix errors when loading draft that does not have access_rights
* Show errors that aren't translation keys properly in submit buttons
